### PR TITLE
fix: use specific exceptions and idiomatic None comparison

### DIFF
--- a/starVLA/dataloader/vlm_datasets.py
+++ b/starVLA/dataloader/vlm_datasets.py
@@ -65,7 +65,7 @@ def preprocess_qwen_2_visual(
         try:
             if roles[source[0]["from"]] != roles["human"]:
                 source = source[1:]
-        except:
+        except (KeyError, IndexError):
             print(sources)
 
         input_id, target = [], []
@@ -77,7 +77,7 @@ def preprocess_qwen_2_visual(
             try:
                 role = conv["role"]
                 content = conv["content"]
-            except:
+            except KeyError:
                 role = conv["from"]
                 content = conv["value"]
 

--- a/starVLA/model/framework/QwenDual.py
+++ b/starVLA/model/framework/QwenDual.py
@@ -185,7 +185,7 @@ class Qwen_Dual(baseframework):
             last_hidden = qwenvl_outputs.hidden_states[connect_layer_index]   # [B, L, H]
             
             # Step 2: DINO Forward
-            if wrist_views == None:
+            if wrist_views is None:
                 wrist_views = batch_images
             image_tensors = self.dino_encoder.prepare_dino_input(wrist_views)  #
             B = len(batch_images)

--- a/starVLA/model/modules/dino_model/dino.py
+++ b/starVLA/model/modules/dino_model/dino.py
@@ -47,7 +47,7 @@ class DINOv2BackBone(nn.Module):
         super().__init__()
         try:
             self.body = torch.hub.load("facebookresearch/dinov2", backone_name)
-        except:
+        except Exception:
             import traceback
 
             traceback.print_exc()


### PR DESCRIPTION
## Changes

| File | Before | After | Rationale |
|------|--------|-------|-----------|
| `vlm_datasets.py:68` | `except:` | `except (KeyError, IndexError):` | Dict/list access |
| `vlm_datasets.py:80` | `except:` | `except KeyError:` | Dict key fallback |
| `dino.py:50` | `except:` | `except Exception:` | torch.hub.load fallback |
| `QwenDual.py:188` | `== None` | `is None` | PEP 8 E711 |