### PR TITLE
fix(trainer): step LR scheduler only on actual optimizer updates

### DIFF
--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -345,7 +345,14 @@ class VLATrainer(TrainerUtils):
                 self.accelerator.clip_grad_norm_(self.model.parameters(), self.config.trainer.gradient_clipping)
 
             self.optimizer.step()
-            self.lr_scheduler.step()
+            # Only step the scheduler when an actual optimizer update occurs.
+            # Inside accelerator.accumulate(), optimizer.step() is a no-op on
+            # non-sync micro-steps, but lr_scheduler.step() always advances
+            # the internal counter.  This caused the scheduler to advance
+            # gradient_accumulation_steps times faster than intended, leading
+            # to premature LR decay and incorrect LR on resume (#204).
+            if self.accelerator.sync_gradients:
+                self.lr_scheduler.step()
 
         return {
             "action_dit_loss": action_loss.item(),

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -338,7 +338,9 @@ class VLAMTrainer(TrainerUtils):
                 self.accelerator.clip_grad_norm_(self.model.parameters(), self.config.trainer.gradient_clipping)
 
             self.optimizer.step()
-            self.lr_scheduler.step()
+            # Only step scheduler on actual optimizer updates (see train_starvla.py)
+            if self.accelerator.sync_gradients:
+                self.lr_scheduler.step()
 
             log_dict.update(
                 {


### PR DESCRIPTION
## Problem

When using gradient_accumulation_steps > 1, lr_scheduler.step() is called on every micro-batch inside accelerator.accumulate(), but optimizer.step() is a no-op on non-sync micro-steps. This causes the LR scheduler to advance gradient_accumulation_steps times faster than intended.

### Impact

1. **Normal training**: LR decays faster than configured — with gradient_accumulation_steps=2, the effective num_training_steps for the scheduler is halved.

2. **Resume training (#204)**: _adjust_lr_scheduler_for_resume() replays completed_steps (which counts optimizer steps), but the scheduler internal counter was advancing at the micro-batch rate. On resume, the scheduler restarts from 0 and is stepped completed_steps times, but this does not match the phase it was at before the interruption. The result is an unexpected LR spike after resuming.

## Fix

Guard lr_scheduler.step() with self.accelerator.sync_gradients so it only advances when an actual optimizer update occurs.

Applied to both train_starvla.py and train_starvla_cotrain.py.

Closes #204