### PR TITLE
Implemented LeRobot Version Concurrency

### DIFF
--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -71,6 +71,23 @@ LE_ROBOT3_TASKS_FILENAME = "meta/tasks.parquet"
 LE_ROBOT3_EPISODE_FILENAME = "meta/episodes/*/*.parquet"
 
 
+def detect_lerobot_version(dataset_path: Path) -> str | None:
+    """Auto-detect LeRobot dataset version from file structure.
+
+    Checks for version-specific marker files:
+    - v3.0: meta/tasks.parquet (checked first as the newer format)
+    - v2.0: meta/episodes.jsonl
+
+    Returns:
+        "v3.0", "v2.0", or None if version cannot be determined.
+    """
+    if (Path(dataset_path) / LE_ROBOT3_TASKS_FILENAME).exists():
+        return "v3.0"
+    if (Path(dataset_path) / LE_ROBOT_EPISODE_FILENAME).exists():
+        return "v2.0"
+    return None
+
+
 def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
     """Calculate the dataset statistics of all columns for a list of parquet files."""
     # Dataset statistics
@@ -568,6 +585,7 @@ class LeRobotSingleDataset(Dataset):
         transforms: ComposedModalityTransform | None = None,
         delete_pause_frame: bool = False,
         data_cfg = None,
+        lerobot_version: str | None = None,
         **kwargs,
     ):
         """
@@ -586,8 +604,16 @@ class LeRobotSingleDataset(Dataset):
         self.data_cfg = data_cfg
         if not Path(dataset_path).exists():
             raise FileNotFoundError(f"Dataset path {dataset_path} does not exist")
-        # indict letobot version
-        self._lerobot_version =  self.data_cfg.get("lerobot_version", "v2.0") #self._indict_lerobot_version(**kwargs)
+        # Determine lerobot version: explicit override > auto-detect > data_cfg fallback > default
+        if lerobot_version is not None:
+            self._lerobot_version = lerobot_version
+        else:
+            detected = detect_lerobot_version(Path(dataset_path))
+            if detected is not None:
+                self._lerobot_version = detected
+            else:
+                self._lerobot_version = self.data_cfg.get("lerobot_version", "v2.0") if self.data_cfg else "v2.0"
+        print(f"[LeRobot] Dataset {Path(dataset_path).name}: using version {self._lerobot_version}")
 
         self._action_mode = None
         self._action_mode_state_map = {}
@@ -1001,6 +1027,7 @@ class LeRobotSingleDataset(Dataset):
         config_dict = {
             "delete_pause_frame": self.delete_pause_frame,
             "dataset_name": self.dataset_name,
+            "lerobot_version": self._lerobot_version,
         }
         # Create a hash of the configuration
         config_str = str(sorted(config_dict.items()))

--- a/starVLA/dataloader/lerobot_datasets.py
+++ b/starVLA/dataloader/lerobot_datasets.py
@@ -22,6 +22,7 @@ def make_LeRobotSingleDataset(
     robot_type: str,
     delete_pause_frame: bool = False,
     data_cfg: dict | None = None,
+    lerobot_version: str | None = None,
 ) -> LeRobotSingleDataset:
     """
     Make a LeRobotSingleDataset object.
@@ -29,7 +30,7 @@ def make_LeRobotSingleDataset(
     :param data_root_dir: The root directory of the dataset.
     :param data_name: The name of the dataset.
     :param robot_type: The robot type config to use.
-    :param crop_obs_camera: Whether to crop the observation camera images.
+    :param lerobot_version: Explicit lerobot version override ("v2.0" or "v3.0"). If None, auto-detected from dataset file structure.
     :return: A LeRobotSingleDataset object.
     """
     
@@ -52,6 +53,7 @@ def make_LeRobotSingleDataset(
         video_backend=video_backend, # decord is more efficiency | torchvision_av for video.av1
         delete_pause_frame=delete_pause_frame,
         data_cfg=data_cfg,
+        lerobot_version=lerobot_version,
     )
 
 def get_vla_dataset(
@@ -70,18 +72,21 @@ def get_vla_dataset(
     delete_pause_frame = data_cfg.get("delete_pause_frame", False)
     mixture_spec = DATASET_NAMED_MIXTURES[data_mix]
     included_datasets, filtered_mixture_spec = set(), []
-    for d_name, d_weight, robot_type in mixture_spec:  
-        dataset_key = (d_name, robot_type)  
+    for entry in mixture_spec:
+        # Support both 3-tuple (name, weight, robot_type) and 4-tuple (name, weight, robot_type, lerobot_version)
+        d_name, d_weight, robot_type = entry[0], entry[1], entry[2]
+        d_version = entry[3] if len(entry) > 3 else None
+        dataset_key = (d_name, robot_type)
         if dataset_key in included_datasets:
             print(f"Skipping Duplicate Dataset: `{(d_name, d_weight, robot_type)}`")
             continue
 
         included_datasets.add(dataset_key)
-        filtered_mixture_spec.append((d_name, d_weight, robot_type))
+        filtered_mixture_spec.append((d_name, d_weight, robot_type, d_version))
 
     dataset_mixture = []
-    for d_name, d_weight, robot_type in filtered_mixture_spec:
-        dataset_mixture.append((make_LeRobotSingleDataset(Path(data_root_dir), d_name, robot_type, delete_pause_frame=delete_pause_frame, data_cfg=data_cfg), d_weight))
+    for d_name, d_weight, robot_type, d_version in filtered_mixture_spec:
+        dataset_mixture.append((make_LeRobotSingleDataset(Path(data_root_dir), d_name, robot_type, delete_pause_frame=delete_pause_frame, data_cfg=data_cfg, lerobot_version=d_version), d_weight))
 
     return LeRobotMixtureDataset(
         dataset_mixture,


### PR DESCRIPTION
Our training datasets are mixed between LeRobot v2.0 and v3.0. 
These changes allow us to use both v2.0/v3.0 without conversion.

Wrote some E2E integration tests, changes seemed to be working.