### PR TITLE
[feature] Add config tracking to save only accessed items

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ rich
 diffusers
 timm
 tyro
+websockets

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -38,6 +38,7 @@ from starVLA.training.trainer_utils.trainer_tools import normalize_dotlist_args
 from starVLA.model.framework import build_framework
 from starVLA.training.trainer_utils.trainer_tools import TrainerUtils
 from starVLA.training.trainer_utils.trainer_tools import build_param_lr_groups
+from starVLA.training.trainer_utils.config_tracker import wrap_config, AccessTrackedConfig
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -68,11 +69,11 @@ def setup_directories(cfg) -> Path:
         os.makedirs(output_dir, exist_ok=True)
         os.makedirs(output_dir / "checkpoints", exist_ok=True)
 
-        # save config
-        OmegaConf.save(cfg, output_dir / "config.yaml")
-        with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
-            yaml_cfg = yaml.safe_load(f_yaml)
-            json.dump(yaml_cfg, f_json, indent=2)
+        # # save config
+        # OmegaConf.save(cfg, output_dir / "config.yaml")
+        # with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
+        #     yaml_cfg = yaml.safe_load(f_yaml)
+        #     json.dump(yaml_cfg, f_json, indent=2)
 
     return output_dir
 
@@ -406,6 +407,20 @@ class VLATrainer(TrainerUtils):
             torch.save(state_dict, os.path.join(final_checkpoint, "pytorch_model.pt"))
             logger.info(f"Training complete. Final model saved at {final_checkpoint}")
 
+            # ✅ Save accessed configuration only
+            if isinstance(self.config, AccessTrackedConfig):
+                logger.info("📊 Saving accessed configuration...")
+                output_dir = Path(self.config.output_dir)
+                self.config.save_accessed_config(
+                    output_dir / "config.json", 
+                    use_original_values=False 
+                )
+                self.config.save_accessed_config(
+                    output_dir / "config.yaml", 
+                    use_original_values=False 
+                )
+                logger.info("✅ Configuration files saved")
+
         # close W&B
         if self.accelerator.is_main_process:
             wandb.finish()
@@ -415,6 +430,10 @@ class VLATrainer(TrainerUtils):
 
 def main(cfg) -> None:
     logger.info("VLA Training :: Warming Up")
+
+    #  Wrap config to enable access tracking
+    cfg = wrap_config(cfg)
+    logger.info("✅ Configuration wrapped for access tracking")
 
     # create output directory and save config
     output_dir = setup_directories(cfg=cfg)

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -39,6 +39,7 @@ from starVLA.training.trainer_utils.trainer_tools import normalize_dotlist_args
 from starVLA.model.framework import build_framework
 from starVLA.training.trainer_utils.trainer_tools import TrainerUtils
 from starVLA.training.trainer_utils.trainer_tools import build_param_lr_groups
+from starVLA.training.trainer_utils.config_tracker import wrap_config, AccessTrackedConfig
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -67,11 +68,11 @@ def setup_directories(cfg) -> Path:
         os.makedirs(output_dir, exist_ok=True)
         os.makedirs(output_dir / "checkpoints", exist_ok=True)
 
-        # save config
-        OmegaConf.save(cfg, output_dir / "config.yaml")
-        with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
-            yaml_cfg = yaml.safe_load(f_yaml)
-            json.dump(yaml_cfg, f_json, indent=2)
+        # # save config
+        # OmegaConf.save(cfg, output_dir / "config.yaml")
+        # with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
+        #     yaml_cfg = yaml.safe_load(f_yaml)
+        #     json.dump(yaml_cfg, f_json, indent=2)
 
     return output_dir
 
@@ -422,6 +423,20 @@ class VLAMTrainer(TrainerUtils):
             torch.save(state_dict, os.path.join(final_checkpoint, "pytorch_model.pt"))
             logger.info(f"Training complete. Final model saved at {final_checkpoint}")
 
+            # ✅ Save accessed configuration only
+            if isinstance(self.config, AccessTrackedConfig):
+                logger.info("📊 Saving accessed configuration...")
+                output_dir = Path(self.config.output_dir)
+                self.config.save_accessed_config(
+                    output_dir / "config.json", 
+                    use_original_values=False 
+                )
+                self.config.save_accessed_config(
+                    output_dir / "config.yaml", 
+                    use_original_values=False 
+                )
+                logger.info("✅ Configuration files saved")
+
         # close W&B
         if self.accelerator.is_main_process:
             wandb.finish()
