### PR TITLE
[fix] Save full merged config during checkpointing

### DIFF
--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -229,6 +229,9 @@ class VLATrainer(TrainerUtils):
                 logger.info("📊 Saving accessed configuration...")
                 output_dir = Path(self.config.output_dir)
                 self.config.save_accessed_config(output_dir / "config.yaml", use_original_values=False)
+                full_cfg_path = output_dir / "config.full.yaml"
+                logger.info(f"📦 Saving full merged configuration to `{full_cfg_path}`...")
+                self.config.save_full_config(full_cfg_path, resolve=True)
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -207,6 +207,9 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("📊 Saving accessed configuration...")
                 output_dir = Path(self.config.output_dir)
                 self.config.save_accessed_config(output_dir / "config.yaml", use_original_values=False)
+                full_cfg_path = output_dir / "config.full.yaml"
+                logger.info(f"📦 Saving full merged configuration to `{full_cfg_path}`...")
+                self.config.save_full_config(full_cfg_path, resolve=True)
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -192,6 +192,9 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("📊 Saving accessed configuration...")
                 output_dir = Path(self.config.output_dir)
                 self.config.save_accessed_config(output_dir / "config.yaml", use_original_values=False)
+                full_cfg_path = output_dir / "config.full.yaml"
+                logger.info(f"📦 Saving full merged configuration to `{full_cfg_path}`...")
+                self.config.save_full_config(full_cfg_path, resolve=True)
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()

--- a/starVLA/training/trainer_utils/config_tracker.py
+++ b/starVLA/training/trainer_utils/config_tracker.py
@@ -445,6 +445,16 @@ class AccessTrackedConfig:
                 OmegaConf.save(OmegaConf.create(accessed_config), f)
             else:
                 raise ValueError(f"Unsupported file format: {filepath.suffix}")
+
+    def save_full_config(self, filepath: Path, resolve: bool = True):
+        """Save the full merged configuration to file."""
+        filepath = Path(filepath)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        if filepath.suffix not in (".yaml", ".yml"):
+            raise ValueError(f"Unsupported file format: {filepath.suffix}")
+
+        OmegaConf.save(self.get_root()._cfg, filepath, resolve=resolve)
     
     def get_access_summary(self) -> dict:
         """Get summary of accessed configuration"""


### PR DESCRIPTION
## Summary

This PR saves a full merged config backup (`config.full.yaml`) alongside the existing access-tracked config (`config.yaml`) during checkpointing.

## Motivation

The current checkpoint flow saves only the config keys tracked by `AccessTrackedConfig` in the running process. While this is useful as a concise snapshot of the actively used config, it is not a complete guarantee of reproducibility in multi-process execution.

More broadly, config access tracking is process-local by nature. In distributed training or any workflow that delegates runtime logic to independent subprocesses, some config fields may be consumed outside the main process and therefore never appear in the main-process tracked snapshot.

This can happen in several places, including but not limited to:

- dataloader worker processes,
- distributed rank-specific execution paths,
- subprocess-based preprocessing or caching logic,
- any runtime branch that reads config only in a child process.

In those cases, the access-tracked config may under-report the effective runtime configuration of the job. That makes post-hoc debugging, run auditing, and experiment reproduction less reliable.

A full merged config backup provides a simple and robust fallback:
- `config.yaml` remains a lightweight view of the tracked config,
- `config.full.yaml` preserves the complete resolved runtime configuration.

This PR adopts that dual-output approach so checkpoint artifacts remain both readable and reproducible.

As one concrete example, our local dataloader pipeline contains worker-side dataset logic that reads runtime config in subprocesses. A related config-driven dataloader pattern can also be seen in the PUMA LeRobot pipeline:  
[PUMA `starVLA-dataloader`](https://github.com/H-EmbodVis/DOMINO/blob/main/policy/PUMA/PUMA/dataloader)

## Changes

- Added `save_full_config()` to `AccessTrackedConfig`
- Saved `config.full.yaml` during checkpointing in:
  - `starVLA/training/train_starvla.py`
  - `starVLA/training/train_starvlm.py`
  - `starVLA/training/train_starvla_cotrain.py`

## Behavior After This Change

Each checkpoint now saves:

- `config.yaml`: access-tracked config snapshot
- `config.full.yaml`: full merged config backup

## Why this is safe

- No change to training logic or checkpoint weight format
- No change to the existing behavior of `config.yaml`
- Only adds a small extra YAML write during checkpointing

## Validation

- Verified that the modified files pass lint checks without introducing new issues