### PR TITLE
[fix](calvin): add eval_sequences.json

### DIFF
--- a/examples/calvin/README.md
+++ b/examples/calvin/README.md
@@ -135,5 +135,7 @@ Additionally, you need to modify the following paths in `eval_calvin.py`:
 * `calvin_config_path`: Path to Calvin models configuration directory (default: `"/path/to/calvin/calvin_models/conf"`)
 * `eval_sequences_path`: Path to evaluation sequences JSON file (default: `"/path/to/calvin/eval_sequences.json"`)
 
+For convenience, we provide a reference evaluation sequence file at `examples/calvin/eval_files/eval_sequences.json`, which can be used directly.
+
 
 

--- a/examples/calvin/eval_files/eval_sequences.json
+++ b/examples/calvin/eval_files/eval_sequences.json
@@ -1,0 +1,19002 @@
+[
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "rotate_red_block_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_right",
+            "turn_on_led",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_right",
+            "move_slider_left",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_right",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "rotate_blue_block_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_red_block_left",
+            "turn_off_led",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "close_drawer",
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "move_slider_left",
+            "turn_off_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_pink_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_pink_block_slider",
+            "stack_block",
+            "turn_off_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_red_block_right",
+            "move_slider_left",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "push_red_block_left",
+            "move_slider_left",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "open_drawer",
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "turn_off_led",
+            "unstack_block",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "turn_on_lightbulb",
+            "push_into_drawer",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_blue_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "open_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "push_red_block_right",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_blue_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "push_into_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_red_block_right",
+            "push_into_drawer",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_pink_block_right",
+            "move_slider_right",
+            "close_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "close_drawer",
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_into_drawer",
+            "turn_off_led",
+            "lift_pink_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_pink_block_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "rotate_pink_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_led",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_pink_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "turn_on_led",
+            "unstack_block",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "rotate_blue_block_right",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_right",
+            "move_slider_left",
+            "push_into_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "turn_on_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_left",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "rotate_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "close_drawer",
+            "move_slider_left",
+            "push_pink_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "close_drawer",
+            "rotate_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_blue_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_on_led",
+            "lift_red_block_slider",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_pink_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "move_slider_right",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_on_lightbulb",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_blue_block_right",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_left",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "open_drawer",
+            "rotate_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "close_drawer",
+            "push_pink_block_right",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "open_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_led",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_left",
+            "turn_off_lightbulb",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "close_drawer",
+            "lift_red_block_slider",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "push_blue_block_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "open_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "push_pink_block_right",
+            "move_slider_right",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_left",
+            "close_drawer",
+            "turn_off_led",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_right",
+            "turn_on_led",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_lightbulb",
+            "unstack_block",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_left",
+            "rotate_pink_block_left",
+            "turn_on_led",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_red_block_right",
+            "push_into_drawer",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_left",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_right",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_pink_block_left",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_red_block_right",
+            "open_drawer",
+            "turn_off_led",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_pink_block_right",
+            "close_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_led",
+            "move_slider_right",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "close_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_blue_block_right",
+            "turn_off_lightbulb",
+            "push_into_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "close_drawer",
+            "turn_on_led",
+            "move_slider_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "rotate_blue_block_left",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_left",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "push_red_block_right",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "stack_block",
+            "move_slider_right",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "move_slider_left",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "close_drawer",
+            "unstack_block",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "push_into_drawer",
+            "close_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_left",
+            "lift_pink_block_slider",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_led",
+            "push_red_block_left",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_off_led",
+            "move_slider_left",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "rotate_red_block_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "push_blue_block_left",
+            "push_into_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_on_lightbulb",
+            "lift_pink_block_slider",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "close_drawer",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "turn_on_led",
+            "move_slider_left",
+            "push_into_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "push_pink_block_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_red_block_drawer",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "rotate_red_block_left",
+            "lift_blue_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_red_block_left",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_right",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "move_slider_left",
+            "rotate_red_block_right",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "move_slider_left",
+            "turn_off_led",
+            "push_into_drawer",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "rotate_red_block_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "open_drawer",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_on_led",
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_right",
+            "turn_off_led",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "move_slider_left",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "push_into_drawer",
+            "lift_red_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_blue_block_left",
+            "move_slider_right",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "push_into_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_blue_block_left",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "close_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_pink_block_right",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "close_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "rotate_pink_block_left",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "rotate_blue_block_right",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "push_into_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_off_led",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "push_pink_block_right",
+            "turn_on_lightbulb",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "rotate_red_block_left",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "rotate_pink_block_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_right",
+            "turn_on_led",
+            "close_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "push_blue_block_right",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "close_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_right",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "push_into_drawer",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_led",
+            "move_slider_right",
+            "rotate_blue_block_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_left",
+            "open_drawer",
+            "push_blue_block_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "move_slider_right",
+            "push_red_block_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_blue_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_blue_block_right",
+            "move_slider_left",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_off_lightbulb",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "close_drawer",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_red_block_left",
+            "close_drawer",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_pink_block_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_right",
+            "turn_on_led",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "push_blue_block_left",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "stack_block",
+            "move_slider_left",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "move_slider_left",
+            "unstack_block",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_led",
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left",
+            "lift_red_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_red_block_slider",
+            "stack_block",
+            "turn_on_led",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "push_into_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "open_drawer",
+            "turn_off_led",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_red_block_right",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "open_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "close_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "turn_off_lightbulb",
+            "unstack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_red_block_left",
+            "open_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "close_drawer",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "close_drawer",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "push_into_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "push_into_drawer",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_right",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_led",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "turn_off_led",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "push_red_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_blue_block_slider",
+            "stack_block",
+            "open_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "close_drawer",
+            "lift_red_block_table",
+            "stack_block",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "open_drawer",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "push_blue_block_left",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_on_lightbulb",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_blue_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_led",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "move_slider_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "close_drawer",
+            "turn_off_led",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_red_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_right",
+            "rotate_red_block_right",
+            "close_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_right",
+            "lift_blue_block_slider",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_drawer",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_pink_block_left",
+            "turn_on_led",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_on_led",
+            "close_drawer",
+            "move_slider_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_pink_block_right",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "push_into_drawer",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "rotate_red_block_right",
+            "move_slider_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "rotate_blue_block_left",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "open_drawer",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "open_drawer",
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_led",
+            "push_into_drawer",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "open_drawer",
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_left",
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "rotate_red_block_left",
+            "close_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_led",
+            "open_drawer",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "move_slider_right",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "open_drawer",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_pink_block_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "close_drawer",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_led",
+            "close_drawer",
+            "push_pink_block_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "close_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "close_drawer",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "turn_on_led",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "close_drawer",
+            "unstack_block",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_led",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "turn_off_led",
+            "push_pink_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_left",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "rotate_red_block_left",
+            "move_slider_left",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_pink_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "rotate_blue_block_left",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "unstack_block",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_blue_block_right",
+            "move_slider_right",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_blue_block_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "move_slider_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_on_led",
+            "move_slider_left",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_right",
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "turn_on_lightbulb",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "turn_on_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "push_pink_block_right",
+            "close_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_blue_block_right",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_right",
+            "move_slider_right",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_left",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_left",
+            "move_slider_left",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "rotate_red_block_left",
+            "open_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "turn_off_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "push_pink_block_left",
+            "turn_off_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "open_drawer",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_on_led",
+            "close_drawer",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "push_blue_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "close_drawer",
+            "turn_off_led",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_red_block_right",
+            "turn_on_led",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_right",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "turn_off_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "move_slider_right",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "rotate_red_block_right",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_into_drawer",
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_red_block_right",
+            "push_into_drawer",
+            "move_slider_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "rotate_blue_block_left",
+            "turn_on_led",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "open_drawer",
+            "move_slider_left",
+            "push_into_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "close_drawer",
+            "rotate_blue_block_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "rotate_pink_block_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_pink_block_left",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "rotate_red_block_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "move_slider_right",
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_pink_block_left",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "move_slider_left",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_red_block_table",
+            "stack_block",
+            "move_slider_right",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_right",
+            "rotate_blue_block_left",
+            "turn_on_led",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_off_led",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_right",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "turn_on_led",
+            "lift_red_block_table",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_on_lightbulb",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_right",
+            "turn_on_led",
+            "push_pink_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "rotate_pink_block_left",
+            "move_slider_left",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_led",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "stack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_right",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "close_drawer",
+            "push_blue_block_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_lightbulb",
+            "rotate_blue_block_left",
+            "lift_red_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "move_slider_right",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_left",
+            "push_red_block_right",
+            "open_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_pink_block_right",
+            "turn_on_led",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_left",
+            "close_drawer",
+            "turn_off_led",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "push_red_block_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "stack_block",
+            "move_slider_left",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_blue_block_left",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "turn_off_led",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "push_into_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "turn_on_led",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "move_slider_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_red_block_left",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_right",
+            "push_blue_block_left",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_red_block_left",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "push_into_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "close_drawer",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "rotate_blue_block_right",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_red_block_left",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "rotate_pink_block_right",
+            "turn_off_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "open_drawer",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_slider",
+            "close_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "push_into_drawer",
+            "move_slider_left",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "push_pink_block_right",
+            "turn_on_lightbulb",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "move_slider_left",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_right",
+            "push_into_drawer",
+            "turn_on_led",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_red_block_left",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "close_drawer",
+            "push_pink_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_on_lightbulb",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_pink_block_right",
+            "close_drawer",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "push_red_block_left",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_on_lightbulb",
+            "push_red_block_right",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "push_blue_block_left",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_drawer",
+            "stack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_red_block_left",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "close_drawer",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "turn_off_lightbulb",
+            "push_pink_block_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_left",
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_off_lightbulb",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_red_block_table",
+            "stack_block",
+            "open_drawer",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "push_into_drawer",
+            "lift_pink_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_red_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "push_into_drawer",
+            "turn_off_led",
+            "move_slider_left",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_red_block_right",
+            "push_into_drawer",
+            "move_slider_left",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "open_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "stack_block",
+            "close_drawer",
+            "unstack_block",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "close_drawer",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "push_into_drawer",
+            "turn_on_led",
+            "lift_red_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_pink_block_right",
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "rotate_pink_block_left",
+            "move_slider_left",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_led",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "turn_off_lightbulb",
+            "push_into_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "turn_on_lightbulb",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_off_lightbulb",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "push_red_block_right",
+            "close_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_right",
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_red_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "turn_off_lightbulb",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_red_block_left",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "move_slider_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "turn_off_lightbulb",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "push_pink_block_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "move_slider_left",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "lift_blue_block_table",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_blue_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_right",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "rotate_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "move_slider_left",
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_right",
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "push_into_drawer",
+            "turn_off_led",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_on_led",
+            "push_into_drawer",
+            "lift_pink_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "open_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "stack_block",
+            "open_drawer",
+            "unstack_block",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_off_led",
+            "close_drawer",
+            "push_red_block_right",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "push_red_block_left",
+            "push_into_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "open_drawer",
+            "move_slider_right",
+            "push_pink_block_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "rotate_red_block_right",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_right",
+            "open_drawer",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "open_drawer",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "move_slider_left",
+            "push_red_block_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "open_drawer",
+            "push_blue_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_off_led",
+            "push_into_drawer",
+            "close_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_red_block_left",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "rotate_pink_block_right",
+            "move_slider_right",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "unstack_block",
+            "turn_on_led",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "rotate_red_block_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_right",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_right",
+            "turn_on_led",
+            "open_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "turn_on_led",
+            "open_drawer",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_red_block_right",
+            "close_drawer",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_left",
+            "turn_off_led",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_red_block_right",
+            "move_slider_right",
+            "close_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "rotate_red_block_right",
+            "open_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "push_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_lightbulb",
+            "lift_red_block_slider",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "turn_off_led",
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_red_block_right",
+            "turn_on_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_pink_block_right",
+            "move_slider_right",
+            "open_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_pink_block_left",
+            "move_slider_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_off_lightbulb",
+            "open_drawer",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_blue_block_left",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_red_block_drawer",
+            "place_in_slider",
+            "close_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_red_block_table",
+            "stack_block",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "turn_on_led",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "close_drawer",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_off_led",
+            "move_slider_left",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_lightbulb",
+            "push_red_block_right",
+            "push_into_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_off_led",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_pink_block_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "move_slider_left",
+            "open_drawer",
+            "turn_on_led",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "lift_pink_block_slider",
+            "stack_block",
+            "open_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_pink_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "push_into_drawer",
+            "turn_on_led",
+            "lift_blue_block_drawer",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_pink_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_lightbulb",
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_led",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block",
+            "open_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "move_slider_left",
+            "lift_blue_block_drawer",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "rotate_red_block_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "move_slider_right",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "close_drawer",
+            "turn_on_led",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_right",
+            "open_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "stack_block",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_off_led",
+            "rotate_red_block_left",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_right",
+            "close_drawer",
+            "turn_on_led",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "rotate_red_block_right",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "open_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "move_slider_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_led",
+            "close_drawer",
+            "move_slider_right",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_left",
+            "rotate_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_blue_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_red_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_led",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_into_drawer",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "turn_off_led",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "close_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "lift_pink_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "rotate_red_block_left",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "rotate_red_block_left",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "open_drawer",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_blue_block_right",
+            "move_slider_right",
+            "turn_off_led",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "close_drawer",
+            "rotate_pink_block_right",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_right",
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "rotate_blue_block_left",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "close_drawer",
+            "rotate_pink_block_left",
+            "move_slider_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_into_drawer",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_lightbulb",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "turn_off_led",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_left",
+            "turn_off_lightbulb",
+            "lift_blue_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "turn_off_led",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "close_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "close_drawer",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_into_drawer",
+            "close_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "move_slider_left",
+            "push_into_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "rotate_red_block_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "push_red_block_right",
+            "move_slider_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "move_slider_right",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_on_led",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "close_drawer",
+            "rotate_red_block_left",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "turn_on_led",
+            "push_into_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "move_slider_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "open_drawer",
+            "turn_on_lightbulb",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_pink_block_left",
+            "turn_off_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_pink_block_left",
+            "turn_off_led",
+            "move_slider_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_left",
+            "open_drawer",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "lift_blue_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "turn_on_led",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "rotate_pink_block_right",
+            "close_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "move_slider_right",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "rotate_red_block_left",
+            "turn_on_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_pink_block_right",
+            "open_drawer",
+            "move_slider_right",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_off_led",
+            "push_into_drawer",
+            "lift_red_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "move_slider_right",
+            "open_drawer",
+            "turn_on_led",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_red_block_left",
+            "close_drawer",
+            "turn_on_led",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "move_slider_right",
+            "lift_red_block_table",
+            "stack_block",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "rotate_blue_block_right",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "close_drawer",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_into_drawer",
+            "lift_red_block_drawer",
+            "place_in_slider",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "rotate_pink_block_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_led",
+            "move_slider_right",
+            "push_into_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "push_red_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_blue_block_slider",
+            "stack_block",
+            "turn_off_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "turn_on_led",
+            "rotate_blue_block_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "turn_on_led",
+            "lift_red_block_table",
+            "stack_block",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "turn_on_lightbulb",
+            "push_into_drawer",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_red_block_left",
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_blue_block_right",
+            "lift_pink_block_table",
+            "stack_block",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "open_drawer",
+            "move_slider_left",
+            "push_into_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "close_drawer",
+            "rotate_blue_block_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "move_slider_left",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_pink_block_left",
+            "turn_on_lightbulb",
+            "lift_blue_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_off_lightbulb",
+            "open_drawer",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_blue_block_drawer",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "rotate_pink_block_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "push_blue_block_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "push_blue_block_left",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_on_led",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_red_block_table",
+            "place_in_slider",
+            "rotate_pink_block_left",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "move_slider_left",
+            "lift_red_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "rotate_blue_block_right",
+            "turn_on_led",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "move_slider_left",
+            "push_red_block_left",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "rotate_pink_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_pink_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_left",
+            "open_drawer",
+            "push_pink_block_left",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "push_blue_block_left",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "turn_off_led",
+            "rotate_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "lift_blue_block_slider",
+            "stack_block",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "close_drawer",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "rotate_pink_block_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "open_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "stack_block",
+            "close_drawer",
+            "unstack_block",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "rotate_blue_block_right",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "push_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_on_lightbulb",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "lift_blue_block_drawer",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_blue_block_right",
+            "open_drawer",
+            "turn_off_led",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_led",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "turn_off_led",
+            "move_slider_left",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "turn_off_led",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_on_led",
+            "push_red_block_right",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "push_red_block_left",
+            "push_into_drawer",
+            "turn_off_led",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "rotate_pink_block_left",
+            "open_drawer",
+            "move_slider_right",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_pink_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "turn_on_led",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_blue_block_left",
+            "close_drawer",
+            "move_slider_left",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "rotate_red_block_right",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "move_slider_left",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "rotate_pink_block_right",
+            "move_slider_left",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "close_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "turn_on_led",
+            "move_slider_left",
+            "close_drawer",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_into_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "move_slider_right",
+            "turn_off_lightbulb",
+            "close_drawer",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "rotate_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "stack_block",
+            "move_slider_left",
+            "open_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "push_blue_block_right",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "stack_block",
+            "unstack_block",
+            "push_pink_block_right",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "close_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_off_led",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "rotate_red_block_left",
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_into_drawer",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "move_slider_right",
+            "push_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_on_led",
+            "rotate_blue_block_left",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "lift_red_block_slider",
+            "stack_block",
+            "unstack_block",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_red_block_right",
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "move_slider_left",
+            "rotate_pink_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "move_slider_left",
+            "open_drawer",
+            "push_into_drawer",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_blue_block_right",
+            "move_slider_right",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_red_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "turn_off_lightbulb",
+            "lift_red_block_table",
+            "stack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "open_drawer",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_pink_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "open_drawer",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_red_block_slider",
+            "place_in_slider",
+            "turn_off_led",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_slider",
+            "place_in_slider",
+            "rotate_blue_block_left",
+            "move_slider_left",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_led",
+            "open_drawer",
+            "rotate_pink_block_left",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_right",
+            "turn_on_lightbulb",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "rotate_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "move_slider_right",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "rotate_blue_block_left",
+            "turn_on_lightbulb",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_lightbulb",
+            "rotate_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_pink_block_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "turn_off_led",
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "rotate_pink_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_on_lightbulb",
+            "push_blue_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "push_red_block_right",
+            "open_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "open_drawer",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "push_blue_block_left",
+            "turn_off_lightbulb",
+            "lift_red_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "move_slider_right",
+            "turn_on_led",
+            "lift_pink_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "move_slider_right",
+            "push_blue_block_right",
+            "close_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_blue_block_right",
+            "move_slider_right",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_on_led",
+            "move_slider_right",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "rotate_pink_block_left",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_red_block_left",
+            "move_slider_right",
+            "turn_on_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "move_slider_left",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "push_into_drawer",
+            "move_slider_left",
+            "close_drawer",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer",
+            "push_pink_block_right",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_blue_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_table",
+            "place_in_slider",
+            "lift_pink_block_slider",
+            "stack_block",
+            "move_slider_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "push_pink_block_left",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "move_slider_right",
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "push_red_block_left",
+            "move_slider_right",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "turn_off_led",
+            "push_into_drawer",
+            "move_slider_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_slider",
+            "place_in_drawer",
+            "close_drawer",
+            "rotate_red_block_left",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_on_led",
+            "rotate_pink_block_left",
+            "lift_pink_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "turn_off_lightbulb",
+            "rotate_blue_block_right",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_led",
+            "open_drawer",
+            "push_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "turn_off_lightbulb",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_right",
+            "close_drawer",
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "lift_pink_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "push_blue_block_right",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_into_drawer",
+            "close_drawer",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "move_slider_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "close_drawer",
+            "turn_on_lightbulb",
+            "rotate_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "rotate_blue_block_left",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "lift_pink_block_slider",
+            "stack_block",
+            "unstack_block",
+            "rotate_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "turn_on_led",
+            "rotate_blue_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "push_red_block_left",
+            "move_slider_left",
+            "push_into_drawer",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "open_drawer",
+            "lift_pink_block_slider",
+            "place_in_slider",
+            "turn_off_led",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "turn_off_led",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_pink_block_right",
+            "turn_off_led"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_led",
+            "lift_blue_block_slider",
+            "place_in_slider",
+            "push_red_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_slider",
+            "move_slider_left",
+            "lift_red_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_on_lightbulb",
+            "push_blue_block_right",
+            "lift_blue_block_table",
+            "stack_block",
+            "unstack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "rotate_red_block_left",
+            "close_drawer",
+            "turn_on_led",
+            "lift_pink_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "lift_red_block_table",
+            "place_in_drawer",
+            "push_blue_block_left",
+            "turn_off_led",
+            "lift_red_block_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "turn_off_lightbulb",
+            "push_pink_block_left",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "move_slider_left",
+            "lift_blue_block_slider",
+            "place_in_drawer",
+            "turn_off_lightbulb"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_on_lightbulb",
+            "close_drawer",
+            "lift_pink_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "close_drawer",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "rotate_red_block_right"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_left",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer",
+            "turn_on_led"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "rotate_red_block_right",
+            "lift_blue_block_slider",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "rotate_pink_block_right",
+            "turn_off_lightbulb",
+            "open_drawer",
+            "lift_pink_block_table",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "turn_off_led",
+            "move_slider_right",
+            "push_blue_block_left",
+            "lift_red_block_slider",
+            "place_in_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "slider_right",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_left",
+            "push_into_drawer",
+            "move_slider_right",
+            "lift_red_block_slider",
+            "place_in_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "lift_pink_block_table",
+            "place_in_slider",
+            "turn_off_led",
+            "move_slider_right",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_blue_block_right",
+            "open_drawer",
+            "lift_blue_block_table",
+            "place_in_slider",
+            "push_into_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "lift_red_block_table",
+            "place_in_drawer",
+            "turn_off_lightbulb",
+            "close_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_left",
+            "turn_off_led",
+            "move_slider_right",
+            "lift_red_block_table",
+            "stack_block"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "table",
+            "blue_block": "table",
+            "pink_block": "slider_right",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_off_lightbulb",
+            "rotate_blue_block_left",
+            "open_drawer",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 1,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "table",
+            "blue_block": "slider_right",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "push_red_block_right",
+            "close_drawer",
+            "turn_off_lightbulb",
+            "move_slider_left",
+            "lift_blue_block_slider"
+        ]
+    ],
+    [
+        {
+            "led": 0,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "push_pink_block_right",
+            "lift_pink_block_table",
+            "place_in_slider",
+            "move_slider_right",
+            "open_drawer"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "open",
+            "red_block": "slider_left",
+            "blue_block": "table",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "lift_blue_block_table",
+            "place_in_drawer",
+            "close_drawer",
+            "push_pink_block_left"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "right",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "table",
+            "pink_block": "slider_left",
+            "grasped": 0
+        },
+        [
+            "move_slider_left",
+            "turn_on_lightbulb",
+            "open_drawer",
+            "rotate_blue_block_right",
+            "lift_blue_block_table"
+        ]
+    ],
+    [
+        {
+            "led": 1,
+            "lightbulb": 0,
+            "slider": "left",
+            "drawer": "closed",
+            "red_block": "slider_right",
+            "blue_block": "slider_left",
+            "pink_block": "table",
+            "grasped": 0
+        },
+        [
+            "move_slider_right",
+            "turn_on_lightbulb",
+            "push_pink_block_left",
+            "open_drawer",
+            "push_into_drawer"
+        ]
+    ]
+]


### PR DESCRIPTION
### What this PR does

This PR add `eval_sequences.json` to the Calvin evaluation in **starVLA** 

* The current README mentions `eval_sequences.json` as a required file, but this file is **not included in the original CALVIN benchmark release**. It is a **protocol-level multi-step task sequence list** used only during evaluation, which can be confusing for first-time users.

* Since starVLA’s Calvin evaluation is stated to follow **RoboTron-Mani**, and RoboTron-Mani explicitly points to **RoboFlamingo’s `eval_sequences.json`** , we include the same reference file in starVLA to make evaluation setup reproducible and plug-and-play.

### References / Consistency

* RoboTron-Mani uses RoboFlamingo’s `eval_sequences.json` in [this](https://github.com/EmbodiedAI-RoboTron/RoboTron-Mani/blob/eede7992b8607c5afa90774ea907485127c4d74b/config/uvformer_5data_OCCLoss_euler_C.yaml#L79)
* The same `eval_sequences.json` is also used by [Xiaomi-Robotics-0](https://github.com/XiaomiRobotics/Xiaomi-Robotics-0/blob/main/eval_calvin/config/eval_sequences.json) in their CALVIN evaluation config.