@@ -431,6 +446,10 @@ class VLAMTrainer(TrainerUtils):
 
 def main(cfg) -> None:
     logger.info("VLA Training :: Warming Up")
+
+    #  Wrap config to enable access tracking
+    cfg = wrap_config(cfg)
+    logger.info("✅ Configuration wrapped for access tracking")
 
     # create output directory and save config
     output_dir = setup_directories(cfg=cfg)

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -20,6 +20,7 @@ from starVLA.dataloader import build_dataloader
 from starVLA.training.trainer_utils.trainer_tools import normalize_dotlist_args, TrainerUtils
 from starVLA.model.framework import build_framework
 from starVLA.training.trainer_utils.trainer_tools import build_param_lr_groups
+from starVLA.training.trainer_utils.config_tracker import wrap_config, AccessTrackedConfig
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -43,11 +44,11 @@ def setup_directories(cfg) -> Path:
         os.makedirs(output_dir, exist_ok=True)
         os.makedirs(output_dir / "checkpoints", exist_ok=True)
 
-        # Save config
-        OmegaConf.save(cfg, output_dir / "config.yaml")
-        with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
-            yaml_cfg = yaml.safe_load(f_yaml)
-            json.dump(yaml_cfg, f_json, indent=2)
+        # # Save config
+        # OmegaConf.save(cfg, output_dir / "config.yaml")
+        # with open(output_dir / "config.yaml", "r") as f_yaml, open(output_dir / "config.json", "w") as f_json:
+        #     yaml_cfg = yaml.safe_load(f_yaml)
+        #     json.dump(yaml_cfg, f_json, indent=2)
 
     return output_dir
 
@@ -254,6 +255,21 @@ class VLAMTrainer(TrainerUtils):
             torch.save(state_dict, os.path.join(final_checkpoint, "pytorch_model.pt"))
             logger.info(f"Training complete. Final model saved at {final_checkpoint}")
 
+            # ✅ Save accessed configuration only
+            if isinstance(self.config, AccessTrackedConfig):
+                logger.info("📊 Saving accessed configuration...")
+                output_dir = Path(self.config.output_dir)
+                self.config.save_accessed_config(
+                    output_dir / "config.json", 
+                    use_original_values=False 
+                )
+                self.config.save_accessed_config(
+                    output_dir / "config.yaml", 
+                    use_original_values=False 
+                )
+                logger.info("✅ Configuration files saved")
+
+        # close W&B
         if self.accelerator.is_main_process:
             wandb.finish()
 
@@ -262,7 +278,11 @@ class VLAMTrainer(TrainerUtils):
 
 def main(cfg) -> None:
     logger.info("VLA Training :: Warming Up")
+    #  Wrap config to enable access tracking
+    cfg = wrap_config(cfg)
+    logger.info("✅ Configuration wrapped for access tracking")
 
+    # create output directory and save config
     output_dir = setup_directories(cfg=cfg)
     vlm = build_framework(cfg)
     vlm_train_dataloader = prepare_data(cfg=cfg, accelerator=accelerator, output_dir=output_dir)

