### PR TITLE
[feat] support Qwen3.5

### DIFF
--- a/starVLA/model/framework/LangForce.py
+++ b/starVLA/model/framework/LangForce.py
@@ -1,6 +1,6 @@
 # Copyright 2025 starVLA community. All rights reserved.
 # Licensed under the MIT License, Version 1.0 (the "License");
-# Implemented by [Junqiu YU / Fudan University] in [2025].
+# Implemented by [Shijie LIAN/ Huazhong University of Science & Technology] in [2025].
 # Design and Merged by [Jinhui YE / HKUST University] in [2025].
 """
 Qwen-GR00T Framework
@@ -67,6 +67,8 @@ class LangForce(baseframework):
     Additionally:
       - Training-time assertion: extracted language spans in prior/post must match exactly (token-level).
         If mismatch => raise AssertionError with decoded spans.
+      - LangForce utilizes Qwen3-VL and extends the vocabulary with specialized tokens that serve as Latent Action Queries. 
+        Run the provided example script add_token.py in https://github.com/ZGC-EmbodyAI/LangForce to update the tokenizer with these additional tokens.
     """
 
     def __init__(
@@ -104,13 +106,13 @@ class LangForce(baseframework):
         self.detach_prior_cond = bool(self.config.framework.get("detach_prior_cond", True))
 
         # ===== (2) Hard-token LLR =====
-        self.use_hard_token_llr = bool(self.config.framework.get("use_hard_token_llr", True))
+        self.use_hard_token_llr = bool(self.config.framework.get("use_hard_token_llr", False))
         self.hard_token_k = int(self.config.framework.get("hard_token_k", 16))
         assert self.hard_token_k > 0
 
         # ===== (3) Shortcut gate =====
         # gate computed from posterior language-span NLL: high NLL => log p(L|V) low => gate small
-        self.use_kl_gate = bool(self.config.framework.get("use_kl_gate", True))
+        self.use_kl_gate = bool(self.config.framework.get("use_kl_gate", False))
         self.kl_gate_momentum = float(self.config.framework.get("kl_gate_momentum", 0.99))
         self.kl_gate_temp = float(self.config.framework.get("kl_gate_temp", 0.5))
         self.kl_gate_tau_scale = float(self.config.framework.get("kl_gate_tau_scale", 0.7))  # scale EMA threshold

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -1,0 +1,198 @@
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License"); 
+# Implemented by [Shijie LIAN/ Huazhong University of Science & Technology] in [2026].
+# Design and Merged by [Jinhui YE / HKUST University] in [2026].
+
+import torch
+from torch.nn.utils.rnn import pad_sequence
+from typing import Dict, Optional, List
+
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers import AutoProcessor, BatchFeature
+
+from qwen_vl_utils import process_vision_info
+from accelerate.logging import get_logger
+
+try:
+    from transformers import Qwen3_5ForConditionalGeneration
+except ImportError as import_error:
+    raise ImportError(
+        "Qwen3.5 model class is unavailable. Please install transformers >= 5.2.0 or check your transformers version."
+    ) from import_error
+
+logger = get_logger(__name__)
+
+IGNORE_INDEX = -100
+IMAGE_TOKEN_INDEX = 248056
+VIDEO_TOKEN_INDEX = 248057
+DEFAULT_IMAGE_TOKEN = "<image>"
+DEFAULT_VIDEO_TOKEN = "<video>"
+
+_ACTION_TOKEN_MIN = 248077 # how can we know this range? check how you add fast tokens into VLM
+_ACTION_TOKEN_MAX = 248077 + 2047 # here only for fast_tokenizer, see starVLA/model/modules/vlm/tools/add_qwen_special_tokens/README.md
+
+
+import torch.nn as nn
+
+
+class _QWen3_5_VL_Interface(nn.Module):
+    """
+    This exists because of the diversity of VLMs, so we encapsulate the changes here.
+    Lightweight wrapper around Qwen3.5-VL (Qwen3_5ForConditionalGeneration).
+
+    Purpose:
+        - Unify interface with other VLM backends (CausalLM-like usage).
+        - Centralize preprocessing (tokenization + multimodal packing).
+        - Provide consistent forward / generate signatures.
+
+    """
+
+    def __init__(self, config: Optional[dict] = None, **kwargs):
+        """
+        Initialize the Qwen3.5-VL wrapper.
+        Following https://huggingface.co/Qwen/Qwen3.5-VL-4B-Instruct
+
+        """
+        super().__init__()
+
+        qwenvl_config = config.framework.get("qwenvl", {})
+        model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3.5-VL-4B-Instruct")
+
+        model = Qwen3_5ForConditionalGeneration.from_pretrained(
+            model_id,
+            attn_implementation="flash_attention_2",
+            torch_dtype=torch.bfloat16,
+        )
+        processor = AutoProcessor.from_pretrained(model_id)
+        processor.tokenizer.padding_side = "left"
+
+        self.model = model
+        self.processor = processor
+        self.config = config
+
+        # alin qwen3.5 with qwen2.5
+        self.model.config.hidden_size = self.model.config.text_config.hidden_size
+
+        # only for fast base model
+        if "-Action" in model_id:
+            self._ACTION_TOKEN_MIN = _ACTION_TOKEN_MIN
+            self._ACTION_TOKEN_MAX = _ACTION_TOKEN_MAX
+
+    def forward(
+        self,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        """
+        Forward pass delegating to underlying Qwen3.5-VL backbone.
+        """
+
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            outputs = self.model(
+                **kwargs,
+            )
+
+        return outputs
+
+    def generate(
+        self,
+        **kwargs,
+    ):
+        """
+        High-level generation interface (auto-regressive decoding), optionally vision-conditioned.
+
+        Args:
+            **kwargs: fully follow raw model.generate() signature.
+        Returns:
+            GenerateOutput | Model-dependent generation return.
+        """
+        with torch.autocast("cuda", dtype=torch.float16):
+            generation_output = self.model.generate(
+                **kwargs,
+            )
+        return generation_output
+
+    def build_qwenvl_inputs(self, images, instructions, solutions=None, **kwargs):
+        """
+        Build model inputs from raw data (images + instructions + optional solutions).
+        Follow Oficial Qwen3.5-VL Instruct format: https://huggingface.co/Qwen/Qwen3.5-VL-4B-Instruct
+        """
+
+        # Create messages: one message per sample
+        messages = []
+        assert len(images) == len(instructions), "Images and instructions must have the same length"
+        for imgs, instruction in zip(images, instructions):
+            content = [{"type": "image", "image": img} for img in imgs]
+
+            if "CoT_prompt" in self.config.datasets.vla_data:  # If using a grounding prompt to task
+                CoT_prompt = self.config.datasets.vla_data.get("CoT_prompt", "")
+                prompt = CoT_prompt.replace("{instruction}", instruction)
+            else:
+                prompt = instruction
+
+            content.append({"type": "text", "text": prompt})
+            msg = [{"role": "user", "content": content}]
+
+            if solutions is not None:
+                solution = solutions[len(messages)]
+                msg.append({"role": "assistant", "content": [{"type": "text", "text": solution}]})
+            messages.append(msg)
+
+        # Preparation for inference
+
+        batch_inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            padding=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt"
+        )
+
+        # if solutions, mask out the solution tokens in labels
+        if solutions is not None: #  here only for fast_tokenizer now. 
+            action_token_min = _ACTION_TOKEN_MIN # how can we know this range? --> we has other way for this, but is slower see qwenhelix branch
+            action_token_max = _ACTION_TOKEN_MAX # here only for fast_tokenizer, see starVLA/model/modules/vlm/tools/add_qwen_special_tokens/README.md
+            labels = batch_inputs['input_ids'].clone()
+            # For each sequence in the batch, find the first occurrence of an action token.
+            for i in range(labels.size(0)):
+                seq = labels[i]
+                # Create a mask for tokens within the action token range.
+                mask_seq = (seq >= action_token_min) & (seq <= action_token_max)
+                nonzero_indices = torch.nonzero(mask_seq, as_tuple=False)
+                if nonzero_indices.numel() > 0:
+                    first_action_index = nonzero_indices[0].item()
+                    # Mask out all tokens before the first action token.
+                    seq[:first_action_index] = IGNORE_INDEX
+                else:
+                    # If no action token is found, mask the entire sequence.
+                    seq[:] = IGNORE_INDEX
+                    logger.warning(
+                        "No action token found in sequence; please check action-tokenized tokenizer in "
+                        "starVLA/model/modules/vlm/tools/add_qwen_special_tokens/README.md"
+                    )
+            
+            labels[labels == self.processor.tokenizer.pad_token_id] = -100 ## mask out pad tokens as well
+            batch_inputs['labels'] = labels
+
+        return batch_inputs.to(self.model.device)
+
+
+
+
+if __name__ == "__main__":
+    from omegaconf import OmegaConf
+    import debugpy
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_oxe.yaml", help="Path to YAML config")
+    args, clipargs = parser.parse_known_args()
+
+    debugpy.listen(("0.0.0.0", 10092))
+    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
+    debugpy.wait_for_client()
+
+    cfg = OmegaConf.load(args.config_yaml)
+    
+    cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen3.5-VL-4B-Instruct"
+    qwen_vl = _QWen3_5_VL_Interface(cfg)
+    pass

--- a/starVLA/model/modules/vlm/__init__.py
+++ b/starVLA/model/modules/vlm/__init__.py
@@ -1,6 +1,3 @@
-
-
-
 def get_vlm_model(config):
 
     vlm_name = config.framework.qwenvl.base_vlm
@@ -10,8 +7,10 @@ def get_vlm_model(config):
         return _QWen_VL_Interface(config)
     elif "Qwen3-VL" in vlm_name:
         from .QWen3 import _QWen3_VL_Interface
-
         return _QWen3_VL_Interface(config)
+    elif "Qwen3.5" in vlm_name:
+        from .QWen3_5 import _QWen3_5_VL_Interface
+        return _QWen3_5_VL_Interface(config)
     elif "florence" in vlm_name.lower(): # temp for some ckpt
         from .Florence2 import _Florence_Interface 
         return _Florence_Interface(config)


### PR DESCRIPTION
This PR includes two updates:

1. Integrated Qwen3.5 into the current pipeline.
Just now, the official Qwen team released the weights for Qwen3.5 0.8B, 2B, 4B, and 9B. So, it is time to integrate Qwen3.5 into starVLA. I have tested Qwen3.5-4B with QwenGR00T on SimplerEnv (global batch=128). The training loss behavior is normal during the first 500 steps.
<img width="1878" height="654" alt="image" src="https://github.com/user-attachments/assets/35dd79cc-d3a8-46f4-bc6e-e40d9be4208e" />

2. Improved LangForce text descriptions
Added/updated several textual descriptions for LangForce to make prompts and related outputs clearer.
