### PR TITLE
[fix] Add fallback loader for FAST processor on transformers >= 5.x

### DIFF
--- a/starVLA/model/modules/action_model/fast_ActionHeader.py
+++ b/starVLA/model/modules/action_model/fast_ActionHeader.py
@@ -16,19 +16,62 @@ Overview:
 import torch.nn as nn
 from typing import List, Dict, Any, Callable, Optional
 import os
+import json
 import numpy as np
-from transformers import AutoProcessor
+from transformers import AutoProcessor, PreTrainedTokenizerFast
 
+
+def _load_fast_processor(pretrained_path: str = "physical-intelligence/fast"):
+    """Load the FAST UniversalActionProcessor with compatibility for transformers >= 5.x.
+
+    transformers 5.x changed AutoProcessor internals which breaks the default
+    loading path for the physical-intelligence/fast custom processor. This
+    helper manually loads the custom class and its BPE tokenizer component.
+    """
+    try:
+        return AutoProcessor.from_pretrained(pretrained_path, trust_remote_code=True)
+    except (ValueError, OSError):
+        pass
+
+    # Fallback: manual load
+    from huggingface_hub import snapshot_download
+    import importlib.util
+
+    local_dir = snapshot_download(pretrained_path)
+
+    spec = importlib.util.spec_from_file_location(
+        "processing_action_tokenizer",
+        os.path.join(local_dir, "processing_action_tokenizer.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    UniversalActionProcessor = mod.UniversalActionProcessor
+
+    bpe_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_file=os.path.join(local_dir, "tokenizer.json"),
+        clean_up_tokenization_spaces=False,
+    )
+
+    with open(os.path.join(local_dir, "processor_config.json"), "r") as f:
+        cfg = json.load(f)
+
+    processor = UniversalActionProcessor(
+        bpe_tokenizer=bpe_tokenizer,
+        scale=cfg.get("scale", 10),
+        vocab_size=cfg.get("vocab_size", 2048),
+        min_token=cfg.get("min_token", -354),
+        action_dim=cfg.get("action_dim"),
+        time_horizon=cfg.get("time_horizon"),
+    )
+    return processor
 
 
 class Fast_Action_Tokenizer(nn.Module):
     """One MLP ResNet block with a residual connection."""
-    def __init__(self, fast_tokenizer_name="playground/Pretrained_models/fast"):
+    def __init__(self, fast_tokenizer_name="physical-intelligence/fast"):
         super().__init__()
-        
-        self.fast_tokenizer = AutoProcessor.from_pretrained(
-            fast_tokenizer_name, trust_remote_code=True
-        ) # load https://huggingface.co/physical-intelligence/fast
+
+        self.fast_tokenizer = _load_fast_processor(fast_tokenizer_name)
 
 
     def encoder_action2fastoken(self, raw_actions):


### PR DESCRIPTION
AutoProcessor.from_pretrained("physical-intelligence/fast") fails on transformers >= 5.x due to internal changes in tokenizer loading.

This patch adds a _load_fast_processor() helper that:
1. Tries the standard AutoProcessor path first
2. Falls back to manually downloading the repo, dynamically loading the UniversalActionProcessor class, and constructing the BPE tokenizer from tokenizer.json directly

Also updates the default FAST tokenizer path from a local placeholder to the HuggingFace hub identifier ("physical-intelligence/fast").