--- a/starVLA/training/trainer_utils/config_tracker.py
+++ b/starVLA/training/trainer_utils/config_tracker.py
@@ -1,0 +1,248 @@
+# starVLA/training/trainer_utils/config_tracker.py
+
+from omegaconf import OmegaConf
+from typing import Set, Any, Optional
+import json
+from pathlib import Path
+
+
+class AccessTrackedConfig:
+    """
+    Wrapper for OmegaConf to track accessed parameters.
+    Only saves configuration items that were actually accessed during execution.
+    """
+    
+    _original_cfg_snapshot: Optional[OmegaConf] = None
+    
+    def __init__(self, cfg: OmegaConf, parent: 'AccessTrackedConfig' = None, key_path: str = ""):
+        object.__setattr__(self, '_cfg', cfg)
+        object.__setattr__(self, '_parent', parent)
+        object.__setattr__(self, '_key_path', key_path)
+        object.__setattr__(self, '_local_accessed', set())
+        object.__setattr__(self, '_children', {})
+        
+        if parent is None:
+            AccessTrackedConfig._original_cfg_snapshot = OmegaConf.create(
+                OmegaConf.to_container(cfg, resolve=True)
+            )
+    
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith('_'):
+            return object.__getattribute__(self, name)
+        
+        self._local_accessed.add(name)
+        # Use safe access: for hasattr() semantics, raise AttributeError on missing keys
+        try:
+            value = self._cfg[name]
+        except Exception:
+            raise AttributeError(f"Config has no attribute '{name}'")
+        
+        if OmegaConf.is_config(value):
+            new_path = f"{self._key_path}.{name}" if self._key_path else name
+            if name not in self._children:
+                self._children[name] = AccessTrackedConfig(value, parent=self, key_path=new_path)
+            return self._children[name]
+        
+        return value
+    
+    def __getitem__(self, key: str) -> Any:
+        return self.__getattr__(key)
+    
+    def __setattr__(self, name: str, value: Any):
+        if name.startswith('_'):
+            object.__setattr__(self, name, value)
+        else:
+            self._cfg[name] = value
+    
+    def __setitem__(self, key: str, value: Any):
+        self._cfg[key] = value
+    
+    def __iter__(self):
+        """Support iteration (required for dict unpacking {**cfg})"""
+        return iter(self._cfg)
+    
+    def keys(self):
+        """Return config keys (required for dict unpacking)"""
+        return self._cfg.keys()
+    
+    def values(self):
+        """Return config values"""
+        for key in self._cfg.keys():
+            yield self.get(key)
+    
+    def items(self):
+        """Return config items"""
+        for key in self._cfg.keys():
+            yield key, self.get(key)
+    
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get value with default fallback"""
+        self._local_accessed.add(key)
+        value = self._cfg.get(key, default)
+        
+        if value is not default and OmegaConf.is_config(value):
+            new_path = f"{self._key_path}.{key}" if self._key_path else key
+            if key not in self._children:
+                self._children[key] = AccessTrackedConfig(value, parent=self, key_path=new_path)
+            return self._children[key]
+        
+        return value
+    
+    def unwrap(self) -> OmegaConf:
+        """Get the underlying OmegaConf object"""
+        return self._cfg
+    
+    def get_root(self) -> 'AccessTrackedConfig':
+        """Get root config object"""
+        current = self
+        while current._parent is not None:
+            current = current._parent
+        return current
+    
+    def _collect_all_paths(self, node: 'AccessTrackedConfig' = None, prefix: str = "") -> Set[str]:
+        """Recursively collect all accessed paths"""
+        if node is None:
+            node = self.get_root()
+        
+        paths = set()
+        for key in node._local_accessed:
+            current_path = f"{prefix}.{key}" if prefix else key
+            paths.add(current_path)
+            if key in node._children:
+                paths.update(self._collect_all_paths(node._children[key], current_path))
+        return paths
+    
+    def _filter_leaf_paths(self, paths: Set[str]) -> Set[str]:
+        """Filter to only leaf paths (no sub-paths)"""
+        if not paths:
+            return set()
+        
+        leaf_paths = set()
+        for path in paths:
+            if not any(other.startswith(f"{path}.") for other in paths if other != path):
+                leaf_paths.add(path)
+        return leaf_paths
+    
+    @staticmethod
+    def _get_nested_value(cfg: OmegaConf, path: str) -> Any:
+        """Get nested value through dot-separated path"""
+        value = cfg
+        for key in path.split('.'):
+            value = value[key]
+        return OmegaConf.to_container(value, resolve=True) if OmegaConf.is_config(value) else value
+    
+    @staticmethod
+    def _set_nested_value(d: dict, path: str, value: Any):
+        """Set nested value through dot-separated path"""
+        keys = path.split('.')
+        for key in keys[:-1]:
+            d = d.setdefault(key, {})
+        d[keys[-1]] = value
+    
+    def export_accessed_config(self, use_original_values: bool = True) -> dict:
+        """Export accessed configuration as dictionary (only leaf values)"""
+        all_paths = self._collect_all_paths()
+        leaf_paths = self._filter_leaf_paths(all_paths)
+        source_cfg = AccessTrackedConfig._original_cfg_snapshot if use_original_values else self.get_root()._cfg
+        
+        result = {}
+        for path in sorted(leaf_paths):
+            try:
+                value = self._get_nested_value(source_cfg, path)
+                self._set_nested_value(result, path, value)
+            except Exception:
+                if use_original_values:
+                    try:
+                        value = self._get_nested_value(self.get_root()._cfg, path)
+                        self._set_nested_value(result, path, value)
+                    except Exception:
+                        pass
+        return result
+    
+    def save_accessed_config(self, filepath: Path, use_original_values: bool = True):
+        """Save accessed configuration to file"""
+        accessed_config = self.export_accessed_config(use_original_values=use_original_values)
+        filepath = Path(filepath)
+        
+        with open(filepath, 'w') as f:
+            if filepath.suffix == '.json':
+                json.dump(accessed_config, f, indent=2)
+            elif filepath.suffix == '.yaml':
+                OmegaConf.save(OmegaConf.create(accessed_config), f)
+            else:
+                raise ValueError(f"Unsupported file format: {filepath.suffix}")
+    
+    def get_access_summary(self) -> dict:
+        """Get summary of accessed configuration"""
+        all_paths = self._collect_all_paths()
+        leaf_paths = self._filter_leaf_paths(all_paths)
+        
+        return {
+            "total_accessed_keys": len(all_paths),
+            "leaf_accessed_keys": len(leaf_paths),
+            "leaf_accessed_paths": sorted(leaf_paths),
+            "top_level_keys": sorted(self.get_root()._local_accessed)
+        }
+
+
+def wrap_config(cfg: OmegaConf) -> AccessTrackedConfig:
+    """Wrap OmegaConf configuration to enable access tracking"""
+    return AccessTrackedConfig(cfg)
+
+
+def unwrap_config(cfg) -> OmegaConf:
+    """Unwrap AccessTrackedConfig to get underlying OmegaConf object"""
+    return cfg.unwrap() if isinstance(cfg, AccessTrackedConfig) else cfg
+
+
+# ========== Monkey Patch OmegaConf for Compatibility ==========
+
+_original_to_container = OmegaConf.to_container
+_original_save = OmegaConf.save
+_original_to_yaml = OmegaConf.to_yaml
+_original_is_config = OmegaConf.is_config
+
+
+def _patched_to_container(cfg, resolve=True, enum_to_str=False, structured_config_mode=None):
+    """Patched OmegaConf.to_container that handles AccessTrackedConfig"""
+    if isinstance(cfg, AccessTrackedConfig):
+        cfg = cfg.unwrap()
+    
+    try:
+        if structured_config_mode is not None:
+            return _original_to_container(cfg, resolve=resolve, enum_to_str=enum_to_str, 
+                                         structured_config_mode=structured_config_mode)
+        else:
+            return _original_to_container(cfg, resolve=resolve, enum_to_str=enum_to_str)
+    except TypeError:
+        return _original_to_container(cfg, resolve=resolve)
+
+
+def _patched_save(config, f, resolve=False):
+    """Patched OmegaConf.save that handles AccessTrackedConfig"""
+    if isinstance(config, AccessTrackedConfig):
+        config = config.unwrap()
+    return _original_save(config, f, resolve=resolve)
+
+
+def _patched_to_yaml(cfg, resolve=False, sort_keys=False):
+    """Patched OmegaConf.to_yaml that handles AccessTrackedConfig"""
+    if isinstance(cfg, AccessTrackedConfig):
+        cfg = cfg.unwrap()
+    
+    try:
+        return _original_to_yaml(cfg, resolve=resolve, sort_keys=sort_keys)
+    except TypeError:
+        return _original_to_yaml(cfg, resolve=resolve)
+
+
+def _patched_is_config(obj):
+    """Patched OmegaConf.is_config that handles AccessTrackedConfig"""
+    return True if isinstance(obj, AccessTrackedConfig) else _original_is_config(obj)
+
+
+# Apply patches
+OmegaConf.to_container = _patched_to_container
+OmegaConf.save = _patched_save
+OmegaConf.to_yaml = _patched_to_yaml
+OmegaConf.is_config = _patched_is_config


### PR DESCRIPTION
When saving a checkpoint, persist only the config keys that were actually accessed/used during runtime, instead of dumping the full parameters.
eg. no "epoch"

Example config:


<img width="812" height="880" alt="截屏2025-12-17 13 41 08" src="https://github.com/user-attachments/assets/9e623a50-c20c-46b0-89de-b28f9082c41c" />

[config.json](https://github.com/user-attachments/files/24205602/config.json)
