### PR TITLE
[Fix] Improved Normalization Stats for Large Datasets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ diffusers
 timm
 tyro
 websockets
+tdigest

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ diffusers
 timm
 tyro
 websockets
-tdigest
+tdigest==0.5.2.2

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -114,7 +114,7 @@ def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
         finally:
             pf.close()
 
-    return {name: acc.finalize() for name, acc in accumulators.items() if acc._count > 0}
+    return {name: acc.finalize() for name, acc in accumulators.items() if acc.count > 0}
 
 
 def _normalize_action_mode(mode: str) -> str:
@@ -442,7 +442,7 @@ def calculate_delta_action_statistics(
 
     delta_stats = copy.deepcopy(base_stats)
     for action_col, acc in accumulators.items():
-        if acc._count > 0:
+        if acc.count > 0:
             delta_stats[action_col] = acc.finalize()
     return delta_stats
 
@@ -530,7 +530,7 @@ def calculate_rel_action_statistics(
 
     rel_stats = copy.deepcopy(base_stats)
     for action_col, acc in accumulators.items():
-        if acc._count > 0:
+        if acc.count > 0:
             rel_stats[action_col] = acc.finalize()
     return rel_stats
 

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -55,6 +55,10 @@ from typing import Tuple, List
 import pickle
 import gc
 
+import pyarrow.parquet as pq
+
+from starVLA.dataloader.gr00t_lerobot.streaming_stats import StreamingStatsAccumulator
+
 # LeRobot v2.0 dataset file names 
 LE_ROBOT_MODALITY_FILENAME = "meta/modality.json"
 LE_ROBOT_EPISODE_FILENAME = "meta/episodes.jsonl"
@@ -72,46 +76,42 @@ LE_ROBOT3_EPISODE_FILENAME = "meta/episodes/*/*.parquet"
 
 
 def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
-    """Calculate the dataset statistics of all columns for a list of parquet files."""
-    # Dataset statistics
-    all_low_dim_data_list = []
-    # Collect all the data
-    # parquet_paths = parquet_paths[:3]
+    """Calculate per-column normalization statistics using streaming computation.
+
+    Uses Welford's online algorithm for mean/std, running min/max, and
+    t-digest for q01/q99 quantile estimation. Memory is bounded to one
+    parquet row-group at a time regardless of total dataset size.
+    """
+    accumulators: dict[str, StreamingStatsAccumulator] = {}
+
     for parquet_path in tqdm(
         sorted(list(parquet_paths)),
-        desc="Collecting all parquet files...",
+        desc="Computing dataset statistics...",
     ):
-        # Load the parquet file
-        parquet_data = pd.read_parquet(parquet_path)
-        parquet_data = parquet_data
-        all_low_dim_data_list.append(parquet_data)
-    
-    all_low_dim_data = pd.concat(all_low_dim_data_list, axis=0)
-    # Compute dataset statistics
-    dataset_statistics = {}
-    for le_modality in tqdm(all_low_dim_data.columns, desc="Processing modalities"):
-        print(le_modality)
-        if "task_info" in le_modality:
-            continue
-        print(f"Computing statistics for {le_modality}...")
-        # 检查数据是否为空或无效
-        try:
-            np_data = np.vstack(
-                [np.asarray(x, dtype=np.float32) for x in all_low_dim_data[le_modality]]
-            )
-        except Exception as e:
-            print(f"Warning: Failed to process modality {le_modality} due to error: {e}")
-            continue  
+        pf = pq.ParquetFile(str(parquet_path))
+        for batch in pf.iter_batches():
+            if batch.num_rows == 0:
+                continue
+            for col_name in batch.schema.names:
+                if "task_info" in col_name:
+                    continue
+                col = batch.column(col_name)
+                try:
+                    pylist = col.to_pylist()
+                    # Skip scalar (metadata) columns — only process list/array columns
+                    first = next((x for x in pylist if x is not None), None)
+                    if first is None or not isinstance(first, (list, np.ndarray)):
+                        continue
+                    values = np.vstack(
+                        [np.asarray(x, dtype=np.float32) for x in pylist]
+                    )
+                except Exception:
+                    continue
+                if col_name not in accumulators:
+                    accumulators[col_name] = StreamingStatsAccumulator()
+                accumulators[col_name].update(values)
 
-        dataset_statistics[le_modality] = {
-            "mean": np.mean(np_data, axis=0).tolist(),
-            "std": np.std(np_data, axis=0).tolist(),
-            "min": np.min(np_data, axis=0).tolist(),
-            "max": np.max(np_data, axis=0).tolist(),
-            "q01": np.quantile(np_data, 0.01, axis=0).tolist(),
-            "q99": np.quantile(np_data, 0.99, axis=0).tolist(),
-        }
-    return dataset_statistics
+    return {name: acc.finalize() for name, acc in accumulators.items() if acc._count > 0}
 
 
 def _normalize_action_mode(mode: str) -> str:

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -404,8 +404,8 @@ def calculate_delta_action_statistics(
                 raise ValueError(f"Invalid padding strategy: {padding_strategy}")
         return output
 
-    accum: dict[str, list[np.ndarray]] = {col: [] for col in action_col_slices.keys()}
-    for parquet_path in tqdm(sorted(list(parquet_paths)), desc="Collecting delta action stats"):
+    accumulators: dict[str, StreamingStatsAccumulator] = {}
+    for parquet_path in tqdm(sorted(list(parquet_paths)), desc="Computing delta action stats"):
         data = pd.read_parquet(parquet_path)
         trajectory_length = len(data)
         for action_col, slice_list in action_col_slices.items():
@@ -436,21 +436,14 @@ def calculate_delta_action_statistics(
                     out[0] = action_part_chunk[0] - state_chunk[0]
                     action_chunk_full[:, a_slice[0] : a_slice[1]] = out
 
-                accum[action_col].append(action_chunk_full)
+                if action_col not in accumulators:
+                    accumulators[action_col] = StreamingStatsAccumulator()
+                accumulators[action_col].update(action_chunk_full)
 
     delta_stats = copy.deepcopy(base_stats)
-    for action_col, series_list in accum.items():
-        if not series_list:
-            continue
-        all_values = np.concatenate(series_list, axis=0).astype(np.float32)
-        delta_stats[action_col] = {
-            "mean": np.mean(all_values, axis=0).tolist(),
-            "std": np.std(all_values, axis=0).tolist(),
-            "min": np.min(all_values, axis=0).tolist(),
-            "max": np.max(all_values, axis=0).tolist(),
-            "q01": np.quantile(all_values, 0.01, axis=0).tolist(),
-            "q99": np.quantile(all_values, 0.99, axis=0).tolist(),
-        }
+    for action_col, acc in accumulators.items():
+        if acc._count > 0:
+            delta_stats[action_col] = acc.finalize()
     return delta_stats
 
 

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -67,7 +67,7 @@ LE_ROBOT_INFO_FILENAME = "meta/info.json"
 LE_ROBOT_STATS_FILENAME = "meta/stats_gr00t.json"
 LE_ROBOT_DATA_FILENAME = "data/*/*.parquet"
 LE_ROBOT_STEPS_FILENAME = "meta/steps.pkl"
-LE_ROBOT_STATS_FORMAT_VERSION = 2
+LE_ROBOT_STATS_FORMAT_VERSION = 3
 EPSILON = 5e-4
 
 #  LeRobot v3.0 dataset file names 

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -495,8 +495,8 @@ def calculate_rel_action_statistics(
                 raise ValueError(f"Invalid padding strategy: {padding_strategy}")
         return output
 
-    accum: dict[str, list[np.ndarray]] = {col: [] for col in action_col_slices.keys()}
-    for parquet_path in tqdm(sorted(list(parquet_paths)), desc="Collecting rel action stats"):
+    accumulators: dict[str, StreamingStatsAccumulator] = {}
+    for parquet_path in tqdm(sorted(list(parquet_paths)), desc="Computing rel action stats"):
         data = pd.read_parquet(parquet_path)
         trajectory_length = len(data)
         for action_col, slice_list in action_col_slices.items():
@@ -524,21 +524,14 @@ def calculate_rel_action_statistics(
                     out = action_part_chunk - state_chunk[0]
                     action_chunk_full[:, a_slice[0] : a_slice[1]] = out
 
-                accum[action_col].append(action_chunk_full)
+                if action_col not in accumulators:
+                    accumulators[action_col] = StreamingStatsAccumulator()
+                accumulators[action_col].update(action_chunk_full)
 
     rel_stats = copy.deepcopy(base_stats)
-    for action_col, series_list in accum.items():
-        if not series_list:
-            continue
-        all_values = np.concatenate(series_list, axis=0).astype(np.float32)
-        rel_stats[action_col] = {
-            "mean": np.mean(all_values, axis=0).tolist(),
-            "std": np.std(all_values, axis=0).tolist(),
-            "min": np.min(all_values, axis=0).tolist(),
-            "max": np.max(all_values, axis=0).tolist(),
-            "q01": np.quantile(all_values, 0.01, axis=0).tolist(),
-            "q99": np.quantile(all_values, 0.99, axis=0).tolist(),
-        }
+    for action_col, acc in accumulators.items():
+        if acc._count > 0:
+            rel_stats[action_col] = acc.finalize()
     return rel_stats
 
 class ModalityConfig(BaseModel):

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -80,7 +80,7 @@ def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
 
     Uses Welford's online algorithm for mean/std, running min/max, and
     t-digest for q01/q99 quantile estimation. Memory is bounded to one
-    parquet row-group at a time regardless of total dataset size.
+    batch at a time regardless of total dataset size.
     """
     accumulators: dict[str, StreamingStatsAccumulator] = {}
 
@@ -89,27 +89,30 @@ def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
         desc="Computing dataset statistics...",
     ):
         pf = pq.ParquetFile(str(parquet_path))
-        for batch in pf.iter_batches():
-            if batch.num_rows == 0:
-                continue
-            for col_name in batch.schema.names:
-                if "task_info" in col_name:
+        try:
+            for batch in pf.iter_batches():
+                if batch.num_rows == 0:
                     continue
-                col = batch.column(col_name)
-                try:
-                    pylist = col.to_pylist()
-                    # Skip scalar (metadata) columns — only process list/array columns
-                    first = next((x for x in pylist if x is not None), None)
-                    if first is None or not isinstance(first, (list, np.ndarray)):
+                for col_name in batch.schema.names:
+                    if "task_info" in col_name:
                         continue
-                    values = np.vstack(
-                        [np.asarray(x, dtype=np.float32) for x in pylist]
-                    )
-                except Exception:
-                    continue
-                if col_name not in accumulators:
-                    accumulators[col_name] = StreamingStatsAccumulator()
-                accumulators[col_name].update(values)
+                    col = batch.column(col_name)
+                    try:
+                        pylist = col.to_pylist()
+                        # Skip scalar (metadata) columns — only process list/array columns
+                        first = next((x for x in pylist if x is not None), None)
+                        if first is None or not isinstance(first, (list, np.ndarray)):
+                            continue
+                        values = np.vstack(
+                            [np.asarray(x, dtype=np.float32) for x in pylist if x is not None]
+                        )
+                    except (ValueError, TypeError):
+                        continue
+                    if col_name not in accumulators:
+                        accumulators[col_name] = StreamingStatsAccumulator()
+                    accumulators[col_name].update(values)
+        finally:
+            pf.close()
 
     return {name: acc.finalize() for name, acc in accumulators.items() if acc._count > 0}
 

--- a/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
+++ b/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
@@ -63,6 +63,8 @@ class StreamingStatsAccumulator:
             batch = batch.reshape(-1, 1)
         batch = batch.astype(np.float64)
         n_rows, n_dims = batch.shape
+        if n_rows == 0:
+            return
 
         if self._mean is not None and n_dims != len(self._mean):
             raise ValueError(

--- a/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
+++ b/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
@@ -1,0 +1,114 @@
+"""Streaming normalization statistics accumulator.
+
+Uses Welford's online algorithm for mean/variance, running min/max,
+and per-dimension t-digests for quantile estimation. Memory usage is
+bounded regardless of dataset size.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from tdigest import TDigest
+
+
+class StreamingStatsAccumulator:
+    """Accumulates per-dimension statistics from arbitrarily many batches.
+
+    Tracks mean, std (population), min, max, q01, and q99 for each feature
+    dimension using streaming algorithms that never hold the full dataset
+    in memory.
+
+    Usage:
+        acc = StreamingStatsAccumulator()
+        for batch in data_source:          # batch: np.ndarray [N, D]
+            acc.update(batch)
+        stats = acc.finalize()             # {mean, std, min, max, q01, q99}
+    """
+
+    def __init__(self, digest_delta: float = 0.01, digest_k: int = 25) -> None:
+        self._digest_delta = digest_delta
+        self._digest_k = digest_k
+        # Welford state
+        self._count: int = 0
+        self._mean: np.ndarray | None = None
+        self._m2: np.ndarray | None = None
+        # Running extrema
+        self._min: np.ndarray | None = None
+        self._max: np.ndarray | None = None
+        # Per-dimension t-digests
+        self._digests: list[TDigest] | None = None
+
+    def update(self, batch: np.ndarray) -> None:
+        """Incorporate a batch of observations.
+
+        Args:
+            batch: Array of shape [N, D] or [N]. If 1-D, treated as [N, 1].
+        """
+        if batch.ndim == 1:
+            batch = batch.reshape(-1, 1)
+        batch = batch.astype(np.float64)
+        n_rows, n_dims = batch.shape
+
+        # First batch: initialize all accumulators
+        if self._mean is None:
+            self._mean = np.zeros(n_dims, dtype=np.float64)
+            self._m2 = np.zeros(n_dims, dtype=np.float64)
+            self._min = np.full(n_dims, np.inf, dtype=np.float64)
+            self._max = np.full(n_dims, -np.inf, dtype=np.float64)
+            self._digests = [
+                TDigest(delta=self._digest_delta, K=self._digest_k)
+                for _ in range(n_dims)
+            ]
+
+        # --- Running min/max ---
+        self._min = np.minimum(self._min, np.min(batch, axis=0))
+        self._max = np.maximum(self._max, np.max(batch, axis=0))
+
+        # --- Welford's parallel/batch merge (Chan et al. 1979) ---
+        batch_count = n_rows
+        batch_mean = np.mean(batch, axis=0)
+        batch_m2 = np.sum((batch - batch_mean) ** 2, axis=0)
+
+        new_count = self._count + batch_count
+        delta = batch_mean - self._mean
+        new_mean = self._mean + delta * (batch_count / new_count)
+        new_m2 = (
+            self._m2
+            + batch_m2
+            + delta ** 2 * (self._count * batch_count / new_count)
+        )
+
+        self._count = new_count
+        self._mean = new_mean
+        self._m2 = new_m2
+
+        # --- t-digest quantile tracking ---
+        for dim in range(n_dims):
+            self._digests[dim].batch_update(batch[:, dim])
+
+    def finalize(self) -> dict[str, list[float]]:
+        """Compute final statistics and return as JSON-serializable dict.
+
+        Returns:
+            Dict with keys: mean, std, min, max, q01, q99.
+            Each value is a list of floats with length D (feature dimensions).
+
+        Raises:
+            ValueError: If no data was ever fed via update().
+        """
+        if self._count == 0 or self._mean is None:
+            raise ValueError("No data has been fed to the accumulator.")
+
+        std = np.sqrt(self._m2 / self._count)
+
+        q01 = [self._digests[d].percentile(1) for d in range(len(self._digests))]
+        q99 = [self._digests[d].percentile(99) for d in range(len(self._digests))]
+
+        return {
+            "mean": self._mean.tolist(),
+            "std": std.tolist(),
+            "min": self._min.tolist(),
+            "max": self._max.tolist(),
+            "q01": [float(v) for v in q01],
+            "q99": [float(v) for v in q99],
+        }

--- a/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
+++ b/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Streaming normalization statistics accumulator.
 
 Uses Welford's online algorithm for mean/variance, running min/max,
@@ -49,6 +64,12 @@ class StreamingStatsAccumulator:
         batch = batch.astype(np.float64)
         n_rows, n_dims = batch.shape
 
+        if self._mean is not None and n_dims != len(self._mean):
+            raise ValueError(
+                f"Dimension mismatch: accumulator has {len(self._mean)} dims "
+                f"but batch has {n_dims}"
+            )
+
         # First batch: initialize all accumulators
         if self._mean is None:
             self._mean = np.zeros(n_dims, dtype=np.float64)
@@ -84,7 +105,7 @@ class StreamingStatsAccumulator:
 
         # --- t-digest quantile tracking ---
         for dim in range(n_dims):
-            self._digests[dim].batch_update(batch[:, dim])
+            self._digests[dim].batch_update(batch[:, dim].tolist())
 
     def finalize(self) -> dict[str, list[float]]:
         """Compute final statistics and return as JSON-serializable dict.

--- a/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
+++ b/starVLA/dataloader/gr00t_lerobot/streaming_stats.py
@@ -41,17 +41,25 @@ class StreamingStatsAccumulator:
     """
 
     def __init__(self, digest_delta: float = 0.01, digest_k: int = 25) -> None:
+        """
+        Args:
+            digest_delta: Compression parameter for t-digest. Smaller values
+                give more accurate quantile estimates at the cost of memory.
+            digest_k: Size parameter for t-digest centroid merging.
+        """
         self._digest_delta = digest_delta
         self._digest_k = digest_k
-        # Welford state
         self._count: int = 0
         self._mean: np.ndarray | None = None
         self._m2: np.ndarray | None = None
-        # Running extrema
         self._min: np.ndarray | None = None
         self._max: np.ndarray | None = None
-        # Per-dimension t-digests
         self._digests: list[TDigest] | None = None
+
+    @property
+    def count(self) -> int:
+        """Total number of observations seen so far."""
+        return self._count
 
     def update(self, batch: np.ndarray) -> None:
         """Incorporate a batch of observations.
@@ -123,15 +131,13 @@ class StreamingStatsAccumulator:
             raise ValueError("No data has been fed to the accumulator.")
 
         std = np.sqrt(self._m2 / self._count)
-
-        q01 = [self._digests[d].percentile(1) for d in range(len(self._digests))]
-        q99 = [self._digests[d].percentile(99) for d in range(len(self._digests))]
+        n_dims = len(self._digests)
 
         return {
             "mean": self._mean.tolist(),
             "std": std.tolist(),
             "min": self._min.tolist(),
             "max": self._max.tolist(),
-            "q01": [float(v) for v in q01],
-            "q99": [float(v) for v in q99],
+            "q01": [float(self._digests[d].percentile(1)) for d in range(n_dims)],
+            "q99": [float(self._digests[d].percentile(99)) for d in range(n_dims)],
         }


### PR DESCRIPTION
The previous calculate_dataset_statistics loaded every parquet file into one massive pandas dataframe in memory, then computed stats with numpy. For large datasets, we would run out of memory.

The three stats functions (base, delta, rel) did the same - load everything, then compute.                                                                                          
 
The new code streams through data one batch at a time using Welford's algorithm for mean/std, running min/max, and t-digest for quantile estimation. Memory is bounded regardless of dataset size. The output format is identical.

I ran a bunch of E2E tests but would appreciate someone helping verify the changes.
                                          