### PR TITLE
fix(vlm): read attn_implementation from qwenvl config

### DIFF
--- a/starVLA/model/modules/vlm/CosmosReason2.py
+++ b/starVLA/model/modules/vlm/CosmosReason2.py
@@ -29,11 +29,13 @@ PIXELS_PER_TOKEN = 32**2
 class _CosmosReason2_Interface(nn.Module):
     def __init__(self, config: Optional[dict] = None, **kwargs):
         super().__init__()
+        qwenvl_config = config.framework.get("qwenvl", {})
         model_name = "nvidia/Cosmos-Reason2-2B"
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
         self.model = transformers.Qwen3VLForConditionalGeneration.from_pretrained(
             model_name,
             dtype=torch.bfloat16,
-            attn_implementation="sdpa"
+            attn_implementation=attn_implementation
         )
         self.processor = transformers.Qwen3VLProcessor.from_pretrained(model_name)
         self.config = config

--- a/starVLA/model/modules/vlm/QWen2_5.py
+++ b/starVLA/model/modules/vlm/QWen2_5.py
@@ -84,10 +84,11 @@ class _QWen_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen2.5-VL-3B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             torch_dtype="auto",
         )
         processor = AutoProcessor.from_pretrained(model_id)

--- a/starVLA/model/modules/vlm/QWen3.py
+++ b/starVLA/model/modules/vlm/QWen3.py
@@ -53,10 +53,11 @@ class _QWen3_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3-VL-4B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen3VLForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             dtype=torch.bfloat16,
         )
         processor = AutoProcessor.from_pretrained(model_id)

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -57,10 +57,11 @@ class _QWen3_5_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3.5-VL-4B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen3_5ForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             torch_dtype=torch.bfloat16,
         )
         processor = AutoProcessor.from_pretrained(model_id)


### PR DESCRIPTION
Current training configs expose [framework.qwenvl.attn_implementation](https://github.com/starVLA/starVLA/blob/starVLA/starVLA/config/training/starvla_cotrain_oxe.yaml#L13), but several VLM backends ignored it and always used fixed values (e.g., flash_attention_2 / sdpa).

This PR fixes VLM initialization so `attn_implementation` is read from framework.qwenv config instead of being hardcoded.