### PR TITLE
[flow matching] fix: clamp the sample to an upper bound drawn from a Beta distribution

### DIFF
--- a/starVLA/model/modules/action_model/GR00T_ActionHeader.py
+++ b/starVLA/model/modules/action_model/GR00T_ActionHeader.py
@@ -260,7 +260,7 @@ class FlowmatchingActionHead(nn.Module):
         self.config = config
 
     def sample_time(self, batch_size, device, dtype):
-        sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype).clamp(max=self.config.noise_s)
         return (self.config.noise_s - sample) / self.config.noise_s
 
     def prepare_input(self, batch: dict) -> BatchFeature:


### PR DESCRIPTION
Samples from a Beta distribution lie in the range [ 0 , 1 ] and may be larger than self.config.noise_s (e.g., 0.999). In such cases, ( self.config.noise_s − sample ) / self.config.noise_s becomes negative. However, in flow matching, t<0 should not occur.