### PR TITLE
[fix] Fix alignment format errors in the SimplerEnv training files.

### DIFF
--- a/examples/SimplerEnv/train_files/starvla_cotrain_oxe.yaml
+++ b/examples/SimplerEnv/train_files/starvla_cotrain_oxe.yaml
@@ -17,7 +17,7 @@ framework:
 
   action_model:
     action_model_type: DiT-B
-  hidden_size: 1024     # Matches the final DiT projection, used by the ActionDecoder
+    hidden_size: 1024     # Matches the final DiT projection, used by the ActionDecoder
     add_pos_embed: True
     max_seq_len: 1024
     action_dim: 7


### PR DESCRIPTION
An alignment error in SimplerEnv’s `starvla_cotrain_oxe.yaml` file was causing training failures; this PR resolves the issue.