### PR TITLE
feat: Support OpenVLA/OFT modified LIBERO RLDS datasets for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Collecting, integrating, and exploring cutting-edge technologies for generalist 
 <!-- [![Update](https://img.shields.io/badge/UPDATE-Scripts%20fixed%20%7C%20Packaging%20smoother-red?style=for-the-badge)](https://github.com/starVLA/starVLA) -->
 [![Model & Data on Hugging Face](https://img.shields.io/badge/HuggingFace-Model%20%26%20Data-orange?style=for-the-badge&logo=huggingface)](https://huggingface.co/StarVLA) [![WeChat](https://img.shields.io/badge/WeChat-加入讨论群-brightgreen?style=for-the-badge&logo=wechat)](https://github.com/starVLA/starVLA/issues/64#issuecomment-3715403845)
 
+
+**[2026/03/19]** 🔥 StarVLA now provides a complete real-robot development case with [Franka robot examples](https://github.com/starVLA/starVLA/pull/198)!
+
 **[2026/03/03]** 🔥 We now support [**Qwen3.5** as a backbone for VLA](https://github.com/starVLA/starVLA/pull/172) — the fastest integration in the community ⚡  
 With more model size options: **0.8B, 2B, 4B, and 9B**! Build your VLA flexibly on top of native multimodal models! 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Collecting, integrating, and exploring cutting-edge technologies for generalist 
 <!-- [![Update](https://img.shields.io/badge/UPDATE-Scripts%20fixed%20%7C%20Packaging%20smoother-red?style=for-the-badge)](https://github.com/starVLA/starVLA) -->
 [![Model & Data on Hugging Face](https://img.shields.io/badge/HuggingFace-Model%20%26%20Data-orange?style=for-the-badge&logo=huggingface)](https://huggingface.co/StarVLA) [![WeChat](https://img.shields.io/badge/WeChat-加入讨论群-brightgreen?style=for-the-badge&logo=wechat)](https://github.com/starVLA/starVLA/issues/64#issuecomment-3715403845)
 
+**[2026/03/29]** 🔥 Thanks to the [ABot-M0](https://github.com/amap-cvlab/ABot-Manipulation) team for providing the [pre-trained weights](https://www.modelscope.cn/models/amap_cvlab/ABot-M0-Pretrain). For `Qwen3-VL 4B`, you can reload the `qwen_vl_interface` module in various frameworks!
 
 **[2026/03/19]** 🔥 StarVLA now provides a complete real-robot development case with [Franka robot examples](https://github.com/starVLA/starVLA/pull/198)!
 
@@ -471,6 +472,7 @@ This project draws inspiration and references from several notable open-source i
 - [DeepSpeed](https://github.com/deepspeedai/DeepSpeed)  
 - [Qwen-VL](https://github.com/QwenLM/Qwen3-VL/tree/main)  
 - [InternVL](https://github.com/OpenGVLab/InternVL)  
+- [ABot-Manipulation](https://github.com/amap-cvlab/ABot-Manipulation)
 
 The codebase was originally forked from [InternVLA-M1](https://github.com/InternRobotics/InternVLA-M1).
 

--- a/examples/Franka/README.md
+++ b/examples/Franka/README.md
@@ -1,0 +1,362 @@
+# Training StarVLA with Franka Data
+
+## Part 1: Convert Data to LeRobot 2.1 Format
+
+1. Convert your Franka data into `LeRobot 2.1` format. See `examples/Franka/franka2lerobot/README.md`.
+
+## Part 2: Register Training Data in StarVLA
+### 1. Configure the Modality File
+Create `modality.json` under your data directory:
+
+```
+your_data/meta/modality.json
+```
+
+### 2. Register the Dataset
+
+Register your dataset in StarVLA's `dataloader`:
+
+```
+starVLA/dataloader/gr00t_lerobot/data_config.py
+```
+
+### 3. Configure Data Paths
+
+Create or modify a training configuration file, for example:
+
+```
+examples/Franka/train_files/starvla_cotrain_franka_single.yaml
+```
+
+Example configuration:
+
+```yaml
+vla_data:
+  dataset_py: lerobot_datasets
+  data_root_dir: playground/Datasets/franka_pick_and_place_lerobot
+  data_mix: franka_eef_joints
+```
+
+Configure the mixture in `starVLA/dataloader/gr00t_lerobot/mixtures.py` and add the new dataset mixture.
+
+### 4. Validate the DataLoader
+
+Use the following command to check whether the DataLoader works correctly:
+
+```bash
+python starVLA/dataloader/lerobot_datasets.py \
+    --config_yaml examples/Franka/train_files/starvla_cotrain_franka_single.yaml
+```
+
+## Part 3: Model Training Preparation
+
+### 1. Configure Model Parameters
+
+Set model parameters in the YAML configuration file, for example:
+
+```yaml
+action_model:
+  action_dim: 7
+  state_dim: 18
+```
+
+### 2. Validate the Model Forward Pass
+
+Before starting training, you can verify that the model forward pass works correctly:
+
+```bash
+python starVLA/model/framework/QwenOFT.py \
+    --config_yaml examples/Franka/train_files/starvla_cotrain_franka_single.yaml
+```
+
+### 3. Start Training
+
+Example training script:
+
+```bash
+bash path/to/your/train_script.sh
+```
+
+After training, you can find the results and model checkpoints in the configured output directory.
+
+
+# Deploying StarVLA on a Franka Robot
+
+This section explains how to use the StarVLA policy server to control a robot arm, including how to adapt it to your own robot.
+
+Complete example code:
+- **Single-arm** (7D): `eval_files/inference_single_example.py`
+- **Dual-arm** (14D): `eval_files/inference_dual_example.py`
+
+## Overall Architecture
+
+![](../../assets/starVLA_PolicyServer.png)
+
+**Core workflow:**
+1. The client reads multi-view camera images (`np.ndarray`, `uint8`, `(H, W, 3)`).
+2. The client sends images and a language instruction to the server over WebSocket.
+3. The server returns normalized actions `normalized_actions` with shape `[B, T, action_dim]` (`action_dim=7` for single-arm, `action_dim=14` for dual-arm).
+4. The client unnormalizes the actions into real control commands.
+5. The client calls `env.step(action)` to execute pose and gripper control together.
+
+## 1. Start the Policy Server
+
+```bash
+# Run from the `starVLA_franka` root directory
+bash examples/Franka/eval_files/run_policy_server.sh
+```
+
+Core contents of `run_policy_server.sh`:
+```bash
+export PYTHONPATH=$(pwd):${PYTHONPATH}
+CUDA_VISIBLE_DEVICES=0 python deployment/model_server/server_policy.py \
+    --ckpt_path your_checkpoint.pt \
+    --port 5694 \
+    --use_bf16
+```
+
+After startup, the server listens for WebSocket connections on the specified port and waits for inference requests from clients.
+
+## 2. Client-side Inference
+
+You can either run `eval_files/inference_single_example.py` directly or integrate the workflow into your own system using the following steps:
+
+### 2.1 Connect to the Server
+
+```python
+from websocketclient import WebsocketClientPolicy
+
+client = WebsocketClientPolicy(host="127.0.0.1", port=5694)
+```
+
+`WebsocketClientPolicy` uses `msgpack_numpy` serialization, which supports direct transmission of NumPy arrays. After connecting, you can call `predict_action()`.
+
+### 2.2 Capture Images
+
+Capture multi-view images from your cameras with the following format:
+- **Type**: `np.ndarray`
+- **Shape**: `(H, W, 3)`, preferably `(224, 224, 3)`
+- **Data type**: `uint8`, RGB format
+- **Count**: consistent with the camera views used during training (for example, one wrist camera + one base camera = 2 images)
+
+```python
+# Pseudocode: implement this based on your camera SDK
+images = [camera_wrist.capture(), camera_base.capture()]  # List[np.ndarray]
+```
+
+### 2.3 Build the Request and Call the Server
+
+```python
+request_data = {
+    "examples": [{
+        "image": images,           # List[np.ndarray], multi-view images
+        "lang": "Pick up the red cup and place it on the plate.",
+    }]
+}
+
+result = client.predict_action(request_data)
+```
+
+### 2.4 Parse the Response and Unnormalize Actions
+
+```python
+# Server response format
+# result = {"data": {"normalized_actions": np.ndarray}, "status": "ok"}
+# normalized_actions shape: [B, T, action_dim], where B=1, T=prediction horizon, action_dim=7
+
+normalized_actions = result["data"]["normalized_actions"][0]  # [T, 7]
+
+# Unnormalize: [-1, 1] -> real action space
+# Formula: action = 0.5 * (normalized + 1) * (max - min) + min
+# The gripper dimension is binarized first: < 0.5 -> -1 (close), >= 0.5 -> 1 (open)
+actions = unnormalize_actions(normalized_actions, action_norm_stats)
+```
+
+### 2.5 Execute Actions
+
+The model outputs an **action chunk** (a T-step action sequence), which should be executed step by step:
+
+```python
+for action in actions:
+    # action: [x, y, z, roll, pitch, yaw, gripper]
+    # env.step() internally handles both pose and gripper control
+    obs, reward, done, truncated, info = env.step(action)
+    if done or truncated:
+        break
+```
+
+## 3. Action Space
+
+> ⚠️ **The current implementation is based on Franka robots.** Other robots may use different action dimensions and semantics, such as joint-space control with `N+1` dimensions. Adjust `action_dim`, gripper indices, and unnormalization logic for your robot.
+
+### Single-arm (7D)
+
+For a single-arm Franka setup, the model outputs a **7D action vector**, where pose and gripper are combined in a single vector:
+```
+action = [x, y, z, roll, pitch, yaw, gripper]
+
+• action[0:3] - position delta (x, y, z), Cartesian coordinates, in meters
+• action[3:6] - orientation delta (roll, pitch, yaw), Euler angles, in radians
+• action[6]   - gripper control (-1: close, 1: open)
+```
+
+### Dual-arm (14D)
+
+For a dual-arm Franka setup, the model outputs a **14D action vector**, i.e. 7D for the left arm and 7D for the right arm:
+```
+action = [x_l, y_l, z_l, roll_l, pitch_l, yaw_l, gripper_l,
+          x_r, y_r, z_r, roll_r, pitch_r, yaw_r, gripper_r]
+
+• action[0:6]   - left-arm pose delta (x, y, z, roll, pitch, yaw)
+• action[6]     - left gripper control (-1: close, 1: open)
+• action[7:13]  - right-arm pose delta (x, y, z, roll, pitch, yaw)
+• action[13]    - right gripper control (-1: close, 1: open)
+```
+
+The gripper is part of the action vector and is executed together inside `env.step(action)`, so it does not need to be handled separately.
+
+## 4. Action Unnormalization
+
+The model outputs normalized actions in the range `[-1, 1]`, which must be unnormalized using the statistics computed during training.
+
+### `dataset_statistics.json` Format
+
+**Single-arm (7D):**
+```json
+{
+    "franka": {
+        "action": {
+            "min": [x_min, y_min, z_min, roll_min, pitch_min, yaw_min, gripper_min],
+            "max": [x_max, y_max, z_max, roll_max, pitch_max, yaw_max, gripper_max],
+            "mask": [true, true, true, true, true, true, true]
+        }
+    }
+}
+```
+
+**Dual-arm (14D):**
+```json
+{
+    "new_embodiment": {
+        "action": {
+            "min": [7 min values for the left arm..., 7 min values for the right arm...],
+            "max": [7 max values for the left arm..., 7 max values for the right arm...],
+            "mask": [true, true, ..., true]
+        }
+    }
+}
+```
+
+### Unnormalization Formula
+
+```python
+# 1. clip to [-1, 1]
+normalized = np.clip(normalized, -1, 1)
+
+# 2. binarize gripper actions
+if action_dim == 14:  # dual-arm
+    normalized[:, 6] = np.where(normalized[:, 6] < 0.5, -1, 1)   # left gripper
+    normalized[:, 13] = np.where(normalized[:, 13] < 0.5, -1, 1)  # right gripper
+else:  # single-arm
+    normalized[:, 6] = np.where(normalized[:, 6] < 0.5, -1, 1)
+
+# 3. map linearly to the real range (only for mask=True dimensions)
+action = 0.5 * (normalized + 1) * (max - min) + min
+```
+
+## 5. Adapting to a New Robot
+
+If you want to use the StarVLA policy server with a new robot arm, you need to implement the following interfaces:
+
+> ⚠️ The explanation below uses the Franka 7D action space as an example. Your robot may use a different action space, such as joint-space control or a dual-arm setup. In that case, set the correct `action_dim` in the training config and adjust the gripper indices in the unnormalization logic.
+
+### What You Need to Implement
+
+| Component             | Description                                                                 |
+|-----------------------|-----------------------------------------------------------------------------|
+| **Image acquisition** | Read images from your cameras and output `List[np.ndarray]` in `(H, W, 3)`, `uint8`, RGB format. The number of views must match training. |
+| **`env.step(action)`** | Accept an action vector (for Franka: 7D `[x,y,z,roll,pitch,yaw,gripper]`) and handle both pose commands and gripper control internally. Adapt this to your robot's action space. |
+| **`env.reset()`** | Reset the robot to its initial pose and return the initial observation. |
+| **Normalization statistics** | Provide a matching `dataset_statistics.json` for your robot, generated during training, with dimensions consistent with `action_dim`. |
+
+### What You Do Not Need to Change
+
+| Component             | Description                                                                 |
+|-----------------------|-----------------------------------------------------------------------------|
+| **Policy Server** | Reuse it directly; just start it with `run_policy_server.sh`. |
+| **WebSocket communication** | Reuse `WebsocketClientPolicy` directly. |
+| **Unnormalization logic** | Reuse `unnormalize_actions()` directly, as long as you provide the matching statistics file. |
+| **Request/response format** | Unchanged: send `{image, lang}` and receive `{normalized_actions}`. |
+
+### `env.step()` Reference Implementation - Single-arm
+
+```python
+def step(self, action: np.ndarray):
+    """
+    Execute a 7D action: [x, y, z, roll, pitch, yaw, gripper]
+    Pose and gripper are handled in the same function.
+    """
+    pose_delta = action[0:6]    # pose delta
+    gripper_cmd = action[6]     # gripper: -1=close, 1=open
+
+    # 1. Pose control
+    target_pose = self.current_pose + pose_delta * self.action_scale
+    target_pose = np.clip(target_pose, self.pose_limit_low, self.pose_limit_high)
+    self.robot.move_to(target_pose)
+
+    # 2. Gripper control
+    if gripper_cmd >= 0.9:
+        self.robot.open_gripper()
+    elif gripper_cmd <= -0.9:
+        self.robot.close_gripper()
+
+    # 3. Read the observation
+    obs = self.get_obs()
+    reward = self.compute_reward()
+    done = self.check_done()
+    return obs, reward, done, False, {}
+```
+
+### `env.step()` Reference Implementation - Dual-arm
+
+```python
+def step(self, action: np.ndarray):
+    """
+    Execute a 14D action: [left-arm 7D, right-arm 7D]
+    Dual-arm pose and gripper control are handled in the same function.
+    """
+    # Left arm
+    left_pose_delta = action[0:6]
+    left_gripper_cmd = action[6]
+    # Right arm
+    right_pose_delta = action[7:13]
+    right_gripper_cmd = action[13]
+
+    # 1. Left-arm pose control
+    left_target = self.left_current_pose + left_pose_delta * self.action_scale
+    left_target = np.clip(left_target, self.left_pose_limit_low, self.left_pose_limit_high)
+    self.left_robot.move_to(left_target)
+
+    # 2. Left gripper control
+    if left_gripper_cmd >= 0.9:
+        self.left_robot.open_gripper()
+    elif left_gripper_cmd <= -0.9:
+        self.left_robot.close_gripper()
+
+    # 3. Right-arm pose control
+    right_target = self.right_current_pose + right_pose_delta * self.action_scale
+    right_target = np.clip(right_target, self.right_pose_limit_low, self.right_pose_limit_high)
+    self.right_robot.move_to(right_target)
+
+    # 4. Right gripper control
+    if right_gripper_cmd >= 0.9:
+        self.right_robot.open_gripper()
+    elif right_gripper_cmd <= -0.9:
+        self.right_robot.close_gripper()
+
+    # 5. Read the observation
+    obs = self.get_obs()
+    reward = self.compute_reward()
+    done = self.check_done()
+    return obs, reward, done, False, {}
+```

--- a/examples/Franka/eval_files/inference_dual_example.py
+++ b/examples/Franka/eval_files/inference_dual_example.py
@@ -1,0 +1,368 @@
+"""
+StarVLA Policy Server Dual-Arm Inference Example — Real Code + Pseudocode
+
+This script shows how to connect to a StarVLA policy server over WebSocket,
+receive model-predicted dual-arm actions, unnormalize them, and execute them on a dual-arm robot.
+
+⚠️ Note: the current implementation is based on a dual-arm Franka setup with a 14D action space:
+    [x_l, y_l, z_l, roll_l, pitch_l, yaw_l, gripper_l,
+     x_r, y_r, z_r, roll_r, pitch_r, yaw_r, gripper_r]
+    where action[0:7] corresponds to the left arm and action[7:14] to the right arm.
+
+For other dual-arm robots, the action dimensionality, arm ordering, and gripper indices may differ.
+Please adjust `action_dim`, gripper indices, and unnormalization logic to match your robot.
+
+For single-arm robots (7D), see `inference_single_example.py`.
+
+Real code sections (directly reusable):
+    - WebSocket client connection and communication
+    - request construction and response parsing
+    - action unnormalization (`unnormalize_actions`), supporting 7D single-arm and 14D dual-arm actions
+
+Pseudocode sections (replace for your robot):
+    - camera image acquisition
+    - dual-arm robot environment creation, `reset`, and `step`
+"""
+
+import numpy as np
+import json
+import time
+from typing import List, Dict
+
+# ============================================================
+# ✅ Real code: WebSocket client
+# ============================================================
+# WebsocketClientPolicy uses msgpack_numpy serialization and communicates with the server over WebSocket.
+# Source: starVLA/deployment/model_server/tools/websocket_policy_client.py
+from websocketclient import WebsocketClientPolicy
+
+
+# ============================================================
+# ✅ Real code: action unnormalization (supports 7D single-arm and 14D dual-arm)
+# ============================================================
+def unnormalize_actions(normalized_actions: np.ndarray,
+                        action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
+    """
+    Convert normalized model outputs in [-1, 1] back to the real action space.
+    Supports both single-arm (7D) and dual-arm (14D) action spaces.
+
+    Args:
+        normalized_actions: normalized actions, shape [T, action_dim], range [-1, 1]
+            - single-arm: action_dim=7, gripper at index=6
+            - dual-arm: action_dim=14, grippers at index=6 (left arm) and index=13 (right arm)
+        action_norm_stats: normalization statistics containing:
+            - "min": np.ndarray, per-dimension minimum values
+            - "max": np.ndarray, per-dimension maximum values
+            - "mask": np.ndarray (bool), which dimensions are normalized
+
+    Returns:
+        actions: unnormalized actions, shape [T, action_dim]
+
+    Formula:
+        action = 0.5 * (normalized + 1) * (max - min) + min
+        where the gripper dimensions are first binarized: < 0.5 → -1, >= 0.5 → 1
+    """
+    mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
+    action_high = np.array(action_norm_stats["max"])
+    action_low = np.array(action_norm_stats["min"])
+
+    normalized_actions = np.clip(normalized_actions, -1, 1)
+
+    # Apply binary thresholding to the gripper dimensions.
+    action_dim = normalized_actions.shape[-1]
+    if action_dim == 14:
+        # Dual-arm: left gripper at index=6, right gripper at index=13.
+        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, -1, 1)
+        normalized_actions[:, 13] = np.where(normalized_actions[:, 13] < 0.5, -1, 1)
+    elif action_dim >= 7:
+        # Single-arm: gripper at index=6.
+        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, -1, 1)
+
+    # Linear unnormalization, only for dimensions with mask=True.
+    actions = np.where(
+        mask,
+        0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
+        normalized_actions,
+    )
+    return actions
+
+
+# ============================================================
+# ✅ Real code: request construction and response parsing
+# ============================================================
+def build_request(images: List[np.ndarray], task_instruction: str) -> dict:
+    """
+    Construct a request for the StarVLA policy server.
+
+    Args:
+        images: multi-view camera images, each with shape (H, W, 3), dtype uint8
+        task_instruction: natural-language task instruction
+
+    Returns:
+        request_data: dict matching the server API
+    """
+    request_data = {
+        "examples": [{
+            "image": images,       # List[np.ndarray], converted to PIL Images on the server side
+            "lang": task_instruction,
+        }]
+    }
+    return request_data
+
+
+def parse_response(result: dict) -> np.ndarray:
+    """
+    Parse the policy server response and extract the action chunk.
+
+    Args:
+        result: dict returned by the server, formatted as:
+            {"data": {"normalized_actions": np.ndarray}, "status": "ok"}
+
+    Returns:
+        action_chunk: shape [T, action_dim], where T is the predicted horizon
+    """
+    data = result.get("data", result)
+
+    for key in ["normalized_actions", "actions", "action"]:
+        if key in data:
+            actions = data[key]
+            if isinstance(actions, list):
+                actions = np.array(actions)
+            # Normalize to [T, action_dim].
+            if len(actions.shape) == 3:
+                actions = actions[0]       # [B, T, D] -> [T, D]
+            elif len(actions.shape) == 1:
+                actions = actions.reshape(1, -1)  # [D] -> [1, D]
+            return actions
+
+    raise KeyError(f"Could not extract actions from response. Available keys: {list(data.keys())}")
+
+
+# ============================================================
+# ✅ Real code: load action normalization statistics
+# ============================================================
+def load_action_norm_stats(json_path: str, embodiment_key: str = "new_embodiment") -> Dict[str, np.ndarray]:
+    """
+    Load normalization statistics from `dataset_statistics.json`.
+
+    Example JSON format for a dual-arm 14D setup:
+    {
+        "new_embodiment": {
+            "action": {
+                "min": [14 minimum values],
+                "max": [14 maximum values],
+                "mask": [true, true, ..., true]  // 14 entries
+            }
+        }
+    }
+    """
+    with open(json_path, 'r') as f:
+        stats_data = json.load(f)
+
+    if embodiment_key in stats_data:
+        stats_data = stats_data[embodiment_key]
+    if "action" in stats_data:
+        stats_data = stats_data["action"]
+
+    norm_stats = {
+        "min": np.array(stats_data.get("min", stats_data.get("low", []))),
+        "max": np.array(stats_data.get("max", stats_data.get("high", []))),
+    }
+    if "mask" in stats_data:
+        norm_stats["mask"] = np.array(stats_data["mask"], dtype=bool)
+
+    return norm_stats
+
+
+# ============================================================
+# === Pseudocode: implement the following functions for your dual-arm robot ===
+# ============================================================
+
+def capture_images_from_cameras() -> List[np.ndarray]:
+        """
+        [Pseudocode] Capture multi-view images from cameras.
+
+        Dual-arm setups usually require more camera views, for example:
+            - a left wrist camera and a right wrist camera
+            - a global base camera
+
+        TODO: implement this based on your camera hardware
+
+        Returns:
+                images: List[np.ndarray], each with shape (H, W, 3), dtype uint8, in RGB format
+        """
+        # --- Example pseudocode ---
+    # return [image_left_wrist, image_right_wrist, image_base]
+        raise NotImplementedError("Please implement camera image acquisition")
+
+
+class YourDualArmRobotEnv:
+        """
+        [Pseudocode] Dual-arm robot environment interface.
+
+        You need to implement the following methods to send 14D actions to a dual-arm robot:
+            - reset(): move both arms to their initial poses and return the initial observation
+            - step(action): execute a 14D action
+            - get_obs(): return the current observation (images + state)
+
+        Dual-arm action definition (Franka dual-arm 14D action space):
+            action[0:3]   - left-arm position delta (x, y, z)
+            action[3:6]   - left-arm orientation delta (roll, pitch, yaw)
+            action[6]     - left gripper control (-1: close, 1: open)
+            action[7:10]  - right-arm position delta (x, y, z)
+            action[10:13] - right-arm orientation delta (roll, pitch, yaw)
+            action[13]    - right gripper control (-1: close, 1: open)
+
+        ⚠️ Other dual-arm robots may use different action sizes, arm ordering, and gripper indices.
+
+        `env.step()` should internally handle both:
+            1. left-arm pose control + left gripper control
+            2. right-arm pose control + right gripper control
+        """
+
+    def reset(self):
+        """Reset both arms to their initial poses."""
+        # TODO: send a reset command for both arms
+        # TODO: wait until both arms reach their initial poses
+        # TODO: return the initial observation
+        raise NotImplementedError
+
+    def step(self, action: np.ndarray):
+        """
+        Execute one action step (dual-arm pose + grippers handled together).
+
+        Args:
+            action: np.ndarray, shape (14,)
+                [x_l, y_l, z_l, roll_l, pitch_l, yaw_l, gripper_l,
+                 x_r, y_r, z_r, roll_r, pitch_r, yaw_r, gripper_r]
+
+        Returns:
+            obs: dict, observation (including images and state)
+            reward: float
+            done: bool
+            truncated: bool
+            info: dict
+        """
+        # TODO: Example implementation:
+        #
+        # 1. Parse the dual-arm action
+        # left_pose_delta = action[0:6]
+        # left_gripper_cmd = action[6]
+        # right_pose_delta = action[7:13]
+        # right_gripper_cmd = action[13]
+        #
+        # 2. Left-arm pose control
+        # left_target = left_current_pose + left_pose_delta * action_scale
+        # left_target = clip_to_safety_box(left_target)
+        # left_robot.move_to(left_target)
+        #
+        # 3. Left gripper control
+        # if left_gripper_cmd >= 0.9:
+        #     left_robot.open_gripper()
+        # elif left_gripper_cmd <= -0.9:
+        #     left_robot.close_gripper()
+        #
+        # 4. Right-arm pose control
+        # right_target = right_current_pose + right_pose_delta * action_scale
+        # right_target = clip_to_safety_box(right_target)
+        # right_robot.move_to(right_target)
+        #
+        # 5. Right gripper control
+        # if right_gripper_cmd >= 0.9:
+        #     right_robot.open_gripper()
+        # elif right_gripper_cmd <= -0.9:
+        #     right_robot.close_gripper()
+        #
+        # 6. Get the observation
+        # obs = self.get_obs()
+        # return obs, reward, done, truncated, info
+        raise NotImplementedError
+
+    def get_obs(self) -> dict:
+        """Get the current observation."""
+        # TODO: return a dict containing images and state
+        # return {
+        #     "images": capture_images_from_cameras(),
+        #     "state": {
+        #         "left_tcp_pose": ...,
+        #         "right_tcp_pose": ...,
+        #         ...
+        #     },
+        # }
+        raise NotImplementedError
+
+
+# ============================================================
+# Main inference loop (dual-arm)
+# ============================================================
+def main():
+    # ------ Configuration ------
+    policy_host = "127.0.0.1"
+    policy_port = 5694
+    task_instruction = "Two robotic arms are working together to perform a handover task."
+    action_stats_path = "/path/to/dataset_statistics.json"
+    max_episodes = 10
+    max_steps_per_episode = 500
+
+    # ------ ✅ Real code: load normalization statistics (dual-arm 14D) ------
+    action_norm_stats = load_action_norm_stats(action_stats_path, embodiment_key="new_embodiment")
+    print(f"Action dim: {len(action_norm_stats['min'])}")  # should be 14
+    print(f"Action min: {action_norm_stats['min']}")
+    print(f"Action max: {action_norm_stats['max']}")
+
+    # ------ ✅ Real code: connect to the Policy Server ------
+    client = WebsocketClientPolicy(host=policy_host, port=policy_port)
+    print(f"Connected to Policy Server: {policy_host}:{policy_port}")
+
+    # ------ [Pseudocode] Create the dual-arm robot environment ------
+    env = YourDualArmRobotEnv()  # TODO: replace with your dual-arm robot environment
+    obs = env.reset()
+
+    # ------ Main inference loop ------
+    for episode in range(max_episodes):
+        obs = env.reset()
+        print(f"\n--- Episode {episode + 1}/{max_episodes} ---")
+
+        step_count = 0
+        done = False
+
+        while step_count < max_steps_per_episode and not done:
+
+            # Step 1: [Pseudocode] Read images from the observation
+            images = obs["images"]  # List[np.ndarray], (H, W, 3), uint8
+
+            # Step 2: ✅ Real code - build the request and call the policy server
+            request = build_request(images, task_instruction)
+            result = client.predict_action(request)
+
+            # Step 3: ✅ Real code - parse the response and get the normalized action chunk
+            normalized_action_chunk = parse_response(result)  # [T, 14]
+
+            # Step 4: ✅ Real code - unnormalize the actions
+            action_chunk = unnormalize_actions(normalized_action_chunk, action_norm_stats)
+            # action_chunk: [T, 14], each row = [left-arm 7D, right-arm 7D]
+
+            # Step 5: Execute the action chunk step by step
+            for action in action_chunk:
+                # action is a 14D vector:
+                # [x_l, y_l, z_l, roll_l, pitch_l, yaw_l, gripper_l,
+                #  x_r, y_r, z_r, roll_r, pitch_r, yaw_r, gripper_r]
+                # env.step() should internally handle dual-arm pose and gripper control together
+                obs, reward, done, truncated, info = env.step(action)  # [Pseudocode]
+                step_count += 1
+
+                if done or truncated:
+                    break
+
+            if done or truncated:
+                break
+
+        print(f"Episode {episode + 1} finished, steps: {step_count}")
+
+    # Close the connection
+    client.close()
+    print("Inference complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Franka/eval_files/inference_single_example.py
+++ b/examples/Franka/eval_files/inference_single_example.py
@@ -1,0 +1,343 @@
+"""
+StarVLA Policy Server Inference Example — Real Code + Pseudocode
+
+This script shows how to connect to a StarVLA policy server over WebSocket,
+receive model-predicted actions, unnormalize them, and execute them on a robot arm.
+
+⚠️ Note: the current implementation is based on a Franka arm with a 7D action space:
+    [x, y, z, roll, pitch, yaw, gripper]
+For other robot arms, the action dimensionality and semantics may differ, for example:
+    - a dual-arm system may use 14 dimensions (7 per arm)
+    - joint-space control may use N joint angles + gripper
+    - the gripper index and meaning may also be different
+Please adjust `action_dim`, gripper indices, and unnormalization logic to match your robot.
+
+Real code sections (directly reusable):
+    - WebSocket client connection and communication
+    - request construction and response parsing
+    - action unnormalization (`unnormalize_actions`)
+
+Pseudocode sections (replace for your robot):
+    - camera image acquisition
+    - robot environment creation, `reset`, and `step`
+"""
+
+import numpy as np
+import json
+import time
+from typing import List, Dict
+
+# ============================================================
+# ✅ Real code: WebSocket client
+# ============================================================
+# WebsocketClientPolicy uses msgpack_numpy serialization and communicates with the server over WebSocket.
+# Source: starVLA/deployment/model_server/tools/websocket_policy_client.py
+from websocketclient import WebsocketClientPolicy
+
+
+# ============================================================
+# ✅ Real code: action unnormalization
+# ============================================================
+def unnormalize_actions(normalized_actions: np.ndarray, 
+                        action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
+    """
+    Convert normalized model outputs in [-1, 1] back to the real action space.
+
+    Args:
+        normalized_actions: normalized actions, shape [T, action_dim], range [-1, 1]
+        action_norm_stats: normalization statistics containing:
+            - "min": np.ndarray, per-dimension minimum values
+            - "max": np.ndarray, per-dimension maximum values
+            - "mask": np.ndarray (bool), which dimensions are normalized
+
+    Returns:
+        actions: unnormalized actions, shape [T, action_dim]
+
+    Formula:
+        action = 0.5 * (normalized + 1) * (max - min) + min
+        where the gripper dimension is first binarized: < 0.5 → -1, >= 0.5 → 1
+    """
+    mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
+    action_high = np.array(action_norm_stats["max"])
+    action_low = np.array(action_norm_stats["min"])
+
+    normalized_actions = np.clip(normalized_actions, -1, 1)
+
+    # Apply binary thresholding to the gripper dimension (index=6).
+    # ⚠️ In the current Franka 7D action space, the gripper is at index=6.
+    # Other robots may use different action sizes and gripper indices.
+    if normalized_actions.shape[-1] >= 7:
+        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, -1, 1)
+
+    # Linear unnormalization, only for dimensions with mask=True.
+    actions = np.where(
+        mask,
+        0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
+        normalized_actions,
+    )
+    return actions
+
+
+# ============================================================
+# ✅ Real code: request construction and response parsing
+# ============================================================
+def build_request(images: List[np.ndarray], task_instruction: str) -> dict:
+    """
+    Construct a request for the StarVLA policy server.
+
+    Args:
+        images: multi-view camera images, each with shape (H, W, 3), dtype uint8
+        task_instruction: natural-language task instruction, e.g. "Pick up the red cup"
+
+    Returns:
+        request_data: dict matching the server API
+    """
+    request_data = {
+        "examples": [{
+            "image": images,       # List[np.ndarray], converted to PIL Images on the server side
+            "lang": task_instruction,
+        }]
+    }
+    return request_data
+
+
+def parse_response(result: dict) -> np.ndarray:
+    """
+    Parse the policy server response and extract the action chunk.
+
+    Args:
+        result: dict returned by the server, formatted as:
+            {"data": {"normalized_actions": np.ndarray}, "status": "ok"}
+
+    Returns:
+        action_chunk: shape [T, action_dim], where T is the predicted horizon
+    """
+    data = result.get("data", result)
+
+    # Try several common output keys.
+    for key in ["normalized_actions", "actions", "action"]:
+        if key in data:
+            actions = data[key]
+            if isinstance(actions, list):
+                actions = np.array(actions)
+            # Normalize to [T, action_dim].
+            if len(actions.shape) == 3:
+                actions = actions[0]       # [B, T, D] -> [T, D]
+            elif len(actions.shape) == 1:
+                actions = actions.reshape(1, -1)  # [D] -> [1, D]
+            return actions
+
+    raise KeyError(f"Could not extract actions from response. Available keys: {list(data.keys())}")
+
+
+# ============================================================
+# ✅ Real code: load action normalization statistics
+# ============================================================
+def load_action_norm_stats(json_path: str, embodiment_key: str = "franka") -> Dict[str, np.ndarray]:
+    """
+    Load normalization statistics from `dataset_statistics.json`.
+
+    Example JSON format:
+    {
+        "franka": {
+            "action": {
+                "min": [...],
+                "max": [...],
+                "mask": [true, true, ...]
+            }
+        }
+    }
+    """
+    with open(json_path, 'r') as f:
+        stats_data = json.load(f)
+
+    if embodiment_key in stats_data:
+        stats_data = stats_data[embodiment_key]
+    if "action" in stats_data:
+        stats_data = stats_data["action"]
+
+    norm_stats = {
+        "min": np.array(stats_data.get("min", stats_data.get("low", []))),
+        "max": np.array(stats_data.get("max", stats_data.get("high", []))),
+    }
+    if "mask" in stats_data:
+        norm_stats["mask"] = np.array(stats_data["mask"], dtype=bool)
+
+    return norm_stats
+
+
+# ============================================================
+# === Pseudocode: implement the following functions for your robot ===
+# ============================================================
+
+def capture_images_from_cameras() -> List[np.ndarray]:
+        """
+        [Pseudocode] Capture multi-view images from cameras.
+
+        TODO: implement this based on your camera hardware, for example:
+            - RealSense: use the pyrealsense2 SDK
+            - USB cameras: use OpenCV VideoCapture
+            - Other devices: use the corresponding SDK
+
+        Returns:
+                images: List[np.ndarray], each with shape (H, W, 3), dtype uint8, in RGB format
+        """
+        # --- Example pseudocode ---
+    # import pyrealsense2 as rs
+    # frames = pipeline.wait_for_frames()
+    # color_frame = frames.get_color_frame()
+    # image = np.asanyarray(color_frame.get_data())  # BGR
+    # image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)  # convert to RGB
+    # image = cv2.resize(image, (224, 224))
+    # return [image_wrist, image_base]  # multi-view
+    raise NotImplementedError("Please implement camera image acquisition")
+
+
+class YourRobotEnv:
+        """
+        [Pseudocode] Robot arm environment interface.
+
+        You need to implement the following methods to send 7D actions to your robot:
+            - reset(): move the robot to its initial pose and return the initial observation
+            - step(action): execute a 7D action [x, y, z, roll, pitch, yaw, gripper]
+            - get_obs(): return the current observation (images + state)
+
+        Action definition (Franka 7D action space):
+            action[0:3] - position delta (x, y, z), Cartesian coordinates, in meters
+            action[3:6] - orientation delta (roll, pitch, yaw), Euler angles, in radians
+            action[6]   - gripper control (-1: close, 1: open)
+
+        ⚠️ Other robots may use different action sizes and meanings. Adjust accordingly.
+
+        `env.step()` should internally handle both:
+            1. pose control: convert action[0:6] into a target pose and send it to the controller
+            2. gripper control: open/close the gripper based on action[6]
+        """
+
+    def reset(self):
+        """Reset the robot to its initial pose."""
+        # TODO: send a reset command to the robot
+        # TODO: wait until the robot reaches the initial pose
+        # TODO: return the initial observation
+        raise NotImplementedError
+
+    def step(self, action: np.ndarray):
+        """
+        Execute one action step (pose + gripper handled together).
+
+        Args:
+            action: np.ndarray, shape (7,),
+                [x, y, z, roll, pitch, yaw, gripper]
+
+        Returns:
+            obs: dict, observation (including images and state)
+            reward: float
+            done: bool
+            truncated: bool
+            info: dict
+        """
+        # TODO: Example implementation:
+        #
+        # 1. Parse the action
+        # pose_delta = action[0:6]   # pose delta
+        # gripper_cmd = action[6]    # gripper: -1=close, 1=open
+        #
+        # 2. Compute the target pose
+        # target_pose = current_pose + pose_delta * action_scale
+        # target_pose = clip_to_safety_box(target_pose)
+        #
+        # 3. Send the pose command
+        # robot.move_to(target_pose)
+        #
+        # 4. Send the gripper command
+        # if gripper_cmd >= 0.9:
+        #     robot.open_gripper()
+        # elif gripper_cmd <= -0.9:
+        #     robot.close_gripper()
+        #
+        # 5. Get the observation
+        # obs = self.get_obs()
+        # return obs, reward, done, truncated, info
+        raise NotImplementedError
+
+    def get_obs(self) -> dict:
+        """Get the current observation."""
+        # TODO: return a dict containing images and state
+        # return {
+        #     "images": capture_images_from_cameras(),
+        #     "state": robot.get_state(),
+        # }
+        raise NotImplementedError
+
+
+# ============================================================
+# Main inference loop
+# ============================================================
+def main():
+    # ------ Configuration ------
+    policy_host = "127.0.0.1"
+    policy_port = 5694
+    task_instruction = "Pick up the pink cube and place it into the black box."
+    action_stats_path = "/path/to/dataset_statistics.json"
+    max_episodes = 10
+    max_steps_per_episode = 500
+
+    # ------ ✅ Real code: load normalization statistics ------
+    action_norm_stats = load_action_norm_stats(action_stats_path, embodiment_key="franka")
+    print(f"Action min: {action_norm_stats['min']}")
+    print(f"Action max: {action_norm_stats['max']}")
+
+    # ------ ✅ Real code: connect to the Policy Server ------
+    client = WebsocketClientPolicy(host=policy_host, port=policy_port)
+    print(f"Connected to Policy Server: {policy_host}:{policy_port}")
+
+    # ------ [Pseudocode] Create the robot environment ------
+    env = YourRobotEnv()  # TODO: replace with your robot environment
+    obs = env.reset()
+
+    # ------ Main inference loop ------
+    for episode in range(max_episodes):
+        obs = env.reset()
+        print(f"\n--- Episode {episode + 1}/{max_episodes} ---")
+
+        step_count = 0
+        done = False
+
+        while step_count < max_steps_per_episode and not done:
+
+            # Step 1: [Pseudocode] Read images from the observation
+            images = obs["images"]  # List[np.ndarray], (H, W, 3), uint8
+
+            # Step 2: ✅ Real code - build the request and call the policy server
+            request = build_request(images, task_instruction)
+            result = client.predict_action(request)
+
+            # Step 3: ✅ Real code - parse the response and get the normalized action chunk
+            normalized_action_chunk = parse_response(result)  # [T, 7]
+
+            # Step 4: ✅ Real code - unnormalize the actions
+            action_chunk = unnormalize_actions(normalized_action_chunk, action_norm_stats)
+            # action_chunk: [T, 7], each row = [x, y, z, roll, pitch, yaw, gripper]
+
+            # Step 5: Execute the action chunk step by step
+            for action in action_chunk:
+                # action is a 7D vector: [x, y, z, roll, pitch, yaw, gripper]
+                # env.step() should internally handle both pose and gripper control
+                obs, reward, done, truncated, info = env.step(action)  # [Pseudocode]
+                step_count += 1
+
+                if done or truncated:
+                    break
+
+            if done or truncated:
+                break
+
+        print(f"Episode {episode + 1} finished, steps: {step_count}")
+
+    # Close the connection
+    client.close()
+    print("Inference complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Franka/eval_files/run_policy_server.sh
+++ b/examples/Franka/eval_files/run_policy_server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+export PYTHONPATH=$(pwd):${PYTHONPATH} # let Franka find the websocket tools from main repo
+export star_vla_python=/mnt/petrelfs/share/yejinhui/Envs/miniconda3/envs/starVLA/bin/python
+your_ckpt=results/Checkpoints/Franka_QwenPI_qwen3/checkpoints/steps_50000_pytorch_model.pt
+gpu_id=0
+port=5694
+################# star Policy Server ######################
+
+# export DEBUG=true
+CUDA_VISIBLE_DEVICES=$gpu_id ${star_vla_python} deployment/model_server/server_policy.py \
+    --ckpt_path ${your_ckpt} \
+    --port ${port} \
+    --use_bf16
+
+# #################################

--- a/examples/Franka/franka2lerobot/README.md
+++ b/examples/Franka/franka2lerobot/README.md
@@ -1,0 +1,327 @@
+# Converting Franka Data to LeRobot Format
+
+This document explains how to organize real Franka robot data into a LeRobot dataset that can be used by StarVLA.
+
+Recommended workflow:
+
+1. Raw episode data -> **LeRobot v3.0-style aggregated dataset**
+2. If needed, convert the v3.0 dataset into a **LeRobot v2.1-style directory layout**
+
+## 1. Environment Setup
+
+### 1.1 Install Dependencies
+
+First, downgrade `datasets`:
+
+```bash
+pip install "datasets<4.0.0"
+```
+
+Reason: `datasets==4.0.0` introduced changes such as `List` and `Column`, which are incompatible with the current conversion logic.
+
+Then install LeRobot:
+
+```bash
+pip install lerobot
+lerobot-info
+```
+
+If `lerobot-info` runs successfully, LeRobot is installed correctly.
+
+### 1.2 Additional Dependencies
+
+If you need to convert from v3.0 to the v2.1 directory layout, you will typically also need:
+
+```bash
+pip install jsonlines pyarrow tqdm numpy pandas
+```
+
+If the dataset contains videos, the second conversion step also depends on `ffmpeg` to split video files:
+
+```bash
+ffmpeg -version
+```
+
+If this command is not available, install `ffmpeg` first.
+
+## 2. Raw Data Requirements
+
+The raw data does not have to use one fixed file format, but it is recommended to organize it by **episode**. Each episode should include at least:
+
+- a multi-frame observation sequence
+- per-frame actions
+- camera images or image paths
+- robot state
+- task text or a task identifier
+
+For example, the raw data can be stored as `demo_*.pkl` files:
+
+```bash
+demo_*.pkl
+```
+
+The directory can look like this:
+
+```text
+your_franka_dataset/
+├── demo_0.pkl
+├── demo_1.pkl
+├── demo_2.pkl
+└── ...
+```
+
+In this case, each `pkl` file is usually treated as one episode.
+
+If your data is not in `pkl` format, that is also fine. Common sources include:
+
+- HDF5
+- ROS bag
+- JSON / NPZ / Parquet
+- your own binary format
+
+As long as you can reorganize the contents into the LeRobot target format described below, the original source format does not matter.
+
+Each frame should include at least the following fields:
+
+- `observation.images.*`: one or more camera-view images
+- `observation.state`: robot state, such as end-effector pose, velocity, gripper state, etc.
+- `action`: the control action corresponding to the current frame
+- `task`: task description text
+- `timestamp` or frame index
+
+For dual-arm tasks, the state and action dimensions will be expanded accordingly.
+
+## 3. Target Format
+
+It is recommended to produce one of the following two formats:
+
+### 3.1 LeRobot v3.0-Style Aggregated Format
+
+This format is suitable as an intermediate format. The directory roughly looks like:
+
+```text
+your_dataset_lerobot/
+├── data/
+├── meta/
+├── videos/
+└── ...
+```
+
+Characteristics: parquet files and videos are usually stored in chunk/file aggregated form, and metadata is also managed in aggregated form.
+
+### 3.2 LeRobot v2.1-Style Legacy Format
+
+If your training or downstream code requires LeRobot 2.1, the dataset should be further organized as:
+
+```text
+your_dataset_lerobot/
+├── data/
+│   ├── chunk-000/
+│   │   ├── episode_000000.parquet
+│   │   ├── episode_000001.parquet
+│   │   └── ...
+├── videos/
+│   ├── chunk-000/
+│   │   ├── camera_0/
+│   │   │   ├── episode_000000.mp4
+│   │   │   └── ...
+├── meta/
+│   ├── episodes.jsonl
+│   ├── episodes_stats.jsonl
+│   ├── tasks.jsonl
+│   └── info.json
+└── ...
+```
+
+Some current StarVLA Franka workflows depend on this layout.
+
+## 4. Conversion Workflow
+
+### 4.1 Step 1: Raw Data -> LeRobot v3.0
+
+The goal of this step is to aggregate multiple raw episodes into a single LeRobot dataset. This usually requires:
+
+1. scanning raw episode files
+2. reading observations, actions, and task information
+3. organizing the data frame by frame into a unified schema
+4. writing the data into a LeRobot dataset
+5. generating metadata, statistics, and video information
+
+Typical input parameters look like:
+
+```bash
+ROOT_PATH="/path/to/your/raw_franka_dataset"
+OUT_PATH="/path/to/output_dir"
+TASK_NAME="Franka pick and place"
+```
+
+Here, `ROOT_PATH` is the raw data directory, `OUT_PATH` is the output root directory, and `TASK_NAME` is the task description text.
+
+Typical command form:
+
+```bash
+python your_converter.py \
+    --root-path "$ROOT_PATH" \
+    --out-path "$OUT_PATH" \
+    --task-name "$TASK_NAME"
+```
+
+### 4.2 Output of Step 1
+
+The output directory will typically be:
+
+```text
+OUT_PATH/
+└── <ROOT_PATH>_lerobot/
+```
+
+example：
+
+```text
+ROOT_PATH=/data/pick_and_place_franka_data
+OUT_PATH=/data/converted
+```
+
+Then the output is typically:
+
+```text
+/data/converted/pick_and_place_franka_data_lerobot/
+```
+
+This step produces a **LeRobot v3.0-style** dataset.
+
+### 4.3 Step 2: LeRobot v3.0 -> LeRobot v2.1
+
+If the training code depends on LeRobot 2.1, a second layout-conversion step is required. This mainly includes:
+
+- splitting aggregated parquet data back into per-episode parquet files
+- splitting aggregated videos back into per-episode mp4 files
+- rebuilding legacy `episodes.jsonl`, `episodes_stats.jsonl`, and `tasks.jsonl`
+- rewriting `info.json` with `codebase_version` set to `v2.1`
+
+This step usually requires:
+
+1. reading episode metadata from the v3.0 dataset
+2. locating the start/end range of each episode inside aggregated parquet files
+3. exporting each episode as `episode_xxxxxx.parquet`
+4. if videos exist, splitting large videos into per-episode clips using timestamps
+5. rebuilding the legacy `meta` files
+6. updating `info.json` to match the v2.1 schema
+
+Typical command form:
+
+```bash
+python your_v30_to_v21_converter.py \
+    --root /path/to/your/lerobot_v30_dataset
+```
+
+A valid v3.0 -> v2.1 converter will usually:
+
+1. read `meta/episodes/chunk-*/file-*.parquet`
+    - recover the data range and video range for each episode
+2. rewrite `info.json`
+    - set `codebase_version` to `v2.1`
+    - restore the legacy `data_path` template
+    - restore the legacy `video_path` template
+3. split aggregated parquet data into:
+    - `data/chunk-xxx/episode_yyyyyy.parquet`
+4. if videos exist:
+    - split aggregated videos into per-episode mp4 files using `ffmpeg`
+5. rebuild legacy metadata:
+    - `meta/tasks.jsonl`
+    - `meta/episodes.jsonl`
+    - `meta/episodes_stats.jsonl`
+6. copy ancillary directories (such as `images/`)
+7. optionally replace the original directory:
+    - first create a temporary `_v2.1` directory
+    - remove the original v3.0 directory
+    - move the v2.1 result back to the original `--root` path
+
+In other words, after the conversion:
+
+- the `--root` path name can remain unchanged
+- but its contents will have changed from a v3.0 layout to a v2.1 layout
+
+## 5. Key Consistency Requirements
+
+Regardless of whether you use our internal scripts, the final dataset should satisfy the following consistency requirements:
+
+### 5.1 Actions
+
+- A single-arm Franka setup usually uses 7D actions.
+- The action semantics must match the training configuration, for example:
+    - `delta_ee`
+    - or another control space that you define
+
+### 5.2 Images
+
+- The number of images must match the camera views used during training.
+- The image ordering should remain consistent throughout the dataset.
+- Image size and preprocessing should be as consistent as possible.
+
+### 5.3 State
+
+- The state dimension must match `state_dim` in the training configuration.
+- Missing state fields or inconsistent ordering can cause silent training errors.
+
+### 5.4 Task Text
+
+- Each episode should have a corresponding task description.
+- If natural-language annotations are unavailable, provide a stable task ID and map it to text.
+
+### 5.5 Episode Boundaries
+
+- The start and end indices of each episode must be correct.
+- If videos exist, their time ranges must align with the corresponding episodes.
+
+
+## 6. Example Commands
+
+If you already have corresponding scripts, you can run them in the following order:
+
+```bash
+cd /project/vonneumann1/cyx/starVLA_franka/examples/Franka/franka2lerobot
+
+bash convert.sh
+
+python convert_dataset.py \
+     --root /path/to/output_dir/<raw_dataset_name>_lerobot
+```
+
+## 7. Output Directory Examples
+
+### After Step 1 (v3.0)
+
+The directory will roughly contain:
+
+```text
+your_dataset_lerobot/
+├── data/
+├── meta/
+├── videos/
+└── ...
+```
+
+### After Step 2 (v2.1)
+
+The directory will look more like the legacy LeRobot structure, for example:
+
+```text
+your_dataset_lerobot/
+├── data/
+│   ├── chunk-000/
+│   │   ├── episode_000000.parquet
+│   │   ├── episode_000001.parquet
+│   │   └── ...
+├── videos/
+│   ├── chunk-000/
+│   │   ├── camera_0/
+│   │   │   ├── episode_000000.mp4
+│   │   │   └── ...
+├── meta/
+│   ├── episodes.jsonl
+│   ├── episodes_stats.jsonl
+│   ├── tasks.jsonl
+│   └── info.json
+└── ...
+```

--- a/examples/Franka/train_files/modality.json
+++ b/examples/Franka/train_files/modality.json
@@ -1,0 +1,61 @@
+{
+    "state": {
+        "joints": {
+            "start": 0,
+            "end": 18,
+            "original_key": "observation.state"
+        }
+        
+    },
+    "action": {
+        "x": {
+            "start": 0,
+            "end": 1,
+            "original_key": "x_position"
+        },
+        "y": {
+            "start": 1,
+            "end": 2,
+            "original_key": "y_position"
+        },
+        "z": {
+            "start": 2,
+            "end": 3,
+            "original_key": "z_position"
+        },
+        "roll": {
+            "start": 3,
+            "end": 4,
+            "original_key": "x_quaternion"
+        },
+        "pitch": {
+            "start": 4,
+            "end": 5,
+            "original_key": "y_quaternion"
+        },
+        "yaw": {
+            "start": 5,
+            "end": 6,
+            "original_key": "z_quaternion"
+        },
+        "gripper": {
+            "start": 6,
+            "end": 7,
+            "original_key": "gripper_command"
+        }
+    },
+    "video": {
+        "external_upper_camera": {
+            "original_key": "observation.images.external_upper_camera"
+        },
+        "left_single_camera": {
+            "original_key": "observation.images.left_single_camera"
+        },
+        "left_dual_camera": {
+            "original_key": "observation.images.left_dual_camera"
+        }
+    },
+    "annotation": {
+        "human.action.task_description": {"original_key": "task_index"}
+    }
+}

--- a/examples/Franka/train_files/run_franka_train_dual.sh
+++ b/examples/Franka/train_files/run_franka_train_dual.sh
@@ -1,0 +1,67 @@
+export NCCL_SOCKET_IFNAME=bond0
+export NCCL_IB_HCA=mlx5_2,mlx5_3
+
+# used for check save when communication
+export NCCL_BLOCKING_WAIT=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_TIMEOUT=1000  # timeout set to 1 hour (unit: seconds)
+
+###########################################################################################
+# === Please modify the following paths according to your environment ===
+Framework_name=QwenOFT
+freeze_module_list=''
+base_vlm=playground/Pretrained_models/Qwen3-VL-4B-Instruct-Action
+config_yaml=./examples/Franka/train_files/starvla_cotrain_franka_dual.yaml
+run_root_dir=./results/Checkpoints
+run_id=0128_${data_mix}_qwen3OFT
+# === End of environment variable configuration ===
+###########################################################################################
+
+
+# export WANDB_MODE=disabled
+
+output_dir=${run_root_dir}/${run_id}
+mkdir -p ${output_dir}
+# mv this script to the output dir
+cp $0 ${output_dir}/
+
+
+
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes 8 \
+  starVLA/training/train_starvla.py \
+  --config_yaml ${config_yaml} \
+  --framework.name ${Framework_name} \
+  --framework.qwenvl.base_vlm ${base_vlm} \
+  --datasets.vla_data.per_device_batch_size 8 \
+  --trainer.freeze_modules ${freeze_module_list} \
+  --trainer.max_train_steps 100000 \
+  --trainer.save_interval 10000 \
+  --trainer.logging_frequency 100 \
+  --trainer.eval_interval 1000 \
+  --run_root_dir ${run_root_dir} \
+  --run_id ${run_id} \
+  --wandb_project starVLA_franka \
+  --wandb_entity zwanggk \
+  # --is_debug True
+
+
+
+##### Multi-Server Multi-GPU training script #####
+  # accelerate launch \
+  #   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  #   --main_process_ip $MASTER_ADDR \
+  #   --main_process_port $MASTER_PORT \
+  #   --machine_rank $SLURM_PROCID \
+  #   --num_machines $SLURM_NNODES \
+  #   --num_processes=${TOTAL_GPUS} \
+  #   starVLA/training/train_starvla.py \
+  #   --config_yaml ${config_yaml} \
+  #   --framework.name ${Framework_name} \
+  #   --framework.qwenvl.base_vlm ${base_vlm} \
+  #   --run_root_dir ${run_root_dir} \
+  #   --run_id ${run_id} \
+  #   --wandb_project your_project \
+  #   --wandb_entity your_name
+##### Multi-Server Multi-GPU training script #####

--- a/examples/Franka/train_files/run_franka_train_single.sh
+++ b/examples/Franka/train_files/run_franka_train_single.sh
@@ -1,0 +1,67 @@
+export NCCL_SOCKET_IFNAME=bond0
+export NCCL_IB_HCA=mlx5_2,mlx5_3
+
+# used for check save when communication
+export NCCL_BLOCKING_WAIT=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_TIMEOUT=1000  # timeout set to 1 hour (unit: seconds)
+
+###########################################################################################
+# === Please modify the following paths according to your environment ===
+Framework_name=QwenOFT
+freeze_module_list=''
+base_vlm=playground/Pretrained_models/Qwen3-VL-4B-Instruct-Action
+config_yaml=./examples/Franka/train_files/starvla_cotrain_franka_single.yaml
+run_root_dir=./results/Checkpoints
+run_id=1221_${data_mix}_qwen3OFT
+# === End of environment variable configuration ===
+###########################################################################################
+
+
+# export WANDB_MODE=disabled
+
+output_dir=${run_root_dir}/${run_id}
+mkdir -p ${output_dir}
+# mv this script to the output dir
+cp $0 ${output_dir}/
+
+
+
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes 8 \
+  starVLA/training/train_starvla.py \
+  --config_yaml ${config_yaml} \
+  --framework.name ${Framework_name} \
+  --framework.qwenvl.base_vlm ${base_vlm} \
+  --datasets.vla_data.per_device_batch_size 8 \
+  --trainer.freeze_modules ${freeze_module_list} \
+  --trainer.max_train_steps 100000 \
+  --trainer.save_interval 10000 \
+  --trainer.logging_frequency 100 \
+  --trainer.eval_interval 1000 \
+  --run_root_dir ${run_root_dir} \
+  --run_id ${run_id} \
+  --wandb_project starVLA_franka \
+  --wandb_entity zwanggk \
+  # --is_debug True
+
+
+
+##### Multi-Server Multi-GPU training script #####
+  # accelerate launch \
+  #   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  #   --main_process_ip $MASTER_ADDR \
+  #   --main_process_port $MASTER_PORT \
+  #   --machine_rank $SLURM_PROCID \
+  #   --num_machines $SLURM_NNODES \
+  #   --num_processes=${TOTAL_GPUS} \
+  #   starVLA/training/train_starvla.py \
+  #   --config_yaml ${config_yaml} \
+  #   --framework.name ${Framework_name} \
+  #   --framework.qwenvl.base_vlm ${base_vlm} \
+  #   --run_root_dir ${run_root_dir} \
+  #   --run_id ${run_id} \
+  #   --wandb_project your_project \
+  #   --wandb_entity your_name
+##### Multi-Server Multi-GPU training script #####

--- a/examples/Franka/train_files/starvla_cotrain_franka_dual.yaml
+++ b/examples/Franka/train_files/starvla_cotrain_franka_dual.yaml
@@ -1,0 +1,114 @@
+run_id: qwenact
+run_root_dir: results/Checkpoints
+seed: 42
+trackers: [jsonl, wandb]
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+
+framework:
+  name: QwenGR00T
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  dino:
+    dino_backbone: dinov2_vits14
+
+  action_model:
+    action_model_type: DiT-B
+    hidden_size: 1024     # Matches the final DiT projection, used by the ActionDecoder
+    action_hidden_dim: 2560
+    add_pos_embed: True
+    max_seq_len: 1024
+    action_dim: 14
+    state_dim: 26
+    future_action_window_size: 15
+    action_horizon: 16
+    past_action_window_size: 0
+    repeated_diffusion_steps: 8
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    num_inference_timesteps: 4
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:    # Parameters for the DiT transformer
+      cross_attention_dim: 2048 # Dimension of the VLM
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: "ada_norm"
+      num_layers: 16
+      output_dim: 1024
+      positional_embeddings: null
+
+
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: sharegpt4v_coco
+    eval_dataset: sharegpt4v_coco
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 307200
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: ./playground/Datasets
+    data_mix: dual_franka_eef_joints
+    action_type: delta_ee
+    CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
+    CoT_answer: bbox
+    default_image_resolution: [3, 224, 224]
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs: ["image_0"]
+    image_size: [224,224]
+    video_backend: torchvision_av
+    
+trainer:
+  epochs: 100
+  max_train_steps: 100000
+  num_warmup_steps: 5000
+  save_interval: 5000
+  eval_interval: 100
+  learning_rate:
+    base: 1e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  # pretrained_checkpoint: ./results/Checkpoints/1_need/0601_qwenact_fixqwen_32gpus_lr_1e-3_qformer_36_37/steps_100000/pytorch_model.pt
+  # reload_modules: 'action_model,layer_qformer' # warning: this may cause model to not converge
+  repeated_diffusion_steps: 4
+  max_grad_norm: 1.0
+  warmup_ratio: 0.1
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+
+  # parameters to be determined
+  is_resume: false
+  resume_epoch: null
+  resume_step: null
+  enable_gradient_checkpointing: true
+  enable_mixed_precision_training: true

--- a/examples/Franka/train_files/starvla_cotrain_franka_single.yaml
+++ b/examples/Franka/train_files/starvla_cotrain_franka_single.yaml
@@ -1,0 +1,114 @@
+run_id: qwenact
+run_root_dir: results/Checkpoints
+seed: 42
+trackers: [jsonl, wandb]
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+
+framework:
+  name: QwenGR00T
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  dino:
+    dino_backbone: dinov2_vits14
+
+  action_model:
+    action_model_type: DiT-B
+    hidden_size: 1024     # Matches the final DiT projection, used by the ActionDecoder
+    action_hidden_dim: 2560
+    add_pos_embed: True
+    max_seq_len: 1024
+    action_dim: 7
+    state_dim: 19
+    future_action_window_size: 15
+    action_horizon: 16
+    past_action_window_size: 0
+    repeated_diffusion_steps: 8
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    num_inference_timesteps: 4
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:    # Parameters for the DiT transformer
+      cross_attention_dim: 2048 # Dimension of the VLM
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: "ada_norm"
+      num_layers: 16
+      output_dim: 1024
+      positional_embeddings: null
+
+
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: sharegpt4v_coco
+    eval_dataset: sharegpt4v_coco
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 307200
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: ./playground/Datasets
+    data_mix: franka_eef_joints
+    action_type: delta_ee
+    CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
+    CoT_answer: bbox
+    default_image_resolution: [3, 224, 224]
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs: ["image_0"]
+    image_size: [224,224]
+    video_backend: torchvision_av
+    
+trainer:
+  epochs: 100
+  max_train_steps: 100000
+  num_warmup_steps: 5000
+  save_interval: 5000
+  eval_interval: 100
+  learning_rate:
+    base: 1e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  # pretrained_checkpoint: ./results/Checkpoints/1_need/0601_qwenact_fixqwen_32gpus_lr_1e-3_qformer_36_37/steps_100000/pytorch_model.pt
+  # reload_modules: 'action_model,layer_qformer' # warning: this may cause model to not converge
+  repeated_diffusion_steps: 4
+  max_grad_norm: 1.0
+  warmup_ratio: 0.1
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+
+  # parameters to be determined
+  is_resume: false
+  resume_epoch: null
+  resume_step: null
+  enable_gradient_checkpointing: true
+  enable_mixed_precision_training: true

--- a/examples/LIBERO-plus/README.md
+++ b/examples/LIBERO-plus/README.md
@@ -84,6 +84,6 @@ Also ensure the environment variables at the top of `eval_libero.sh` are correct
 
 ---
 
-⚠️ **Note:** Since LIBERO-plus has 10,030 tasks, completing all the evaluations will take an extremely long time. It is recommended to run multiple model instances in parallel for the evaluations.
+⚠️ **Note:** Since LIBERO-plus has 10,030 tasks, completing all the evaluations will take an extremely long time. It is recommended to run multiple model instances in parallel for the evaluations. We provide code and scripts for parallel testing on cluster `./parallel_eval/run_nebula_libero_plus`. Please modify them to fit your own cluster.
 
 

--- a/examples/LIBERO-plus/eval_files/parallel_eval/aggregate_results.py
+++ b/examples/LIBERO-plus/eval_files/parallel_eval/aggregate_results.py
@@ -1,0 +1,33 @@
+import os
+import json
+import argparse
+import glob
+
+parser = argparse.ArgumentParser(description="aggregate results")
+
+parser.add_argument("--root_path", help="")
+args = parser.parse_args()
+log_dir = args.root_path
+
+task_suites = ['libero_10','libero_goal','libero_object','libero_spatial']
+overall_results = {"overall": {'total_count':0, 'success_count': 0}}
+for task_suite in task_suites:
+    cur_root = os.path.join(log_dir, 'logs', task_suite)
+    json_files = glob.glob(os.path.join(cur_root, "*.json"), recursive=True)
+    for file in json_files:
+        with open(file) as f:
+            results = json.load(f)
+        for item in results:
+            overall_results["overall"]['total_count']+= results[item]['total_count']
+            overall_results["overall"]['success_count']+= results[item]['success_count']
+            if item not in overall_results:
+                overall_results[item] = results[item]
+            else:
+                overall_results[item]['total_count'] += results[item]['total_count']
+                overall_results[item]['success_count'] += results[item]['success_count']
+
+for category in overall_results:
+    overall_results[category]['success_rate'] = float(overall_results[category]['success_count']) / float(overall_results[category]['total_count'])
+
+with open(os.path.join(log_dir,'overall_results.json'), 'w', encoding='utf-8') as f:
+    json.dump(overall_results, f)

--- a/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_in_one.sh
+++ b/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_in_one.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+eval "$(conda shell.bash hook)"
+# source activate
+conda activate python3.10
+# pip install -r requirements.txt
+# pip list
+# ls /usr/lib64/libOSMesa.so*
+###########################################################################################
+# === Please modify the following paths according to your environment ===
+export LIBERO_HOME=path_to_LIBERO-plus_code
+export LIBERO_CONFIG_PATH=${LIBERO_HOME}/libero
+export MUJOCO_GL=osmesa
+export PYTHONPATH=$PYTHONPATH:${LIBERO_HOME} # let eval_libero find the LIBERO tools
+export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
+
+unnorm_key="franka"
+tasks_per_gpu=3
+your_ckpt=path_to_checkpoint
+output_dir=path_to_output_dir
+# === End of environment variable configuration ===
+###########################################################################################
+
+task_suite_name=$1
+start_idx=$2
+end_idx=$3
+num_trials_per_task=1
+# torchrun --nproc_per_node=1 ./examples/LIBERO-plus/eval_files/eval_nebula/eval_libero_model.py \
+
+total=$((end_idx - start_idx))
+chunk_size=$((total / tasks_per_gpu))
+remainder=$((total % tasks_per_gpu))
+current_start=$start_idx
+
+for ((i=0; i<tasks_per_gpu; i++)); do
+
+    if [ $i -lt $remainder ]; then
+        current_end=$((current_start + chunk_size + 1))
+    else
+        current_end=$((current_start + chunk_size))
+    fi
+
+
+    if [ $current_end -gt $end_idx ]; then
+        current_end=$end_idx
+    fi
+
+    echo "Part $((i)): start=$current_start, end=$current_end ([$current_start, $current_end))"
+    # torchrun --nproc_per_node=$gpu_per_pod --nnodes=$WORLD_SIZE --node_rank=$RANK --master_addr=$((MASTER_ADDR+i)) --master_port=$MASTER_PORT 
+    python ./examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_model.py \
+    --pretrained_path $your_ckpt \
+    --task_suite_name $task_suite_name \
+    --num_trials_per_task $num_trials_per_task \
+    --output_dir $output_dir \
+    --start_idx $current_start \
+    --end_idx $current_end &
+
+    current_start=$current_end
+
+    if [ $current_start -ge $end_idx ]; then
+        break
+    fi
+done
+
+
+wait
+
+# # =============== 聚合结果 ===============
+# echo "All tasks completed. Aggregating results..."
+# export LOG_DIR="${LOG_DIR}"
+# python ./examples/LIBERO-plus/eval_files/aggregate_results.py

--- a/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_model.py
+++ b/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_model.py
@@ -1,0 +1,625 @@
+import dataclasses
+import datetime as dt
+import json
+import logging
+import math
+import os
+import pathlib
+from pathlib import Path
+import requests
+import time
+import draccus
+import imageio
+import numpy as np
+import tqdm
+import tyro
+from libero.libero import benchmark, get_libero_path
+from libero.libero.envs import OffScreenRenderEnv
+from collections import deque
+from typing import Optional, Sequence
+import cv2 as cv
+import matplotlib.pyplot as plt
+from typing import Dict
+from PIL import Image
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.tools import read_mode_config
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+import torch
+
+
+class AdaptiveEnsembler:
+    def __init__(self, pred_action_horizon, adaptive_ensemble_alpha=0.0):
+        self.pred_action_horizon = pred_action_horizon
+        self.action_history = deque(maxlen=self.pred_action_horizon)
+        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
+
+    def reset(self):
+        self.action_history.clear()
+
+    def ensemble_action(self, cur_action):
+        self.action_history.append(cur_action)
+        num_actions = len(self.action_history)
+        if cur_action.ndim == 1:
+            curr_act_preds = np.stack(self.action_history)
+        else:
+            curr_act_preds = np.stack(
+                [pred_actions[i] for (i, pred_actions) in zip(range(num_actions - 1, -1, -1), self.action_history)]
+            )
+
+        # calculate cosine similarity between the current prediction and all previous predictions
+        ref = curr_act_preds[num_actions-1, :]
+        previous_pred = curr_act_preds
+        dot_product = np.sum(previous_pred * ref, axis=1)  
+        norm_previous_pred = np.linalg.norm(previous_pred, axis=1)  
+        norm_ref = np.linalg.norm(ref)  
+        cos_similarity = dot_product / (norm_previous_pred * norm_ref + 1e-7)
+
+        # compute the weights for each prediction
+        weights = np.exp(self.adaptive_ensemble_alpha * cos_similarity)
+        weights = weights / weights.sum()
+  
+        # compute the weighted average across all predictions for this timestep
+        cur_action = np.sum(weights[:, None] * curr_act_preds, axis=0)
+
+        return cur_action
+
+LIBERO_DUMMY_ACTION = [0.0] * 6 + [-1.0]
+LIBERO_ENV_RESOLUTION = 256  # resolution used to render training data
+def _binarize_gripper_open(open_val: np.ndarray | float) -> np.ndarray:
+    arr = np.asarray(open_val, dtype=np.float32).reshape(-1)
+    v = float(arr[0])
+    bin_val = 1.0 - 2.0 * (v > 0.5)
+    return np.asarray([bin_val], dtype=np.float32)
+
+def get_logger(file):
+
+    logger = logging.getLogger('dual_logger')
+    logger.setLevel(logging.DEBUG)
+
+
+    file_handler = logging.FileHandler(file, encoding='utf-8')
+    file_handler.setLevel(logging.INFO)
+    file_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    file_handler.setFormatter(file_formatter)
+
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.DEBUG)
+    console_formatter = logging.Formatter('%(levelname)s - %(message)s')
+    console_handler.setFormatter(console_formatter)
+
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    return logger
+
+
+
+@dataclasses.dataclass
+class Args:
+    host: str = "127.0.0.1"
+    port: int = 10093
+    resize_size = [224,224]
+
+    #################################################################################################################
+    # LIBERO environment-specific parameters
+    #################################################################################################################
+    task_suite_name: str = "libero_goal"  # Task suite. Options: libero_spatial, libero_object, libero_goal, libero_10, libero_90
+    num_steps_wait: int = 10  # Number of steps to wait for objects to stabilize i n sim
+    num_trials_per_task: int = 50  # Number of rollouts per task
+
+    #################################################################################################################
+    # Utils
+    #################################################################################################################
+    video_out_path: str = "experiments/libero/logs"  # Path to save videos
+    log_path: str = "experiments/libero/logs"
+
+    seed: int = 7  # Random Seed (for reproducibility)
+
+    pretrained_path: str = ""
+
+    post_process_action: bool = True
+
+    job_name: str = "test"
+
+    use_bf16: bool = True
+
+    start_idx: int = -1
+    end_idx: int = -1
+    output_dir: str = './output'
+
+
+
+
+
+class PolicyModel:
+    def __init__(
+        self,
+        policy_ckpt_path,
+        unnorm_key: Optional[str] = None,
+        policy_setup: str = "franka",
+        horizon: int = 0,
+        action_ensemble = True,
+        action_ensemble_horizon: Optional[int] = 3, # different cross sim
+        image_size: list[int] = [224, 224],
+        use_ddim: bool = True,
+        num_ddim_steps: int = 10,
+        adaptive_ensemble_alpha = 0.1,
+        host="0.0.0.0",
+        port=10095,
+        use_bf16=True
+    ) -> None:
+        
+        # build client to connect server policy
+        self.policy_setup = policy_setup
+        self.unnorm_key = unnorm_key
+        vla = baseframework.from_pretrained( # TODO should auto detect framework from model path
+            policy_ckpt_path,
+        )
+        
+        if use_bf16: # False
+            vla = vla.to(torch.bfloat16)
+        self.vla = vla.to("cuda").eval()
+
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
+        self.use_ddim = use_ddim
+        self.num_ddim_steps = num_ddim_steps
+        self.image_size = image_size
+        self.horizon = horizon #0
+        self.action_ensemble = action_ensemble
+        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
+        self.action_ensemble_horizon = action_ensemble_horizon
+        self.sticky_action_is_on = False
+        self.gripper_action_repeat = 0
+        self.sticky_gripper_action = 0.0
+        self.previous_gripper_action = None
+
+        self.task_description = None
+        self.image_history = deque(maxlen=self.horizon)
+        if self.action_ensemble:
+            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
+        else:
+            self.action_ensembler = None
+        self.num_image_history = 0
+
+        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
+        
+
+    def _add_image_to_history(self, image: np.ndarray) -> None:
+        self.image_history.append(image)
+        self.num_image_history = min(self.num_image_history + 1, self.horizon)
+
+    def reset(self, task_description: str) -> None:
+        self.task_description = task_description
+        self.image_history.clear()
+        if self.action_ensemble:
+            self.action_ensembler.reset()
+        self.num_image_history = 0
+
+        self.sticky_action_is_on = False
+        self.gripper_action_repeat = 0
+        self.sticky_gripper_action = 0.0
+        self.previous_gripper_action = None
+
+
+    def step(
+        self, 
+        example: dict,
+        step: int = 0,
+        **kwargs
+    ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+        """
+        Perform one step of inference
+        :param image: Input image in the format (H, W, 3), type uint8
+        :param task_description: Task description text
+        :return: (raw action, processed action)
+        """
+
+        task_description = example.get("lang", None) 
+        images = example["image"]  # list of images for history
+
+        if example is not None:
+            if task_description != self.task_description:
+                self.reset(task_description)
+                
+        images = [self._resize_image(image) for image in images]
+        example["image"] = images
+        vla_input = {
+            # "examples": [example],
+            "do_sample": False,
+            "use_ddim": self.use_ddim,
+            "num_ddim_steps": self.num_ddim_steps,
+        }
+        
+        action_chunk_size = self.action_chunk_size
+        if step % action_chunk_size == 0:
+            response = self.vla.predict_action(example, **vla_input)
+            normalized_actions = response["normalized_actions"] # B, chunk, D        
+            
+            normalized_actions = normalized_actions[0]  
+
+            if normalized_actions.shape[1] > 7:
+                normalized_actions = normalized_actions[:,-7:]
+                  
+            self.raw_actions = self.unnormalize_actions(normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats)
+        
+        raw_actions = self.raw_actions[step % action_chunk_size][None]    
+
+        raw_action = {
+            "world_vector": np.array(raw_actions[0, :3]),
+            "rotation_delta": np.array(raw_actions[0, 3:6]),
+            "open_gripper": np.array(raw_actions[0, 6:7]),  # range [0, 1]; 1 = open; 0 = close
+        }
+
+        return {"raw_action": raw_action}
+
+    @staticmethod
+    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
+        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
+        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
+        normalized_actions = np.clip(normalized_actions, -1, 1)
+        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1) 
+        actions = np.where(
+            mask,
+            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
+            normalized_actions,
+        )
+        
+        return actions
+
+    @staticmethod
+    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
+        """
+        Duplicate stats accessor (retained for backward compatibility).
+        """
+        policy_ckpt_path = Path(policy_ckpt_path)
+        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
+
+        unnorm_key = PolicyModel._check_unnorm_key(norm_stats, unnorm_key)
+        return norm_stats[unnorm_key]["action"]
+
+    @staticmethod
+    def get_action_chunk_size(policy_ckpt_path):
+        model_config, _ = read_mode_config(policy_ckpt_path)  # read config and norm_stats
+        # import ipdb; ipdb.set_trace()
+        return model_config['framework']['action_model']['future_action_window_size'] + 1
+
+
+    def _resize_image(self, image: np.ndarray) -> np.ndarray:
+        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
+        return image
+
+    def visualize_epoch(
+        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+    ) -> None:
+        images = [self._resize_image(image) for image in images]
+        ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
+
+        img_strip = np.concatenate(np.array(images[::3]), axis=1)
+
+        # set up plt figure
+        figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
+        plt.rcParams.update({"font.size": 12})
+        fig, axs = plt.subplot_mosaic(figure_layout)
+        fig.set_size_inches([45, 10])
+
+        # plot actions
+        pred_actions = np.array(
+            [
+                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                for a in predicted_raw_actions
+            ]
+        )
+        for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
+            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
+            axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
+            axs[action_label].set_title(action_label)
+            axs[action_label].set_xlabel("Time in one episode")
+
+        axs["image"].imshow(img_strip)
+        axs["image"].set_xlabel("Time in one episode (subsampled)")
+        plt.legend()
+        plt.savefig(save_path)
+    
+    @staticmethod
+    def _check_unnorm_key(norm_stats, unnorm_key):
+        """
+        Duplicate helper (retained for backward compatibility).
+        See primary _check_unnorm_key above.
+        """
+        if unnorm_key is None:
+            assert len(norm_stats) == 1, (
+                f"Your model was trained on more than one dataset, "
+                f"please pass a `unnorm_key` from the following options to choose the statistics "
+                f"used for un-normalizing actions: {norm_stats.keys()}"
+            )
+            unnorm_key = next(iter(norm_stats.keys()))
+
+        assert unnorm_key in norm_stats, (
+            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
+            f"please choose from: {norm_stats.keys()}"
+        )
+        return unnorm_key
+
+@draccus.wrap()
+def eval_libero(args: Args) -> None:
+    
+    local_rank = int(os.getenv("LOCAL_RANK", "0"))
+    world_size = int(os.getenv("WORLD_SIZE", "1"))
+    rank = int(os.getenv("RANK", "0"))
+    print(f"🌍 Rank {rank}/{world_size} | GPU: {local_rank}")
+    torch.cuda.set_device(local_rank)
+    
+    
+    # Set random seed
+    np.random.seed(args.seed)
+
+    # Initialize LIBERO task suite
+    benchmark_dict = benchmark.get_benchmark_dict()
+    task_suite = benchmark_dict[args.task_suite_name]()
+    num_tasks_in_suite = task_suite.n_tasks
+    # if args.start_idx != -1:
+    #     num_tasks_in_suite = args.end_idx - args.start_idx
+    # patch_num = num_tasks_in_suite // world_size
+    # if rank == world_size - 1:
+    #     start_idx = rank * patch_num
+    #     end_idx = num_tasks_in_suite
+    # else:
+    #     start_idx = rank * patch_num
+    #     end_idx = start_idx + patch_num
+    if args.start_idx == -1:
+        args.start_idx = 0
+        args.end_idx = num_tasks_in_suite
+    # args.start_idx = start_idx
+    # args.end_idx = end_idx
+    print(f"processing tasks from {args.start_idx} to {args.end_idx}")
+    # args.video_out_path = f"{date_base}+{args.job_name}"
+    log_path = os.path.join(args.output_dir, f'logs/{args.task_suite_name}')
+    log_file = os.path.join(log_path, f'{args.start_idx}_{args.end_idx}.log')
+    pathlib.Path(log_path).mkdir(parents=True, exist_ok=True)
+    logger = get_logger(log_file)
+    logger.info(f"Arguments: {json.dumps(dataclasses.asdict(args), indent=4)}")
+    video_out_path = os.path.join(args.output_dir, args.task_suite_name)
+    pathlib.Path(video_out_path).mkdir(parents=True, exist_ok=True)
+
+    if args.task_suite_name == "libero_spatial":
+        max_steps = 220  # longest training demo has 193 steps
+    elif args.task_suite_name == "libero_object":
+        max_steps = 280  # longest training demo has 254 steps
+    elif args.task_suite_name == "libero_goal":
+        max_steps = 300  # longest training demo has 270 steps
+    elif args.task_suite_name == "libero_10":
+        max_steps = 520  # longest training demo has 505 steps
+    elif args.task_suite_name == "libero_90":
+        max_steps = 400  # longest training demo has 373 steps
+    else:
+        raise ValueError(f"Unknown task suite: {args.task_suite_name}")
+
+    client_model = PolicyModel(
+        policy_ckpt_path=args.pretrained_path, # to get unnormalization stats
+        host=args.host,
+        port=args.port,
+        image_size=args.resize_size,
+        use_bf16=args.use_bf16,
+    )
+
+    disturb_res = {}
+    LIBERO_HOME = os.environ.get('LIBERO_HOME', 'path_to_LIBERO-plus')
+    with open(os.path.join(LIBERO_HOME,'libero/libero/benchmark/task_classification.json')) as f:
+        TASK_MAPPING = json.load(f)[args.task_suite_name]
+    
+    ID2CATEGORY = {}
+    for item in TASK_MAPPING:
+        category = item["category"]
+        item_name = item["name"]
+        ID2CATEGORY[item['id']] = (category, item_name)
+        if category not in disturb_res:
+            disturb_res[category] = {"total_count": 0, "success_count": 0}
+        
+
+    # Start evaluation
+
+    total_episodes, total_successes = 0, 0
+    print(f"*****************num tasks in {args.task_suite_name}: {num_tasks_in_suite}****************, processing from{args.start_idx} to {args.end_idx}")
+    # for task_id in tqdm.tqdm(range(num_tasks_in_suite)):
+    for task_id in tqdm.tqdm(range(args.start_idx, args.end_idx)):
+        
+        # Get task
+        task = task_suite.get_task(task_id)
+
+        # Get default LIBERO initial states
+        initial_states = task_suite.get_task_init_states(task_id)
+
+        # Initialize LIBERO environment and task description
+        env, task_description = _get_libero_env(task, LIBERO_ENV_RESOLUTION, args.seed)
+
+        # Start episodes
+        task_episodes, task_successes = 0, 0
+        for episode_idx in tqdm.tqdm(range(args.num_trials_per_task)):
+            
+            logger.info(f"\nTask: {task_description}")
+
+            # Reset environment
+            client_model.reset(task_description=task_description)  # Reset the client connection
+            env.reset()
+
+            # Set initial states
+            obs = env.set_init_state(initial_states[episode_idx])
+
+            # Setup
+            t = 0
+            replay_images = []
+            full_actions = []
+
+            logger.info(f"Starting episode {task_episodes + 1}...")
+            step = 0
+            
+            # full_actions = np.load("./debug/action.npy")
+            
+            while t < max_steps + args.num_steps_wait:
+                
+                # try:
+                # IMPORTANT: Do nothing for the first few timesteps because the simulator drops objects
+                # and we need to wait for them to fall
+                if t < args.num_steps_wait:
+                    obs, reward, done, info = env.step(LIBERO_DUMMY_ACTION)
+                    t += 1
+                    continue
+
+                # IMPORTANT: rotate 180 degrees to match train preprocessing
+                img = np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
+                wrist_img = np.ascontiguousarray(
+                    obs["robot0_eye_in_hand_image"][::-1, ::-1]
+                )
+
+                # Save preprocessed image for replay video
+                replay_images.append(img)
+
+                state = np.concatenate(
+                    (
+                        obs["robot0_eef_pos"],
+                        _quat2axisangle(obs["robot0_eef_quat"]),
+                        obs["robot0_gripper_qpos"],
+                    )
+                )
+
+                observation = { # 
+                    "observation.primary": np.expand_dims(
+                        img, axis=0
+                    ),  # (H, W, C), dtype=unit8, range(0-255)
+                    "observation.wrist_image": np.expand_dims(
+                        wrist_img, axis=0
+                    ),  # (H, W, C)
+                    "observation.state": np.expand_dims(state, axis=0),
+                    "instruction": [str(task_description)],
+                }
+
+                example_dict = {
+                    "image": [observation["observation.primary"][0], observation["observation.wrist_image"][0]],
+                    "lang": observation["instruction"][0],
+                    # "state": observation["observation.state"],
+                }
+              
+                start_time = time.time()
+                
+                # response = client_model.step(example=example_dict) 
+                response = client_model.step(example=example_dict, step=step) 
+                
+                end_time = time.time()
+                # print(f"time: {end_time - start_time}")
+                
+                # # 
+                raw_action = response["raw_action"]
+                
+                world_vector_delta = np.asarray(raw_action.get("world_vector"), dtype=np.float32).reshape(-1)
+                rotation_delta = np.asarray(raw_action.get("rotation_delta"), dtype=np.float32).reshape(-1)
+                open_gripper = np.asarray(raw_action.get("open_gripper"), dtype=np.float32).reshape(-1)
+                gripper = _binarize_gripper_open(open_gripper)
+
+                if not (world_vector_delta.size == 3 and rotation_delta.size == 3 and open_gripper.size == 1):
+                    logger.warning(f"Unexpected action sizes: "
+                                    f"wv={world_vector_delta.shape}, rot={rotation_delta.shape}, grip={gripper.shape}. "
+                                    f"Falling back to LIBERO_DUMMY_ACTION.")
+                    raise ValueError(
+                        f"Invalid action sizes: world_vector={world_vector_delta.shape}, "
+                        f"rotation_delta={rotation_delta.shape}, gripper={gripper.shape}"
+                    )
+                else:
+                    delta_action = np.concatenate([world_vector_delta, rotation_delta, gripper], axis=0)
+
+                full_actions.append(delta_action)
+                
+                # __import__("ipdb").set_trace()
+                # see ../robosuite/controllers/controller_factory.py
+                obs, reward, done, info = env.step(delta_action.tolist())
+                if done:
+                    task_successes += 1
+                    total_successes += 1
+                    disturb_res[ID2CATEGORY[task_id+1][0]]['success_count'] += 1
+                    break
+                t += 1
+                step += 1
+
+            task_episodes += 1
+            total_episodes += 1
+            disturb_res[ID2CATEGORY[task_id+1][0]]["total_count"] += 1
+
+            # Save a replay video of the episode
+            suffix = "success" if done else "failure"
+            task_segment = task_description.replace(" ", "_")
+
+            imageio.mimwrite(
+                pathlib.Path(video_out_path)
+                / f"rollout_{ID2CATEGORY[task_id+1][1]}_episode{episode_idx}_{suffix}.mp4",
+                [np.asarray(x) for x in replay_images],
+                fps=25,
+            )
+            
+            full_actions = np.stack(full_actions)
+            # np.save(pathlib.Path(args.video_out_path) / f"rollout_{task_segment}_episode{episode_idx}_{suffix}.npy", full_actions)
+            
+            # print(pathlib.Path(args.video_out_path) / f"rollout_{task_segment}_episode{episode_idx}_{suffix}.mp4")
+            # Log current results
+            logger.info(f"Success: {done}")
+            logger.info(f"# episodes completed so far: {total_episodes}")
+            logger.info(
+                f"# successes: {total_successes} ({total_successes / total_episodes * 100:.1f}%)"
+            )
+
+        # Log final results
+        logger.info(
+            f"Current task success rate: {float(task_successes) / float(task_episodes)}"
+        )
+        logger.info(
+            f"Current total success rate: {float(total_successes) / float(total_episodes)}"
+        )
+    with open(os.path.join(log_path,f'{args.start_idx}_to_{args.end_idx}.json'), 'w', encoding='utf-8') as f:
+        json.dump(disturb_res, f)
+    logger.info(
+        f"Total success rate: {float(total_successes) / float(total_episodes)}"
+    )
+    logger.info(f"Total episodes: {total_episodes}")
+
+
+def _get_libero_env(task, resolution, seed):
+    """Initializes and returns the LIBERO environment, along with the task description."""
+    task_description = task.language
+    task_bddl_file = (
+        pathlib.Path(get_libero_path("bddl_files"))
+        / task.problem_folder
+        / task.bddl_file
+    )
+    env_args = {
+        "bddl_file_name": str(task_bddl_file),
+        "camera_heights": resolution,
+        "camera_widths": resolution,
+    }
+    env = OffScreenRenderEnv(**env_args)
+    env.seed(
+        seed
+    )  # IMPORTANT: seed seems to affect object positions even when using fixed initial state
+    return env, task_description
+
+
+def _quat2axisangle(quat):
+    """
+    Copied from robosuite: https://github.com/ARISE-Initiative/robosuite/blob/eafb81f54ffc104f905ee48a16bb15f059176ad3/robosuite/utils/transform_utils.py#L490C1-L512C55
+    """
+    # clip quaternion
+    if quat[3] > 1.0:
+        quat[3] = 1.0
+    elif quat[3] < -1.0:
+        quat[3] = -1.0
+
+    den = np.sqrt(1.0 - quat[3] * quat[3])
+    if math.isclose(den, 0.0):
+        # This is (close to) a zero degree rotation, immediately return
+        return np.zeros(3)
+
+    return (quat[:3] * 2.0 * math.acos(quat[3])) / den
+
+
+
+if __name__ == "__main__":
+    eval_libero()

--- a/examples/LIBERO-plus/eval_files/parallel_eval/run_nebula_libero_plus.sh
+++ b/examples/LIBERO-plus/eval_files/parallel_eval/run_nebula_libero_plus.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+ENVS="WANDB_MODE=offline,WANDB_MODE=disabled,HF_ENDPOINT=https://hf-mirror.com"
+
+sizes=(2519 2591 2518 2402)
+tasks=("libero_10" "libero_goal" "libero_object" "libero_spatial")
+
+############ GPUs number for each task
+total_slices=(12 4 4 4)
+############
+
+for i in "${!sizes[@]}"; do
+    size=${sizes[$i]}
+    task=${tasks[$i]}
+    num_slice=${total_slices[$i]}
+    base_size=$((size / num_slice))
+    remainder=$((size % num_slice))
+
+    start_idx=0
+
+    for slice in $(seq 0 $((num_slice - 1))); do
+
+        if [ "$slice" -lt "$remainder" ]; then
+            end_idx=$((start_idx + base_size + 1))
+        else
+            end_idx=$((start_idx + base_size))
+        fi
+
+
+        if [ "$slice" -eq $((num_slice - 1)) ]; then
+            end_idx=$size
+        fi
+
+        echo "task=$task, slice=$slice, start_idx=$start_idx, end_idx=$end_idx"
+
+        nebulactl run mdl --queue=...... \
+                  --entry="bash examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_in_one.sh $task $start_idx $end_idx" \
+                  --user_params="" \
+                  --worker_count=1 \
+                  --algoame=pytorch240 \
+                  --file.cluster_file=./cluster.json \
+                  --job_name="libero_plus" \
+                  --nas_file_system_id=...... \
+                  --nas_file_system_mount_path=...... \
+                  --custom_docker_image=...... \
+                  --env="${ENVS}" \
+                #   --public_pool_job_type=queuing
+
+        start_idx=$end_idx
+    done
+done

--- a/examples/LIBERO/README.md
+++ b/examples/LIBERO/README.md
@@ -121,3 +121,70 @@ bash examples/LIBERO/train_files/run_libero_train.sh
 ```
 ⚠️ **Note:** Please ensure that you specify the correct path in `examples/LIBERO/train_files/run_libero_train.sh`
 
+
+## 🚀 LIBERO Training (RLDS / OpenVLA-style)
+
+This repo also supports the OpenVLA / OpenVLA-OFT LIBERO RLDS dataset family:
+- `libero_spatial_no_noops`
+- `libero_object_no_noops`
+- `libero_goal_no_noops`
+- `libero_10_no_noops`
+
+These datasets are the modified LIBERO suites used in OpenVLA and OpenVLA-OFT experiments:
+- OpenVLA dataset release: <https://huggingface.co/datasets/openvla/modified_libero_rlds>
+- OpenVLA LIBERO setup: <https://github.com/openvla/openvla?tab=readme-ov-file#libero-setup>
+- OpenVLA-OFT LIBERO docs: <https://github.com/moojink/openvla-oft/blob/main/LIBERO.md>
+
+`_no_noops` means no-op transitions are filtered out in dataset regeneration.
+
+### 📦 Step 0: Prepare RLDS dataset
+
+Install RLDS reader dependency in the `starVLA` env:
+```bash
+pip install tensorflow-cpu tensorflow-datasets
+```
+
+Download and link the dataset:
+```bash
+export DEST=/path/to/your/data/directory
+bash examples/LIBERO/data_preparation_rlds.sh
+```
+
+Expected layout:
+```text
+playground/Datasets/MODIFIED_LIBERO_RLDS/
+  libero_spatial_no_noops/1.0.0/...
+  libero_object_no_noops/1.0.0/...
+  libero_goal_no_noops/1.0.0/...
+  libero_10_no_noops/1.0.0/...
+```
+
+### ✅ Step 1: Quick validation (recommended)
+
+Check statistics keys and dimensions:
+```bash
+python examples/LIBERO/tools/validate_rlds_statistics.py \
+  --data-root-dir playground/Datasets/MODIFIED_LIBERO_RLDS \
+  --data-mix libero_all
+```
+
+Inspect orientation samples:
+```bash
+python examples/LIBERO/tools/inspect_rlds_orientation.py \
+  --data-root-dir playground/Datasets/MODIFIED_LIBERO_RLDS \
+  --dataset-name libero_spatial_no_noops \
+  --output-dir examples/LIBERO/rlds_inspection/orientation
+```
+
+### 🚀 Step 2: Train with RLDS backend
+
+```bash
+bash examples/LIBERO/train_files/run_libero_train_rlds.sh
+```
+
+### ⚠️ Notes
+
+- The RLDS adapter is loaded from `examples/LIBERO/train_files/rlds_libero_datasets.py`.
+- Per-suite transition counts are read from `dataset_statistics_*.json` (fallback: `dataset_info.json`).
+- OpenVLA notes mention a 180° rotation in HDF5 -> RLDS conversion; verify your local data orientation with the inspection script before training:
+  <https://github.com/openvla/openvla/blob/main/experiments/robot/libero/regenerate_libero_dataset.py>

--- a/examples/LIBERO/data_preparation_rlds.sh
+++ b/examples/LIBERO/data_preparation_rlds.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   export DEST=/path/to/dir && bash examples/LIBERO/data_preparation_rlds.sh
+# or
+#   bash examples/LIBERO/data_preparation_rlds.sh /path/to/dir
+
+DEST="${DEST:-${1:-}}"
+if [[ -z "${DEST}" ]]; then
+  echo "ERROR: DEST is not set."
+  echo "  export DEST=/path/to/dir && bash examples/LIBERO/data_preparation_rlds.sh"
+  echo "  or: bash examples/LIBERO/data_preparation_rlds.sh /path/to/dir"
+  exit 1
+fi
+
+CUR="$(pwd)"
+TARGET="${DEST}/modified_libero_rlds"
+
+if [[ ! -d "${TARGET}" ]]; then
+  git lfs install
+  git clone https://huggingface.co/datasets/openvla/modified_libero_rlds "${TARGET}"
+else
+  echo "Found existing dataset at ${TARGET}, skip clone."
+fi
+
+mkdir -p "${CUR}/playground/Datasets"
+ln -sfn "${TARGET}" "${CUR}/playground/Datasets/MODIFIED_LIBERO_RLDS"
+
+echo "Done. RLDS dataset linked at: ${CUR}/playground/Datasets/MODIFIED_LIBERO_RLDS"

--- a/examples/LIBERO/tools/inspect_rlds_orientation.py
+++ b/examples/LIBERO/tools/inspect_rlds_orientation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Sample modified LIBERO RLDS frames and save side-by-side:
+- left: original
+- right: rotated 180 degrees
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Dict, Iterator
+
+import numpy as np
+from PIL import Image
+
+
+def _resolve_builder_dir(data_root_dir: Path, dataset_name: str) -> Path:
+    version_dir = data_root_dir / dataset_name / "1.0.0"
+    if version_dir.exists():
+        return version_dir
+    suite_dir = data_root_dir / dataset_name
+    if suite_dir.exists():
+        return suite_dir
+    raise FileNotFoundError(f"Dataset not found: {dataset_name} under {data_root_dir}")
+
+
+def _as_dict(record: Any) -> Dict[str, Any]:
+    if isinstance(record, dict):
+        return record
+    if hasattr(record, "keys"):
+        return {key: record[key] for key in record.keys()}
+    if isinstance(record, np.void) and record.dtype.names:
+        return {key: record[key] for key in record.dtype.names}
+    return {}
+
+
+def _iter_steps(episode_steps: Any) -> Iterator[Dict[str, Any]]:
+    if isinstance(episode_steps, dict):
+        keys = list(episode_steps.keys())
+        if not keys:
+            return
+        length = len(episode_steps[keys[0]])
+        for idx in range(length):
+            yield {key: episode_steps[key][idx] for key in keys}
+        return
+    for step in episode_steps:
+        yield _as_dict(step)
+
+
+def _to_rgb_uint8(image: Any) -> np.ndarray | None:
+    image = np.asarray(image)
+    if image.ndim == 2:
+        image = np.repeat(image[..., None], 3, axis=-1)
+    if image.ndim != 3:
+        return None
+    if image.shape[-1] == 1:
+        image = np.repeat(image, 3, axis=-1)
+    if image.shape[-1] > 3:
+        image = image[..., :3]
+    if image.dtype != np.uint8:
+        image = np.clip(image, 0, 255).astype(np.uint8)
+    return image
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-root-dir", type=str, required=True)
+    parser.add_argument("--dataset-name", type=str, default="libero_spatial_no_noops")
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--num-episodes", type=int, default=1)
+    parser.add_argument("--frames-per-episode", type=int, default=4)
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="examples/LIBERO/rlds_inspection/orientation",
+    )
+    args = parser.parse_args()
+
+    try:
+        import tensorflow_datasets as tfds
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "This script requires tensorflow-datasets. Install with: "
+            "`pip install tensorflow-cpu tensorflow-datasets`"
+        ) from exc
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    builder_dir = _resolve_builder_dir(Path(args.data_root_dir), args.dataset_name)
+    builder = tfds.builder_from_directory(str(builder_dir))
+    dataset = builder.as_dataset(split=args.split, shuffle_files=False)
+
+    saved = 0
+    for ep_idx, episode in enumerate(tfds.as_numpy(dataset)):
+        if ep_idx >= args.num_episodes:
+            break
+        episode = _as_dict(episode)
+        steps = list(_iter_steps(episode.get("steps", [])))
+        if not steps:
+            continue
+
+        stride = max(1, len(steps) // max(1, args.frames_per_episode))
+        for step_idx in range(0, len(steps), stride):
+            step = _as_dict(steps[step_idx])
+            observation = _as_dict(step.get("observation", {}))
+            for image_key in ("image", "wrist_image"):
+                if image_key not in observation:
+                    continue
+                image = _to_rgb_uint8(observation[image_key])
+                if image is None:
+                    continue
+                rotated = np.rot90(image, 2)
+                stacked = np.concatenate([image, rotated], axis=1)
+                save_path = out_dir / f"{args.dataset_name}__ep{ep_idx:03d}__step{step_idx:04d}__{image_key}.png"
+                Image.fromarray(stacked).save(save_path)
+                saved += 1
+
+                if saved >= args.num_episodes * args.frames_per_episode * 2:
+                    break
+            if saved >= args.num_episodes * args.frames_per_episode * 2:
+                break
+
+    print(f"Saved {saved} comparison images to: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/LIBERO/tools/validate_rlds_statistics.py
+++ b/examples/LIBERO/tools/validate_rlds_statistics.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Validate modified LIBERO RLDS statistics files for training compatibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+
+REQUIRED_STATS_KEYS = ("mean", "std", "min", "max", "q01", "q99")
+DATA_MIX_TO_SUITES = {
+    "libero_goal": ["libero_goal_no_noops"],
+    "libero_object": ["libero_object_no_noops"],
+    "libero_spatial": ["libero_spatial_no_noops"],
+    "libero_10": ["libero_10_no_noops"],
+    "libero_all": [
+        "libero_spatial_no_noops",
+        "libero_object_no_noops",
+        "libero_goal_no_noops",
+        "libero_10_no_noops",
+    ],
+}
+
+
+def resolve_suite_names(data_root_dir: Path, data_mix: str) -> List[str]:
+    if data_mix in DATA_MIX_TO_SUITES:
+        return DATA_MIX_TO_SUITES[data_mix]
+
+    candidates = [item.strip() for item in str(data_mix).split(",") if item.strip()]
+    resolved = []
+    for name in candidates:
+        if (data_root_dir / name).exists():
+            resolved.append(name)
+        elif (data_root_dir / f"{name}_no_noops").exists():
+            resolved.append(f"{name}_no_noops")
+        else:
+            raise FileNotFoundError(f"Cannot resolve RLDS suite '{name}' under {data_root_dir}")
+    if not resolved:
+        raise ValueError(f"Empty RLDS data_mix: {data_mix}")
+    return resolved
+
+
+def _extract_nested_stats(payload: Dict[str, Any]) -> Dict[str, Any] | None:
+    if isinstance(payload.get("action"), dict):
+        return payload
+    for value in payload.values():
+        if isinstance(value, dict) and isinstance(value.get("action"), dict):
+            return value
+    return None
+
+
+def _extract_num_transitions(stats_payload: Dict[str, Any], split: str, suite_dir: Path) -> int:
+    for key in (f"num_{split}_transitions", "num_transitions"):
+        if key in stats_payload:
+            try:
+                return int(stats_payload[key])
+            except Exception:
+                pass
+
+    info_path = suite_dir / "dataset_info.json"
+    if not info_path.exists():
+        return -1
+    try:
+        info = json.loads(info_path.read_text())
+    except Exception:
+        return -1
+
+    splits = info.get("splits", {})
+    if isinstance(splits, list):
+        for split_info in splits:
+            if split_info.get("name") == split and "shardLengths" in split_info:
+                try:
+                    return int(sum(int(x) for x in split_info["shardLengths"]))
+                except Exception:
+                    return -1
+    if isinstance(splits, dict):
+        split_info = splits.get(split) or splits.get("train")
+        if isinstance(split_info, dict) and "numExamples" in split_info:
+            try:
+                return int(split_info["numExamples"])
+            except Exception:
+                return -1
+    return -1
+
+
+def load_suite_statistics(suite_dir: Path, split: str) -> Dict[str, Any]:
+    stats_files = sorted(suite_dir.glob("dataset_statistics*.json"))
+    if not stats_files:
+        raise FileNotFoundError(f"Missing dataset_statistics*.json under {suite_dir}")
+
+    for stats_file in stats_files:
+        try:
+            payload = json.loads(stats_file.read_text())
+        except Exception:
+            continue
+        stats = _extract_nested_stats(payload)
+        if stats is None:
+            continue
+        stats["num_transitions"] = _extract_num_transitions(payload, split, suite_dir)
+        stats["__source_statistics_file__"] = str(stats_file)
+        return stats
+
+    raise ValueError(f"Cannot parse valid statistics file under {suite_dir}")
+
+
+def _validate_modality_stats(modality: str, stats: Dict[str, Any], expected_dim: int | None) -> List[str]:
+    errors: List[str] = []
+    if not isinstance(stats, dict):
+        return [f"{modality}: expected dict, got {type(stats)}"]
+
+    for key in REQUIRED_STATS_KEYS:
+        if key not in stats:
+            errors.append(f"{modality}: missing key `{key}`")
+
+    if errors:
+        return errors
+
+    lens = {key: len(np.asarray(stats[key]).reshape(-1)) for key in REQUIRED_STATS_KEYS}
+    unique_lens = set(lens.values())
+    if len(unique_lens) != 1:
+        errors.append(f"{modality}: inconsistent lengths {lens}")
+        return errors
+
+    dim = next(iter(unique_lens))
+    if expected_dim is not None and dim != expected_dim:
+        errors.append(f"{modality}: dim mismatch, got {dim}, expected {expected_dim}")
+
+    q01 = np.asarray(stats["q01"], dtype=np.float32)
+    q99 = np.asarray(stats["q99"], dtype=np.float32)
+    if np.any(q01 > q99):
+        errors.append(f"{modality}: found q01 > q99")
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-root-dir", type=str, required=True)
+    parser.add_argument("--data-mix", type=str, default="libero_all")
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--expected-action-dim", type=int, default=7)
+    parser.add_argument("--expected-proprio-dim", type=int, default=8)
+    args = parser.parse_args()
+
+    root = Path(args.data_root_dir)
+    suites = resolve_suite_names(root, args.data_mix)
+    print(f"Checking suites: {suites}")
+
+    all_errors: List[str] = []
+    for suite in suites:
+        version_dir = root / suite / "1.0.0"
+        suite_dir = version_dir if version_dir.exists() else root / suite
+        try:
+            stats = load_suite_statistics(suite_dir, split=args.split)
+        except Exception as exc:
+            all_errors.append(f"{suite}: failed to load statistics: {exc}")
+            continue
+
+        source = stats.get("__source_statistics_file__", "unknown")
+        action_stats = stats.get("action", {})
+        proprio_stats = stats.get("proprio", {})
+        num_transitions = stats.get("num_transitions", "unknown")
+        print(f"[{suite}] source={source} num_transitions={num_transitions}")
+
+        suite_errors = _validate_modality_stats("action", action_stats, args.expected_action_dim)
+        if proprio_stats:
+            suite_errors.extend(
+                _validate_modality_stats("proprio", proprio_stats, args.expected_proprio_dim)
+            )
+        else:
+            print(f"[{suite}] warning: missing `proprio` stats (state normalization will be unavailable)")
+
+        if suite_errors:
+            all_errors.extend([f"{suite}: {err}" for err in suite_errors])
+        else:
+            print(f"[{suite}] OK")
+
+    if all_errors:
+        print("\nValidation failed:")
+        for err in all_errors:
+            print(f"- {err}")
+        sys.exit(1)
+
+    print("\nAll suites passed statistics validation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/LIBERO/train_files/rlds_libero_datasets.py
+++ b/examples/LIBERO/train_files/rlds_libero_datasets.py
@@ -1,0 +1,262 @@
+import json
+import os
+import random
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import numpy as np
+import torch.distributed as dist
+from PIL import Image
+from accelerate.logging import get_logger
+from torch.utils.data import IterableDataset
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+try:
+    import tensorflow as tf
+    import tensorflow_datasets as tfds
+except ImportError:
+    tf = None
+    tfds = None
+
+logger = get_logger(__name__)
+
+
+def _require_tfds():
+    if tf is None or tfds is None:
+        raise ImportError(
+            "RLDS LIBERO dataloader requires tensorflow and tensorflow-datasets. "
+            "Please install: pip install tensorflow-cpu tensorflow-datasets"
+        )
+
+
+def _setup_tf_runtime():
+    if tf is None:
+        return
+    try:
+        tf.config.set_visible_devices([], "GPU")
+    except Exception:
+        pass
+
+    try:
+        tf.config.threading.set_inter_op_parallelism_threads(1)
+        tf.config.threading.set_intra_op_parallelism_threads(1)
+    except Exception:
+        pass
+
+
+DATA_MIX_TO_SUITES = {
+    "libero_goal": ["libero_goal_no_noops"],
+    "libero_object": ["libero_object_no_noops"],
+    "libero_spatial": ["libero_spatial_no_noops"],
+    "libero_10": ["libero_10_no_noops"],
+    "libero_all": [
+        "libero_spatial_no_noops",
+        "libero_object_no_noops",
+        "libero_goal_no_noops",
+        "libero_10_no_noops",
+    ],
+}
+
+
+def _dist_rank() -> int:
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_rank()
+    return 0
+
+
+def _dist_world_size() -> int:
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size()
+    return 1
+
+
+def _decode_text(value) -> str:
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8", errors="ignore")
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _format_state(state: np.ndarray, decimals: int) -> str:
+    return np.array2string(
+        np.asarray(state, dtype=np.float32),
+        precision=decimals,
+        separator=", ",
+        suppress_small=False,
+        floatmode="fixed",
+    )
+
+
+def _extract_images(observation: dict) -> List[Image.Image]:
+    images = []
+    for key in ("image", "wrist_image"):
+        value = observation.get(key)
+        if value is None:
+            continue
+        array = np.asarray(value)
+        if array.ndim != 3 or array.shape[-1] < 3:
+            continue
+        images.append(Image.fromarray(array[..., :3].astype(np.uint8)))
+    return images
+
+
+def resolve_suite_names(data_root_dir: Path, data_mix: str) -> List[str]:
+    if data_mix in DATA_MIX_TO_SUITES:
+        return DATA_MIX_TO_SUITES[data_mix]
+
+    candidates = [item.strip() for item in str(data_mix).split(",") if item.strip()]
+    resolved = []
+    for name in candidates:
+        if (data_root_dir / name).exists():
+            resolved.append(name)
+        elif (data_root_dir / f"{name}_no_noops").exists():
+            resolved.append(f"{name}_no_noops")
+        else:
+            raise FileNotFoundError(f"Cannot resolve RLDS suite '{name}' under {data_root_dir}")
+    if not resolved:
+        raise ValueError(f"Empty RLDS data_mix: {data_mix}")
+    return resolved
+
+
+def _load_num_transitions(version_dir: Path, split: str) -> int:
+    for stats_path in sorted(version_dir.glob("dataset_statistics_*.json")):
+        try:
+            stats = json.loads(stats_path.read_text())
+        except Exception:
+            continue
+        split_key = f"num_{split}_transitions"
+        if split_key in stats:
+            return int(stats[split_key])
+        if "num_transitions" in stats:
+            return int(stats["num_transitions"])
+
+    info_path = version_dir / "dataset_info.json"
+    if info_path.exists():
+        info = json.loads(info_path.read_text())
+        for split_info in info.get("splits", []):
+            if split_info.get("name") == split:
+                return sum(int(x) for x in split_info.get("shardLengths", []))
+    return 1
+
+
+class LiberoRLDSPiFastDataset(IterableDataset):
+    def __init__(self, cfg, split: str = "train"):
+        super().__init__()
+        _require_tfds()
+        _setup_tf_runtime()
+
+        self.cfg = cfg
+        self.vla_cfg = cfg.datasets.vla_data
+        self.split = split
+        self.data_root_dir = Path(self.vla_cfg.data_root_dir)
+        self.suite_names = resolve_suite_names(self.data_root_dir, self.vla_cfg.data_mix)
+        self.horizon = int(cfg.framework.action_model.future_action_window_size) + 1
+        self.rank = _dist_rank()
+        self.world_size = _dist_world_size()
+        self.shuffle_buffer_size = int(getattr(self.vla_cfg, "shuffle_buffer_size", 2048))
+        self.shuffle_buffer_warmup = int(getattr(self.vla_cfg, "shuffle_buffer_warmup", 512))
+        self.state_decimal_places = int(getattr(self.vla_cfg, "state_decimal_places", 4))
+        self.use_state_in_prompt = bool(getattr(self.vla_cfg, "use_state_in_prompt", True))
+
+        self.datasets = []
+        self.total_transitions = 0
+        for suite_name in self.suite_names:
+            version_dir = self.data_root_dir / suite_name / "1.0.0"
+            if not version_dir.exists():
+                version_dir = self.data_root_dir / suite_name
+            if not version_dir.exists():
+                raise FileNotFoundError(f"RLDS suite not found: {suite_name}")
+            builder = tfds.builder_from_directory(str(version_dir))
+            dataset = builder.as_dataset(split=split, shuffle_files=True).repeat()
+            self.datasets.append(dataset)
+            self.total_transitions += _load_num_transitions(version_dir, split)
+
+        logger.info(
+            "Loaded RLDS LIBERO suites %s with ~%s transitions for split %s",
+            self.suite_names,
+            self.total_transitions,
+            split,
+        )
+
+    def __len__(self) -> int:
+        samples_per_rank = max(1, self.total_transitions // max(1, self.world_size))
+        return samples_per_rank
+
+    def _build_instruction(self, task_text: str, state: Optional[np.ndarray]) -> str:
+        task_text = task_text.strip() or "complete the manipulation task"
+        if self.use_state_in_prompt and state is not None:
+            state_text = _format_state(state, self.state_decimal_places)
+            return (
+                f"task: {task_text}\n"
+                f"current observation.state: {state_text}\n"
+                f"predict next {self.horizon} timestep action.\n"
+            )
+        return f"task: {task_text}\npredict next {self.horizon} timestep action.\n"
+
+    def _build_action_chunk(self, actions: List[np.ndarray], index: int) -> np.ndarray:
+        last = len(actions) - 1
+        chunk = [actions[min(index + offset, last)] for offset in range(self.horizon)]
+        return np.asarray(chunk, dtype=np.float32)
+
+    def _iter_suite(self, dataset: Iterable):
+        for episode in tfds.as_numpy(dataset):
+            steps = list(episode["steps"])
+            if not steps:
+                continue
+
+            actions = [np.asarray(step["action"], dtype=np.float32) for step in steps]
+            episode_task = _decode_text(episode.get("language_instruction", ""))
+
+            for index, step in enumerate(steps):
+                observation = step.get("observation", {})
+                images = _extract_images(observation)
+                if not images:
+                    continue
+
+                task_text = _decode_text(step.get("language_instruction", episode_task))
+                state = observation.get("state")
+                state_array = None if state is None else np.asarray(state, dtype=np.float32)
+
+                yield {
+                    "image": images,
+                    "lang": self._build_instruction(task_text, state_array),
+                    "action": self._build_action_chunk(actions, index),
+                    "state": state_array,
+                }
+
+    def __iter__(self):
+        suite_iters = [self._iter_suite(dataset) for dataset in self.datasets]
+        shuffle_buffer = []
+        seen = 0
+        warmup = max(1, min(self.shuffle_buffer_size, self.shuffle_buffer_warmup))
+
+        while True:
+            suite_idx = random.randrange(len(suite_iters))
+            try:
+                sample = next(suite_iters[suite_idx])
+            except StopIteration:
+                suite_iters[suite_idx] = self._iter_suite(self.datasets[suite_idx])
+                continue
+
+            if seen % self.world_size != self.rank:
+                seen += 1
+                continue
+            seen += 1
+
+            shuffle_buffer.append(sample)
+            if len(shuffle_buffer) < warmup:
+                continue
+            if len(shuffle_buffer) > self.shuffle_buffer_size:
+                shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
+            yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
+
+
+def collate_fn(batch):
+    return batch
+
+
+def get_vla_dataset(cfg):
+    split = getattr(cfg.datasets.vla_data, "split", "train")
+    return LiberoRLDSPiFastDataset(cfg=cfg, split=split)

--- a/examples/LIBERO/train_files/run_libero_train_rlds.sh
+++ b/examples/LIBERO/train_files/run_libero_train_rlds.sh
@@ -1,0 +1,48 @@
+export NCCL_SOCKET_IFNAME=bond0
+export NCCL_IB_HCA=mlx5_2,mlx5_3
+
+# used for check save when communication
+export NCCL_BLOCKING_WAIT=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_TIMEOUT=10000
+export NCCL_SOCKET_TIMEOUT_MS=360000
+export TF_CPP_MIN_LOG_LEVEL=3
+unset NCCL_SHM_DISABLE
+
+###########################################################################################
+# === Please modify the following paths according to your environment ===
+Framework_name=QwenFast
+freeze_module_list=''
+base_vlm=playground/Pretrained_models/Qwen2.5-VL-3B-Instruct-Action
+config_yaml=./examples/LIBERO/train_files/starvla_cotrain_libero_rlds.yaml
+libero_data_root=playground/Datasets/MODIFIED_LIBERO_RLDS
+data_mix=libero_all
+run_root_dir=./results/Checkpoints
+run_id=libero_rlds_qwen25vl3b_fast
+# === End of environment variable configuration ===
+###########################################################################################
+
+output_dir=${run_root_dir}/${run_id}
+mkdir -p ${output_dir}
+cp $0 ${output_dir}/
+
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes 8 \
+  starVLA/training/train_starvla.py \
+  --config_yaml ${config_yaml} \
+  --framework.name ${Framework_name} \
+  --framework.qwenvl.base_vlm ${base_vlm} \
+  --datasets.vla_data.dataset_py rlds_libero_datasets \
+  --datasets.vla_data.data_root_dir ${libero_data_root} \
+  --datasets.vla_data.data_mix ${data_mix} \
+  --datasets.vla_data.per_device_batch_size 4 \
+  --trainer.freeze_modules ${freeze_module_list} \
+  --trainer.max_train_steps 100000 \
+  --trainer.save_interval 10000 \
+  --trainer.logging_frequency 10 \
+  --trainer.eval_interval 1000 \
+  --run_root_dir ${run_root_dir} \
+  --run_id ${run_id} \
+  --wandb_project starVLA_Libero_RLDS \
+  --wandb_entity offline

--- a/examples/LIBERO/train_files/starvla_cotrain_libero_rlds.yaml
+++ b/examples/LIBERO/train_files/starvla_cotrain_libero_rlds.yaml
@@ -1,0 +1,91 @@
+run_id: starvla_rlds_libero
+run_root_dir: results/Checkpoints
+seed: 42
+trackers: [jsonl, wandb]
+wandb_entity: offline
+wandb_project: starVLA_Libero_RLDS
+is_debug: false
+
+framework:
+  name: QwenFast
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct-Action
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  dino:
+    dino_backbone: dinov2_vits14
+  action_model:
+    action_model_type: Fast
+    action_hidden_dim: 1024
+    hidden_size: 1024
+    add_pos_embed: true
+    max_seq_len: 1024
+    action_dim: 7
+    state_dim: 8
+    future_action_window_size: 7
+    action_horizon: 8
+    past_action_window_size: 0
+    repeated_diffusion_steps: 1
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    num_inference_timesteps: 4
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:
+      cross_attention_dim: 2048
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: ada_norm
+      num_layers: 16
+      output_dim: 1024
+      positional_embeddings: null
+  reduce_in_full_precision: true
+
+datasets:
+  vla_data:
+    dataset_py: rlds_libero_datasets
+    data_root_dir: playground/Datasets/MODIFIED_LIBERO_RLDS
+    data_mix: libero_all
+    split: train
+    per_device_batch_size: 4
+    num_workers: 0
+    shuffle_buffer_size: 2048
+    shuffle_buffer_warmup: 512
+    use_state_in_prompt: true
+    state_decimal_places: 4
+
+trainer:
+  epochs: 100
+  max_train_steps: 100000
+  num_warmup_steps: 5000
+  save_interval: 10000
+  eval_interval: 1000
+  learning_rate:
+    base: 2.5e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 1.0e-06
+  freeze_modules: ""
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  max_grad_norm: 1.0
+  warmup_ratio: 0.1
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+  is_resume: false
+  resume_epoch: null
+  resume_step: null
+  enable_gradient_checkpointing: true
+  enable_mixed_precision_training: true

--- a/examples/Robotwin/README.md
+++ b/examples/Robotwin/README.md
@@ -174,6 +174,8 @@ bash examples/Robotwin/eval_files/run_policy_server.sh
 ```
 
 Edit your checkpoint path in `examples/Robotwin/eval_files/deploy_policy.yml` and `examples/Robotwin/eval_files/run_policy_server.sh`.
+If your checkpoint was trained with percentile normalization, set `normalization_mode: "q99"` in `examples/Robotwin/eval_files/deploy_policy.yml`.
+Available options are `min_max` and `q99`. The default is `min_max` to preserve the previous RoboTwin deployment behavior.
 
 ---
 

--- a/examples/Robotwin/eval_files/deploy_policy.yml
+++ b/examples/Robotwin/eval_files/deploy_policy.yml
@@ -9,5 +9,6 @@ instruction_type: unseen
 host: "127.0.0.1"
 port: 5694
 policy_ckpt_path: "/mnt/data/gaoning/code_repos/starVLA/results/Checkpoints/robotwin2/QwenPI-noState/checkpoints/steps_60000_pytorch_model.pt"
-unnorm_key: "robotwin"
+unnorm_key: "new_embodiment"
 action_mode: "abs"
+normalization_mode: "min_max"  # options: min_max, q99

--- a/examples/Robotwin/eval_files/model2robotwin_interface.py
+++ b/examples/Robotwin/eval_files/model2robotwin_interface.py
@@ -37,13 +37,17 @@ class ModelClient:
         host="127.0.0.1",
         port=5694,
         action_mode: str = "abs",
+        normalization_mode: str = "min_max",
     ) -> None:
 
         self.client = WebsocketClientPolicy(host, port)
         self.policy_setup = policy_setup
         self.unnorm_key = unnorm_key
 
-        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, action_mode: {action_mode} ***")
+        print(
+            f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, "
+            f"action_mode: {action_mode}, normalization_mode: {normalization_mode} ***"
+        )
         self.use_ddim = use_ddim
         self.num_ddim_steps = num_ddim_steps
         self.image_size = image_size
@@ -51,6 +55,7 @@ class ModelClient:
         self.action_ensemble = action_ensemble and (AdaptiveEnsembler is not None)
         self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
         self.action_ensemble_horizon = action_ensemble_horizon
+        self.normalization_mode = normalization_mode
 
         # Action mode: "abs", "delta", or "rel"
         self.action_mode = action_mode
@@ -135,7 +140,9 @@ class ModelClient:
             normalized_actions = normalized_actions[0]
             # Unnormalize to get delta/rel values
             raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
+                normalized_actions=normalized_actions,
+                action_norm_stats=self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
             )
 
             # Convert delta/rel to absolute actions
@@ -160,25 +167,42 @@ class ModelClient:
         return current_action
 
     @staticmethod
-    def normalize_state(state: dict[str, np.ndarray], state_norm_stats: Dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    def normalize_state(
+        state: dict[str, np.ndarray],
+        state_norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+    ) -> dict[str, np.ndarray]:
         """
         Normalize the state
         """
-        mask = [True, True, True, True, True, True, True, True, True, True, True, True, False, False]
-        mask = np.array(mask, dtype=bool)
-        state_high, state_low = np.array(state_norm_stats["max"]), np.array(state_norm_stats["min"])
+        continuous_mask = [True, True, True, True, True, True, True, True, True, True, True, True, False, False]
+        continuous_mask = np.array(continuous_mask, dtype=bool)
+        state_high, state_low = ModelClient._get_normalization_bounds(
+            state_norm_stats, normalization_mode=normalization_mode
+        )
+        valid_mask = continuous_mask & (state_high != state_low)
         normalized_state = np.where(
-            mask,
+            valid_mask,
             (state - state_low) / (state_high - state_low) * 2 - 1,
             state,
         )
-        normalized_state = np.where(~mask, (normalized_state > 0.5).astype(normalized_state.dtype), normalized_state)
+        normalized_state = np.where(
+            ~continuous_mask,
+            (normalized_state > 0.5).astype(normalized_state.dtype),
+            normalized_state,
+        )
         return normalized_state
 
     @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
+    def unnormalize_actions(
+        normalized_actions: np.ndarray,
+        action_norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+    ) -> np.ndarray:
+        action_high, action_low = ModelClient._get_normalization_bounds(
+            action_norm_stats, normalization_mode=normalization_mode
+        )
+        mask = action_norm_stats.get("mask", np.ones_like(action_low, dtype=bool))
         normalized_actions = np.clip(normalized_actions, -1, 1)
 
         actions = np.where(
@@ -243,13 +267,18 @@ class ModelClient:
             # New format: directly use the corresponding mode stats
             mode_stats = stats[action_mode]
             return mode_stats.get("action", mode_stats)
-        elif "action" in stats:
+        if "action" in stats:
             # Old format: only supports abs mode
             if action_mode != "abs":
-                print(f"[WARNING] Statistics file only has abs mode, but {action_mode} was requested. Using abs stats.")
+                raise ValueError(
+                    f"Statistics key `{unnorm_key}` only provides `abs` action stats, "
+                    f"but action_mode=`{action_mode}` was requested."
+                )
             return stats["action"]
-        else:
-            raise ValueError(f"Invalid statistics file format for key: {unnorm_key}")
+        raise ValueError(
+            f"Invalid statistics file format for key `{unnorm_key}`. "
+            f"Available top-level keys: {sorted(stats.keys())}"
+        )
 
     @staticmethod
     def get_state_stats(unnorm_key: str, policy_ckpt_path) -> dict:
@@ -269,16 +298,42 @@ class ModelClient:
 
     @staticmethod
     def _check_unnorm_key(norm_stats, unnorm_key):
+        available_keys = sorted(norm_stats.keys())
         if unnorm_key is None:
-            if len(norm_stats) == 1:
-                unnorm_key = next(iter(norm_stats.keys()))
-            else:
-                unnorm_key = next(iter(norm_stats.keys()))
+            if len(available_keys) == 1:
+                return available_keys[0]
+            raise ValueError(
+                "`unnorm_key` must be provided when multiple normalization statistics are available. "
+                f"Available keys: {available_keys}"
+            )
 
         if unnorm_key not in norm_stats:
-            unnorm_key = next(iter(norm_stats.keys()))
+            raise KeyError(
+                f"Unknown `unnorm_key`: `{unnorm_key}`. Available keys: {available_keys}"
+            )
 
         return unnorm_key
+
+    @staticmethod
+    def _get_normalization_bounds(
+        norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if normalization_mode == "q99":
+            if "q01" not in norm_stats or "q99" not in norm_stats:
+                raise KeyError(
+                    "Normalization mode `q99` requires statistics keys `q01` and `q99`."
+                )
+            return np.array(norm_stats["q99"]), np.array(norm_stats["q01"])
+        if normalization_mode == "min_max":
+            if "min" not in norm_stats or "max" not in norm_stats:
+                raise KeyError(
+                    "Normalization mode `min_max` requires statistics keys `min` and `max`."
+                )
+            return np.array(norm_stats["max"]), np.array(norm_stats["min"])
+        raise ValueError(
+            f"Unsupported normalization_mode: {normalization_mode}. Expected one of ['min_max', 'q99']."
+        )
 
 
 def get_model(usr_args):
@@ -287,6 +342,10 @@ def get_model(usr_args):
     port = usr_args.get("port", 5694)
     unnorm_key = usr_args.get("unnorm_key", None)
     action_mode = usr_args.get("action_mode", "abs")
+    normalization_mode = usr_args.get(
+        "action_normalization_mode",
+        usr_args.get("normalization_mode", "min_max"),
+    )
 
     if policy_ckpt_path is None:
         raise ValueError("policy_ckpt_path must be provided in config")
@@ -297,6 +356,7 @@ def get_model(usr_args):
         port=port,
         unnorm_key=unnorm_key,
         action_mode=action_mode,
+        normalization_mode=normalization_mode,
     )
 
 

--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -53,6 +53,28 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
             output_dir = Path(cfg.output_dir)
             vla_dataset.save_dataset_statistics(output_dir / "dataset_statistics.json")
         return vla_train_dataloader
+
+    elif dataset_py == "rlds_libero_datasets":
+        import importlib.util
+
+        adapter_path = Path(__file__).resolve().parents[2] / "examples" / "LIBERO" / "train_files" / "rlds_libero_datasets.py"
+        if not adapter_path.exists():
+            raise FileNotFoundError(f"RLDS adapter file not found: {adapter_path}")
+
+        spec = importlib.util.spec_from_file_location("rlds_libero_datasets_adapter", adapter_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load RLDS adapter from: {adapter_path}")
+        adapter_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(adapter_module)
+
+        vla_dataset = adapter_module.get_vla_dataset(cfg=cfg)
+        vla_train_dataloader = DataLoader(
+            vla_dataset,
+            batch_size=cfg.datasets.vla_data.per_device_batch_size,
+            collate_fn=adapter_module.collate_fn,
+            num_workers=getattr(cfg.datasets.vla_data, "num_workers", 0),
+        )
+        return vla_train_dataloader
     elif dataset_py == "vlm_datasets":
         vlm_data_module = make_vlm_dataloader(cfg)
         vlm_train_dataloader = vlm_data_module["train_dataloader"]

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -63,6 +63,7 @@ LE_ROBOT_INFO_FILENAME = "meta/info.json"
 LE_ROBOT_STATS_FILENAME = "meta/stats_gr00t.json"
 LE_ROBOT_DATA_FILENAME = "data/*/*.parquet"
 LE_ROBOT_STEPS_FILENAME = "meta/steps.pkl"
+LE_ROBOT_STATS_FORMAT_VERSION = 2
 EPSILON = 5e-4
 
 #  LeRobot v3.0 dataset file names 
@@ -123,6 +124,189 @@ def _normalize_action_mode(mode: str) -> str:
     return mode
 
 
+def _normalize_action_mode_apply_keys(
+    action_mode_apply_keys: Sequence[str] | None,
+    fallback_keys: Sequence[str] | None = None,
+) -> list[str]:
+    source_keys = action_mode_apply_keys if action_mode_apply_keys else (fallback_keys or [])
+    normalized = []
+    for key in source_keys:
+        key = str(key)
+        if not key.startswith("action."):
+            key = f"action.{key}"
+        normalized.append(key)
+    return normalized
+
+
+def _normalize_action_mode_state_map(action_mode_state_map: dict[str, str] | None) -> dict[str, str]:
+    normalized = {}
+    for action_key, state_key in (action_mode_state_map or {}).items():
+        action_key = str(action_key)
+        state_key = str(state_key)
+        if not action_key.startswith("action."):
+            action_key = f"action.{action_key}"
+        if not state_key.startswith("state."):
+            state_key = f"state.{state_key}"
+        normalized[action_key] = state_key
+    return normalized
+
+
+def _build_stats_cache_config(
+    action_mode: str,
+) -> dict:
+    return {
+        "mode": action_mode,
+    }
+
+
+def _invalidate_legacy_stats_cache(stats_path: Path, reason: str) -> None:
+    if not stats_path.exists():
+        return
+    print(f"Removing stale dataset statistics cache at {stats_path}: {reason}")
+    stats_path.unlink()
+
+
+def _load_stats_cache(
+    stats_path: Path,
+    expected_config: dict,
+    *,
+    invalidate_legacy: bool,
+) -> dict | None:
+    if not stats_path.exists():
+        return None
+
+    try:
+        with open(stats_path, "r") as f:
+            payload = json.load(f)
+    except Exception as exc:
+        if invalidate_legacy:
+            _invalidate_legacy_stats_cache(stats_path, f"failed to load JSON ({exc})")
+        return None
+
+    if not isinstance(payload, dict):
+        if invalidate_legacy:
+            _invalidate_legacy_stats_cache(stats_path, "unexpected top-level format")
+        return None
+
+    format_version = payload.get("__format_version")
+    cache_config = payload.get("__cache_config")
+    statistics = payload.get("statistics")
+    if format_version != LE_ROBOT_STATS_FORMAT_VERSION or cache_config is None or statistics is None:
+        if invalidate_legacy:
+            _invalidate_legacy_stats_cache(stats_path, "legacy statistics format detected")
+        return None
+
+    if cache_config != expected_config:
+        if invalidate_legacy:
+            _invalidate_legacy_stats_cache(stats_path, "statistics config mismatch, rebuilding cache")
+        return None
+
+    return statistics
+
+
+def _save_stats_cache(stats_path: Path, cache_config: dict, statistics: dict) -> None:
+    payload = {
+        "__format_version": LE_ROBOT_STATS_FORMAT_VERSION,
+        "__cache_config": cache_config,
+        "statistics": statistics,
+    }
+    tmp_path = stats_path.with_suffix(".tmp")
+    stats_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(tmp_path, "w") as f:
+        json.dump(payload, f, indent=4)
+    os.replace(tmp_path, stats_path)
+
+
+def _compute_statistics_for_mode(
+    parquet_paths: list[Path],
+    dataset_name: str,
+    action_mode: str,
+    lerobot_modality_meta: "LeRobotModalityMetadata",
+    action_keys_full: list[str],
+    state_keys_full: list[str],
+    action_indices: list[int] | None,
+    state_indices: list[int] | None,
+    action_mode_apply_keys: list[str] | None,
+    action_mode_state_map: dict[str, str] | None,
+) -> dict:
+    print(f"[RANK 0] Calculating dataset statistics for {dataset_name} (mode={action_mode})")
+
+    base_stats = calculate_dataset_statistics(parquet_paths)
+    
+    if action_mode == "abs":
+        return base_stats
+
+    if action_indices is None or state_indices is None:
+        raise ValueError(
+            "Both action and state modalities are required to compute "
+            f"{action_mode} action mode statistics."
+        )
+
+    if action_mode == "delta":
+        return calculate_delta_action_statistics(
+            parquet_paths=parquet_paths,
+            lerobot_modality_meta=lerobot_modality_meta,
+            action_keys_full=action_keys_full,
+            state_keys_full=state_keys_full,
+            action_indices=action_indices,
+            state_indices=state_indices,
+            action_mode_apply_keys=action_mode_apply_keys,
+            action_mode_state_map=action_mode_state_map,
+            base_stats=base_stats,
+        )
+    if action_mode == "rel":
+        return calculate_rel_action_statistics(
+            parquet_paths=parquet_paths,
+            lerobot_modality_meta=lerobot_modality_meta,
+            action_keys_full=action_keys_full,
+            state_keys_full=state_keys_full,
+            action_indices=action_indices,
+            state_indices=state_indices,
+            action_mode_apply_keys=action_mode_apply_keys,
+            action_mode_state_map=action_mode_state_map,
+            base_stats=base_stats,
+        )
+    raise ValueError(f"Unsupported action mode for statistics: {action_mode}")
+
+
+def _load_or_compute_statistics(
+    stats_path: Path,
+    stats_cache_config: dict,
+    parquet_paths: list[Path],
+    dataset_name: str,
+    action_mode: str,
+    lerobot_modality_meta: "LeRobotModalityMetadata",
+    action_keys_full: list[str],
+    state_keys_full: list[str],
+    action_indices: list[int] | None,
+    state_indices: list[int] | None,
+    action_mode_apply_keys: list[str] | None,
+    action_mode_state_map: dict[str, str] | None,
+) -> dict:
+    le_statistics = _load_stats_cache(
+        stats_path,
+        stats_cache_config,
+        invalidate_legacy=True,
+    )
+    if le_statistics is not None:
+        return le_statistics
+
+    le_statistics = _compute_statistics_for_mode(
+        parquet_paths=parquet_paths,
+        dataset_name=dataset_name,
+        action_mode=action_mode,
+        lerobot_modality_meta=lerobot_modality_meta,
+        action_keys_full=action_keys_full,
+        state_keys_full=state_keys_full,
+        action_indices=action_indices,
+        state_indices=state_indices,
+        action_mode_apply_keys=action_mode_apply_keys,
+        action_mode_state_map=action_mode_state_map,
+    )
+    _save_stats_cache(stats_path, stats_cache_config, le_statistics)
+    return le_statistics
+
+
 def _get_action_col_slices(
     lerobot_modality_meta: "LeRobotModalityMetadata",
     action_keys_full: list[str],
@@ -130,8 +314,8 @@ def _get_action_col_slices(
     action_mode_apply_keys: list[str] | None = None,
     action_mode_state_map: dict[str, str] | None = None,
 ) -> dict[str, list[tuple[tuple[int, int], str, tuple[int, int], str, str]]]:
-    apply_keys = action_mode_apply_keys or action_keys_full
-    action_mode_state_map = action_mode_state_map or {}
+    apply_keys = _normalize_action_mode_apply_keys(action_mode_apply_keys, action_keys_full)
+    action_mode_state_map = _normalize_action_mode_state_map(action_mode_state_map)
 
     action_meta = lerobot_modality_meta.action
     state_meta = lerobot_modality_meta.state
@@ -614,132 +798,62 @@ class LeRobotSingleDataset(Dataset):
             return (not dist.is_initialized()) or dist.get_rank() == 0
         
         action_mode = _normalize_action_mode(self.data_cfg.get("action_mode", "abs") if self.data_cfg else "abs")
-        le_statistics_by_mode = None
 
         stats_path = self.dataset_path / LE_ROBOT_STATS_FILENAME
-        tmp_path = stats_path.with_suffix(".tmp")
-        
-        # ---------- all rank try to read  ----------
-        if stats_path.exists():
-            try:
-                with open(stats_path, "r") as f:
-                    le_statistics = json.load(f)
-                if any(k in le_statistics for k in ["abs", "delta", "rel"]):
-                    le_statistics_by_mode = le_statistics
-                else:
-                    cleaned = {k: v for k, v in le_statistics.items() if not str(k).startswith("__")}
-                    le_statistics_by_mode = {"abs": cleaned}
-            except Exception as e:
-                print(
-                    f"[RANK {os.environ.get('RANK', 'NA')}] "
-                    f"Failed to load dataset statistics ({e}), rebuilding..."
-                )
-                le_statistics_by_mode = None
+        action_cfg = self.modality_configs.get("action")
+        state_cfg = self.modality_configs.get("state")
+        action_keys_full = list(action_cfg.modality_keys) if action_cfg else []
+        state_keys_full = list(state_cfg.modality_keys) if state_cfg else []
+        action_indices = list(action_cfg.delta_indices) if action_cfg else None
+        state_indices = list(state_cfg.delta_indices) if state_cfg else None
 
-        # ---------- rank0 build ----------
-        if le_statistics_by_mode is None:
-            le_statistics_by_mode = {}
+        apply_keys = _normalize_action_mode_apply_keys(
+            self.data_cfg.get("action_mode_apply_keys", None) if self.data_cfg else None,
+            action_keys_full,
+        )
+        normalized_state_map = _normalize_action_mode_state_map(
+            self.data_cfg.get("action_mode_state_map", {}) if self.data_cfg else {}
+        )
+        stats_cache_config = _build_stats_cache_config(
+            action_mode=action_mode,
+        )
+        parquet_files = list(self.dataset_path.glob(LE_ROBOT_DATA_FILENAME))
+        parquet_files_filtered = [
+            pf for pf in parquet_files if "episode_033675.parquet" not in pf.name
+        ]
 
-        computed_any = False
         if is_main():
-            action_keys_full = []
-            state_keys_full = []
-            if "action" in self.modality_configs:
-                action_keys_full = list(self.modality_configs["action"].modality_keys)
-            if "state" in self.modality_configs:
-                state_keys_full = list(self.modality_configs["state"].modality_keys)
-            if "action" in self.modality_configs:
-                action_indices = list(self.modality_configs["action"].delta_indices)
-            else:
-                action_indices = None
-            if "state" in self.modality_configs:
-                state_indices = list(self.modality_configs["state"].delta_indices)
-            else:
-                state_indices = None
-            if action_indices is None or state_indices is None:
-                raise ValueError("Both action and state modalities are required to compute action mode statistics.")
+            le_statistics = _load_or_compute_statistics(
+                stats_path,
+                stats_cache_config=stats_cache_config,
+                parquet_paths=parquet_files_filtered,
+                dataset_name=self.dataset_name,
+                action_mode=action_mode,
+                lerobot_modality_meta=le_modality_meta,
+                action_keys_full=action_keys_full,
+                state_keys_full=state_keys_full,
+                action_indices=action_indices,
+                state_indices=state_indices,
+                action_mode_apply_keys=apply_keys,
+                action_mode_state_map=normalized_state_map,
+            )
+        else:
+            le_statistics = None
 
-            apply_keys = None
-            if self.data_cfg:
-                apply_keys = self.data_cfg.get("action_mode_apply_keys", None)
-            if apply_keys:
-                normalized = []
-                for key in apply_keys:
-                    key = str(key)
-                    if not key.startswith("action."):
-                        key = f"action.{key}"
-                    normalized.append(key)
-                apply_keys = normalized
-            else:
-                apply_keys = action_keys_full
-
-            state_map_cfg = self.data_cfg.get("action_mode_state_map", {}) if self.data_cfg else {}
-            normalized_state_map = {}
-            for action_key, state_key in (state_map_cfg or {}).items():
-                action_key = str(action_key)
-                state_key = str(state_key)
-                if not action_key.startswith("action."):
-                    action_key = f"action.{action_key}"
-                if not state_key.startswith("state."):
-                    state_key = f"state.{state_key}"
-                normalized_state_map[action_key] = state_key
-            parquet_files = list(self.dataset_path.glob(LE_ROBOT_DATA_FILENAME))
-            parquet_files_filtered = [
-                pf for pf in parquet_files if "episode_033675.parquet" not in pf.name
-            ]
-        
-            if "abs" not in le_statistics_by_mode:
-                print(f"[RANK 0] Calculating dataset statistics for {self.dataset_name}")
-
-                le_statistics_by_mode["abs"] = calculate_dataset_statistics(parquet_files_filtered)
-                computed_any = True
-
-            for mode in ["delta", "rel"]:
-                if mode not in le_statistics_by_mode:
-                    if mode == "delta":
-                        le_statistics_by_mode[mode] = calculate_delta_action_statistics(
-                            parquet_paths=parquet_files_filtered,
-                            lerobot_modality_meta=le_modality_meta,
-                            action_keys_full=action_keys_full,
-                            state_keys_full=state_keys_full,
-                            action_indices=action_indices,
-                            state_indices=state_indices,
-                            action_mode_apply_keys=apply_keys,
-                            action_mode_state_map=normalized_state_map,
-                            base_stats=le_statistics_by_mode["abs"],
-                        )
-                    else:
-                        le_statistics_by_mode[mode] = calculate_rel_action_statistics(
-                            parquet_paths=parquet_files_filtered,
-                            lerobot_modality_meta=le_modality_meta,
-                            action_keys_full=action_keys_full,
-                            state_keys_full=state_keys_full,
-                            action_indices=action_indices,
-                            state_indices=state_indices,
-                            action_mode_apply_keys=apply_keys,
-                            action_mode_state_map=normalized_state_map,
-                            base_stats=le_statistics_by_mode["abs"],
-                        )
-                    computed_any = True
-
-            if computed_any:
-                stats_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(tmp_path, "w") as f:
-                    json.dump(le_statistics_by_mode, f, indent=4)
-                os.replace(tmp_path, stats_path)
-
-        # ---------- sync ----------
         if dist.is_initialized():
             dist.barrier()
-        
-        # ---------- all rank read again ----------
-        if not is_main() or computed_any:
-            with open(stats_path, "r") as f:
-                le_statistics_by_mode = json.load(f)
 
-        # Validate selected mode stats
-        selected_mode = action_mode if action_mode in le_statistics_by_mode else "abs"
-        le_statistics = le_statistics_by_mode[selected_mode]
+        if le_statistics is None:
+            le_statistics = _load_stats_cache(
+                stats_path,
+                stats_cache_config,
+                invalidate_legacy=False,
+            )
+            if le_statistics is None:
+                raise RuntimeError(
+                    f"Dataset statistics cache is missing or invalid after sync: {stats_path}"
+                )
+
         for stat in le_statistics.values():
             DatasetStatisticalValues.model_validate(stat)
 
@@ -1064,34 +1178,18 @@ class LeRobotSingleDataset(Dataset):
         action_mode = self.data_cfg.get("action_mode", "abs")
         if action_mode is None:
             action_mode = "abs"
-        action_mode = str(action_mode).lower()
-        if action_mode in {"absolute", "raw"}:
-            action_mode = "abs"
+        action_mode = _normalize_action_mode(action_mode)
         if action_mode not in {"abs", "delta", "rel"}:
             raise ValueError(f"Invalid action_mode: {action_mode}. Expected one of: abs, delta, rel.")
         self._action_mode = action_mode
 
-        apply_keys = self.data_cfg.get("action_mode_apply_keys", None)
+        apply_keys = _normalize_action_mode_apply_keys(self.data_cfg.get("action_mode_apply_keys", None))
         if apply_keys:
-            normalized = []
-            for key in apply_keys:
-                key = str(key)
-                if not key.startswith("action."):
-                    key = f"action.{key}"
-                normalized.append(key)
-            self._action_mode_apply_keys = normalized
+            self._action_mode_apply_keys = apply_keys
 
-        state_map = self.data_cfg.get("action_mode_state_map", {}) or {}
-        normalized_map = {}
-        for action_key, state_key in state_map.items():
-            action_key = str(action_key)
-            state_key = str(state_key)
-            if not action_key.startswith("action."):
-                action_key = f"action.{action_key}"
-            if not state_key.startswith("state."):
-                state_key = f"state.{state_key}"
-            normalized_map[action_key] = state_key
-        self._action_mode_state_map = normalized_map
+        self._action_mode_state_map = _normalize_action_mode_state_map(
+            self.data_cfg.get("action_mode_state_map", {}) or {}
+        )
 
     def _infer_state_key_for_action(self, action_key: str) -> str | None:
         if action_key in self._action_mode_state_map:

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -71,6 +71,23 @@ LE_ROBOT3_TASKS_FILENAME = "meta/tasks.parquet"
 LE_ROBOT3_EPISODE_FILENAME = "meta/episodes/*/*.parquet"
 
 
+def detect_lerobot_version(dataset_path: Path) -> str | None:
+    """Auto-detect LeRobot dataset version from file structure.
+
+    Checks for version-specific marker files:
+    - v3.0: meta/tasks.parquet (checked first as the newer format)
+    - v2.0: meta/episodes.jsonl
+
+    Returns:
+        "v3.0", "v2.0", or None if version cannot be determined.
+    """
+    if (Path(dataset_path) / LE_ROBOT3_TASKS_FILENAME).exists():
+        return "v3.0"
+    if (Path(dataset_path) / LE_ROBOT_EPISODE_FILENAME).exists():
+        return "v2.0"
+    return None
+
+
 def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
     """Calculate the dataset statistics of all columns for a list of parquet files."""
     # Dataset statistics
@@ -568,6 +585,7 @@ class LeRobotSingleDataset(Dataset):
         transforms: ComposedModalityTransform | None = None,
         delete_pause_frame: bool = False,
         data_cfg = None,
+        lerobot_version: str | None = None,
         **kwargs,
     ):
         """
@@ -586,8 +604,16 @@ class LeRobotSingleDataset(Dataset):
         self.data_cfg = data_cfg
         if not Path(dataset_path).exists():
             raise FileNotFoundError(f"Dataset path {dataset_path} does not exist")
-        # indict letobot version
-        self._lerobot_version =  self.data_cfg.get("lerobot_version", "v2.0") #self._indict_lerobot_version(**kwargs)
+        # Determine lerobot version: explicit override > auto-detect > data_cfg fallback > default
+        if lerobot_version is not None:
+            self._lerobot_version = lerobot_version
+        else:
+            detected = detect_lerobot_version(Path(dataset_path))
+            if detected is not None:
+                self._lerobot_version = detected
+            else:
+                self._lerobot_version = self.data_cfg.get("lerobot_version", "v2.0") if self.data_cfg else "v2.0"
+        print(f"[LeRobot] Dataset {Path(dataset_path).name}: using version {self._lerobot_version}")
 
         self._action_mode = None
         self._action_mode_state_map = {}
@@ -1001,6 +1027,7 @@ class LeRobotSingleDataset(Dataset):
         config_dict = {
             "delete_pause_frame": self.delete_pause_frame,
             "dataset_name": self.dataset_name,
+            "lerobot_version": self._lerobot_version,
         }
         # Create a hash of the configuration
         config_str = str(sorted(config_dict.items()))

--- a/starVLA/dataloader/lerobot_datasets.py
+++ b/starVLA/dataloader/lerobot_datasets.py
@@ -22,6 +22,7 @@ def make_LeRobotSingleDataset(
     robot_type: str,
     delete_pause_frame: bool = False,
     data_cfg: dict | None = None,
+    lerobot_version: str | None = None,
 ) -> LeRobotSingleDataset:
     """
     Make a LeRobotSingleDataset object.
@@ -29,7 +30,7 @@ def make_LeRobotSingleDataset(
     :param data_root_dir: The root directory of the dataset.
     :param data_name: The name of the dataset.
     :param robot_type: The robot type config to use.
-    :param crop_obs_camera: Whether to crop the observation camera images.
+    :param lerobot_version: Explicit lerobot version override ("v2.0" or "v3.0"). If None, auto-detected from dataset file structure.
     :return: A LeRobotSingleDataset object.
     """
     
@@ -52,6 +53,7 @@ def make_LeRobotSingleDataset(
         video_backend=video_backend, # decord is more efficiency | torchvision_av for video.av1
         delete_pause_frame=delete_pause_frame,
         data_cfg=data_cfg,
+        lerobot_version=lerobot_version,
     )
 
 def get_vla_dataset(
@@ -70,18 +72,21 @@ def get_vla_dataset(
     delete_pause_frame = data_cfg.get("delete_pause_frame", False)
     mixture_spec = DATASET_NAMED_MIXTURES[data_mix]
     included_datasets, filtered_mixture_spec = set(), []
-    for d_name, d_weight, robot_type in mixture_spec:  
-        dataset_key = (d_name, robot_type)  
+    for entry in mixture_spec:
+        # Support both 3-tuple (name, weight, robot_type) and 4-tuple (name, weight, robot_type, lerobot_version)
+        d_name, d_weight, robot_type = entry[0], entry[1], entry[2]
+        d_version = entry[3] if len(entry) > 3 else None
+        dataset_key = (d_name, robot_type)
         if dataset_key in included_datasets:
             print(f"Skipping Duplicate Dataset: `{(d_name, d_weight, robot_type)}`")
             continue
 
         included_datasets.add(dataset_key)
-        filtered_mixture_spec.append((d_name, d_weight, robot_type))
+        filtered_mixture_spec.append((d_name, d_weight, robot_type, d_version))
 
     dataset_mixture = []
-    for d_name, d_weight, robot_type in filtered_mixture_spec:
-        dataset_mixture.append((make_LeRobotSingleDataset(Path(data_root_dir), d_name, robot_type, delete_pause_frame=delete_pause_frame, data_cfg=data_cfg), d_weight))
+    for d_name, d_weight, robot_type, d_version in filtered_mixture_spec:
+        dataset_mixture.append((make_LeRobotSingleDataset(Path(data_root_dir), d_name, robot_type, delete_pause_frame=delete_pause_frame, data_cfg=data_cfg, lerobot_version=d_version), d_weight))
 
     return LeRobotMixtureDataset(
         dataset_mixture,

--- a/starVLA/model/framework/ABot_M0.py
+++ b/starVLA/model/framework/ABot_M0.py
@@ -1,0 +1,274 @@
+import sys
+from pathlib import Path
+
+# Add workspace root to Python path if not already there
+_workspace_root = Path(__file__).parent.parent.parent.parent
+if str(_workspace_root) not in sys.path:
+    sys.path.insert(0, str(_workspace_root))
+import os
+CHECKPOINT_BASEDIR = os.getenv('CHECKPOINT_BASEDIR', None)
+from typing import List
+from tqdm import tqdm
+from typing import List, Optional, Tuple
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+from PIL import Image
+
+
+
+from starVLA.training.trainer_utils import initialize_overwatch
+from deployment.model_server.tools.image_tools import to_pil_preserve
+
+logger = initialize_overwatch(__name__)
+
+# HuggingFace Default / LLaMa-2 IGNORE_INDEX (for labels)
+IGNORE_INDEX = -100
+
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.modules.vlm import get_vlm_model
+from starVLA.model.modules.action_model.AML_ActionHeader import get_action_model, FlowmatchingActionHead
+from starVLA.training.trainer_utils.trainer_tools import resize_images
+from starVLA.model.tools import FRAMEWORK_REGISTRY, preprocess_images, CrossAttention
+
+
+@FRAMEWORK_REGISTRY.register("ABot_M0")
+class ABot_M0(baseframework):
+    """
+    - Optional spatial geometry backbone: VGGT
+    - Action Expert for Action Manifold Learning
+    - Significantly outperforms GR00T when predicting a large action dimension (action_dim * action_chunk) in a single forward pass
+    - For the full paper, see: https://github.com/amap-cvlab/ABot-Manipulation
+    """
+    def __init__(
+        self,
+        config: Optional[dict] = None,
+        **kwargs,
+    ) -> None:
+        """
+        Construct all submodules and cache key configuration values.
+
+        Args:
+            config: Hierarchical configuration (OmegaConf/dict) containing framework + trainer sections.
+            **kwargs: Reserved for future overrides (unused).
+        """
+        super().__init__()
+        self.config = config
+        self.qwen_vl_interface = get_vlm_model(config=self.config)
+        # align dims --> we should put them to config or no?
+        self.config.framework.action_model.diffusion_model_cfg.cross_attention_dim = self.qwen_vl_interface.model.config.hidden_size
+
+        self.action_model: FlowmatchingActionHead = get_action_model(config=self.config)  
+
+        self.future_action_window_size = config.framework.action_model.future_action_window_size
+        self.past_action_window_size = config.framework.action_model.past_action_window_size
+        self.chunk_len = self.past_action_window_size + 1 + self.future_action_window_size
+
+        # optional, TODO: pip install -e path_to_vggt (https://github.com/facebookresearch/vggt)
+
+        # from vggt.models.vggt import VGGT
+        self.spatial_model = spatial_model = VGGT.from_pretrained('facebook/VGGT-1B')
+        hidden_size = self.qwen_vl_interface.model.config.hidden_size
+        self.spatial_projector = nn.Linear(2048, hidden_size)
+        self.fuser = CrossAttention(d_model=hidden_size,d_hidden=hidden_size,kv_dim=hidden_size)
+
+        
+
+    def forward(
+        self,
+        examples: List[dict] = None,
+        **kwargs,
+    ) -> Tuple:
+
+        batch_images = [example["image"] for example in examples]  #  [B，[PLT]]
+        instructions = [example["lang"] for example in examples]  # [B, str]
+        actions = [example["action"] for example in examples]  # label [B， len, 7]
+        
+        state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
+        action_mask = [example["action_mask"] for example in examples] if "action_mask" in examples[0] else None  # [B, action_dim]
+        
+        # Step 1: QWenVL input format
+        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            qwenvl_outputs = self.qwen_vl_interface(
+                **qwen_inputs,
+                output_attentions=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+            # last_hidden_state: [B, seq_len, H]
+            last_hidden = qwenvl_outputs.hidden_states[-1]   # [B, L, H]
+
+            # feed forward pass of vggt
+            with torch.no_grad():
+                spatial_input = preprocess_images(batch_images, batch_images[0][0].size[0]).to(qwen_inputs['pixel_values'].device)   
+                aggregated_tokens_list, ps_idx = self.spatial_model.aggregator(spatial_input)
+            spatial_tokens = aggregated_tokens_list[-1][:,0,ps_idx:,:]
+            spatial_tokens = self.spatial_projector(spatial_tokens)
+            last_hidden = self.fuser(last_hidden, spatial_tokens)
+
+        
+        # Step 4: Action Expert Forward and Loss
+        with torch.autocast("cuda", dtype=torch.float32):
+            actions = torch.tensor(
+                np.array(actions), device=last_hidden.device, dtype=last_hidden.dtype
+            )  # [B, T_full, action_dim]
+            actions_target = actions[:, -(self.future_action_window_size+1):, :]  # (B, chunk_len, action_dim)
+
+            repeated_diffusion_steps = (
+                self.config.trainer.get("repeated_diffusion_steps", 4) if self.config and self.config.trainer else 4
+            )
+
+            actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
+            last_hidden_repeated = last_hidden.repeat(repeated_diffusion_steps, 1, 1)
+            
+            state_repeated = None
+            if state is not None:
+                state = torch.tensor(
+                    np.array(state), device=last_hidden.device, dtype=last_hidden.dtype
+                )
+                state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
+
+            action_mask_repeated = None
+            if action_mask is not None:
+                action_mask_tensor = torch.tensor(
+                    np.array(action_mask), device=last_hidden.device, dtype=torch.bool
+                )  # [B, action_dim]
+                action_mask_repeated = action_mask_tensor.repeat(repeated_diffusion_steps, 1)  # [B*repeated_diffusion_steps, action_dim]
+
+            action_loss = self.action_model(last_hidden_repeated, actions_target_repeated, state_repeated, action_mask=action_mask_repeated)  # (B, chunk_len, action_dim)
+
+        return {"action_loss": action_loss}
+
+    @torch.inference_mode()
+    def predict_action(
+        self,
+        examples: List[dict],
+        **kwargs: str,
+    ) -> np.ndarray:
+        """
+        Steps:
+          1. Resize images to training resolution (if specified)
+          2. Encode with QwenVL (hidden states retained)
+          6. Return normalized action trajectory
+        Returns:
+            dict:
+                normalized_actions (np.ndarray): Shape [B, T, action_dim], diffusion-sampled normalized actions.
+        """
+        if type(examples) is not list:
+            examples = [examples]
+        batch_images = [to_pil_preserve(example["image"]) for example in examples]  #  [B，[PLT]]
+        instructions = [example["lang"] for example in examples]  # [B, str]
+    
+        state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
+        
+        train_obs_image_size = getattr(self.config.datasets.vla_data, "image_size", None)
+        if train_obs_image_size:
+            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+    
+        # Step 1: QWenVL input format
+        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            qwenvl_outputs = self.qwen_vl_interface(
+                **qwen_inputs,
+                output_attentions=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+
+            # last_hidden_state: [B, seq_len, H]
+            last_hidden = qwenvl_outputs.hidden_states[-1]   # [B, L, H]
+
+            # feed forward pass of vggt
+            with torch.no_grad():
+                spatial_input = preprocess_images(batch_images, batch_images[0][0].size[0]).to(qwen_inputs['pixel_values'].device)   
+                aggregated_tokens_list, ps_idx = self.spatial_model.aggregator(spatial_input)
+            spatial_tokens = aggregated_tokens_list[-1][:,0,ps_idx:,:]
+            spatial_tokens = self.spatial_projector(spatial_tokens)
+            last_hidden = self.fuser(last_hidden, spatial_tokens)
+
+
+        state = torch.from_numpy(np.array(state)).to(last_hidden.device, dtype=last_hidden.dtype) if state is not None else None
+        
+        # Step 4: Action Expert Forward
+        with torch.autocast("cuda", dtype=torch.float32):
+            pred_actions = self.action_model.predict_action(last_hidden, state)  # (B, chunk_len, action_dim)
+
+        normalized_actions = pred_actions.detach().cpu().numpy()
+        return {"normalized_actions": normalized_actions}
+
+
+
+if __name__ == "__main__":
+    from omegaconf import OmegaConf
+    import debugpy
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_oxe.yaml", help="Path to YAML config")
+    args, clipargs = parser.parse_known_args()
+
+    # debugpy.listen(("0.0.0.0", 10092))
+    # print("🔍 Rank 0 waiting for debugger attach on port 10092...")
+    # debugpy.wait_for_client()
+
+    cfg = OmegaConf.load(args.config_yaml)
+    # try get model
+    cfg.framework.action_model.action_hidden_dim = 2048
+
+    # cfg.framework.qwenvl.base_vlm = f"{CHECKPOINT_BASEDIR}/Florence-2-large"
+    
+
+    model: ABot_M0 = ABot_M0(cfg)
+    print(model)
+
+
+
+    # fake sample 
+    image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
+    # Create a sample
+    sample = {
+        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16), # action_chunk, action_dim
+        "image": [image], # three views
+        "lang": "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room.",
+        "state" : np.random.uniform(-1, 1, size=(1, 14)).astype(np.float16), # chunk, state_dim
+    }
+
+    batch  = [sample, sample]  # batch size 2
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    forward_output = model(batch)
+    action_loss = forward_output['action_loss']
+    print(f"Action Loss: {action_loss.item()}")
+
+    # test predict action
+    predict_output = model.predict_action(examples=[sample]) #, state=[batch[0]["state"]]
+    normalized_actions = predict_output['normalized_actions']
+    print(f"Unnormalized Action: {normalized_actions}")
+
+    # # Advance: try forward model with dataloader
+    # # can be fake sample， but here get from dataloader for simpler
+    vla_dataset_cfg = cfg.datasets.vla_data
+    from torch.utils.data import DataLoader
+    from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
+    cfg.datasets.vla_data.include_state = "False"
+    dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
+
+    train_dataloader = DataLoader(
+        dataset,
+        batch_size=2,
+        num_workers=1,  # For Debug
+        collate_fn=collate_fn,
+    )
+    # 
+    for batch in tqdm(train_dataloader, desc="Processing Batches"):
+        batch
+        break
+
+    # try get model
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    model(batch)
+
+    action = model.predict_action(examples=batch)
+    print("Finished")

--- a/starVLA/model/modules/action_model/AML_ActionHeader.py
+++ b/starVLA/model/modules/action_model/AML_ActionHeader.py
@@ -1,0 +1,469 @@
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.distributions import Beta
+from transformers import PretrainedConfig
+from transformers.feature_extraction_utils import BatchFeature
+
+from starVLA.model.modules.action_model.flow_matching_head.action_encoder import (
+    SinusoidalPositionalEncoding,
+    swish,
+)
+
+from starVLA.model.modules.action_model.flow_matching_head.cross_attention_dit import DiT
+
+# TODO try to meger DiT Modules with follow_match_head, they are just the same arch, but diff loss, use diffusers package will be simple
+
+class CategorySpecificLinear(nn.Module):
+    def __init__(self, num_categories, input_dim, hidden_dim):
+        super().__init__()
+        self.num_categories = num_categories
+        # For each category, we have separate weights and biases.
+        self.W = nn.Parameter(0.02 * torch.randn(num_categories, input_dim, hidden_dim))
+        self.b = nn.Parameter(torch.zeros(num_categories, hidden_dim))
+
+    def forward(self, x, cat_ids):
+        selected_W = self.W[cat_ids]
+        selected_b = self.b[cat_ids]
+        # import ipdb; ipdb.set_trace()
+        return torch.bmm(x, selected_W) + selected_b.unsqueeze(1)
+
+
+class CategorySpecificMLP(nn.Module):
+    def __init__(self, num_categories, input_dim, hidden_dim, output_dim):
+        super().__init__()
+        self.num_categories = num_categories
+        self.layer1 = CategorySpecificLinear(num_categories, input_dim, hidden_dim)
+        self.layer2 = CategorySpecificLinear(num_categories, hidden_dim, output_dim)
+
+    def forward(self, x, cat_ids):
+        hidden = F.relu(self.layer1(x, cat_ids))
+        return self.layer2(hidden, cat_ids)
+
+
+
+class MLP(nn.Module):
+    def __init__(self, input_dim, hidden_dim, output_dim):
+        super().__init__()
+        self.layer1 = nn.Linear(input_dim, hidden_dim)
+        self.layer2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        return self.layer2(F.relu(self.layer1(x)))
+
+
+class ActionEncoder(nn.Module):
+    def __init__(self, action_dim, hidden_size):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.action_dim = action_dim
+        self.layer1 = nn.Linear(action_dim, hidden_size)
+        self.layer2 = nn.Linear(2 * hidden_size, hidden_size)
+        self.layer3 = nn.Linear(hidden_size, hidden_size)
+        self.pos_encoding = SinusoidalPositionalEncoding(hidden_size)
+
+    def forward(self, actions, timesteps):
+        """
+        actions:   shape (B, T, action_dim)
+        timesteps: shape (B,)  -- a single scalar per batch item
+        returns:   shape (B, T, hidden_size)
+        """
+        B, T, _ = actions.shape
+
+        # 1) Expand each batch's single scalar time 'tau' across all T steps
+        #    so that shape => (B, T)
+        #    e.g. if timesteps is (B,), replicate across T
+        if timesteps.dim() == 1 and timesteps.shape[0] == B:
+            # shape (B,) => (B,T)
+            timesteps = timesteps.unsqueeze(1).expand(-1, T)
+        else:
+            raise ValueError(
+                "Expected `timesteps` to have shape (B,) so we can replicate across T."
+            )
+
+        # 2) Standard action MLP step for shape => (B, T, w)
+        a_emb = self.layer1(actions)
+
+        # 3) Get the sinusoidal encoding (B, T, w)
+        tau_emb = self.pos_encoding(timesteps).to(dtype=a_emb.dtype)
+
+        # 4) Concat along last dim => (B, T, 2w), then layer2 => (B, T, w), swish
+        x = torch.cat([a_emb, tau_emb], dim=-1)
+        x = swish(self.layer2(x))
+
+        # 5) Finally W3 => (B, T, w)
+        x = self.layer3(x)
+        return x
+
+
+
+class MultiEmbodimentActionEncoder(nn.Module):
+    def __init__(self, action_dim, hidden_size, num_embodiments):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_embodiments = num_embodiments
+
+        # W1: R^{w x d}, W2: R^{w x 2w}, W3: R^{w x w}
+        self.W1 = CategorySpecificLinear(num_embodiments, action_dim, hidden_size)  # (d -> w)
+        self.W2 = CategorySpecificLinear(num_embodiments, 2 * hidden_size, hidden_size)  # (2w -> w)
+        self.W3 = CategorySpecificLinear(num_embodiments, hidden_size, hidden_size)  # (w -> w)
+        self.pos_encoding = SinusoidalPositionalEncoding(hidden_size)
+
+    def forward(self, actions, timesteps, cat_ids):
+        """
+        actions:   shape (B, T, action_dim)
+        timesteps: shape (B,)  -- a single scalar per batch item
+        cat_ids:   shape (B,)
+        returns:   shape (B, T, hidden_size)
+        """
+        B, T, _ = actions.shape
+
+        # 1) Expand each batch's single scalar time 'tau' across all T steps
+        #    so that shape => (B, T)
+        #    e.g. if timesteps is (B,), replicate across T
+        if timesteps.dim() == 1 and timesteps.shape[0] == B:
+            # shape (B,) => (B,T)
+            timesteps = timesteps.unsqueeze(1).expand(-1, T)
+        else:
+            raise ValueError(
+                "Expected `timesteps` to have shape (B,) so we can replicate across T."
+            )
+
+        # 2) Standard action MLP step for shape => (B, T, w)
+        a_emb = self.W1(actions, cat_ids)
+
+        # 3) Get the sinusoidal encoding (B, T, w)
+        tau_emb = self.pos_encoding(timesteps).to(dtype=a_emb.dtype)
+
+        # 4) Concat along last dim => (B, T, 2w), then W2 => (B, T, w), swish
+        x = torch.cat([a_emb, tau_emb], dim=-1)
+        x = swish(self.W2(x, cat_ids))
+
+        # 5) Finally W3 => (B, T, w)
+        x = self.W3(x, cat_ids)
+        return x
+
+
+@dataclass
+class FlowmatchingActionHeadConfig(PretrainedConfig):
+    """NOTE: N1.5 uses XEmbFlowmatchingPolicyHeadConfig as action head"""
+
+    add_pos_embed: bool = field(
+        default=True, metadata={"help": "Whether to add positional embedding"}
+    )
+    diffusion_model_cfg: dict = field(
+        default=None, metadata={"help": "Diffusion model configuration."}
+    )
+    input_embedding_dim: int = field(
+        default=1536, metadata={"help": "Input embedding channel dimension."}
+    )
+
+    hidden_size: int = field(default=1024, metadata={"help": "Input embedding dimension."})
+    max_seq_len: int = field(default=1024, metadata={"help": "Maxium Sequence Length"})
+    action_dim: int = field(default=None, metadata={"help": "Action dimension."})
+    action_horizon: int = field(default=None, metadata={"help": "Action horizon."})
+    noise_beta_alpha: float = field(default=1.5, metadata={"help": ""})
+    noise_beta_beta: float = field(default=1.0, metadata={"help": ""})
+    noise_s: float = field(
+        default=0.999, metadata={"help": "Flow matching noise Beta distribution s."}
+    )
+    num_timestep_buckets: int = field(
+        default=1000, metadata={"help": "Number of timestep discretization buckets."}
+    )
+    num_inference_timesteps: int = field(
+        default=None,
+        metadata={"help": "Number of inference steps for noise diffusion."},
+    )
+    max_num_embodiments: int = field(default=32, metadata={"help": "Number of embodiments."})
+    tune_projector: bool = field(default=True, metadata={"help": "Whether to tune the projector."})
+    tune_diffusion_model: bool = field(
+        default=True, metadata={"help": "Whether to tune the diffusion model."}
+    )
+    load_pretrained_det_decode_layer_path: str = field(
+        default=None, metadata={"help": "Path to pretrained detection model."}
+    )
+    detection_coeff: float = field(default=1.0, metadata={"help": "Detection coefficient."})
+
+    freeze_decode_layer: bool = field(default=False)
+    expand_batch: int = field(default=None)
+    use_vlln: bool = field(default=True)
+
+    vl_self_attention_cfg: dict = field(default=None)
+    num_target_vision_tokens: int = field(
+        default=32, metadata={"help": "Number of target vision tokens."}
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+DiTConfig = {
+    "DiT-B": {"input_embedding_dim": 768, "attention_head_dim": 64, "num_attention_heads": 12},
+    "DiT-L": {"input_embedding_dim": 1536, "attention_head_dim": 48, "num_attention_heads": 32},
+}
+
+class FlowmatchingActionHead(nn.Module):
+    """
+    AML-style Flow Matching Action Head.
+    
+    Key difference from standard Flow Matching:
+    - Standard Flow Matching: model directly predicts velocity = actions - noise
+    - AML-style: model predicts action samples, then computes velocity = (pred_actions - noisy_trajectory) / (1 - t)
+    - Significantly outperforms GR00T for high-dimensional action predictions (action_dim * action_chunk) in a single forward pass
+    
+    This follows the AML (Just image Transformer) approach for images, adapted for action prediction.
+    """
+    def __init__(
+        self,
+        full_config,
+    ):
+        super().__init__()
+        config = full_config.framework.action_model
+        self.hidden_size = config.hidden_size 
+        self.full_config = full_config
+        action_model_type = config.action_model_type
+        action_model_cfg = DiTConfig[action_model_type]
+        
+        self.input_embedding_dim = action_model_cfg["input_embedding_dim"]
+        diffusion_model_cfg = config.diffusion_model_cfg
+        diffusion_model_cfg = {**action_model_cfg, **diffusion_model_cfg}
+        self.model = DiT(**diffusion_model_cfg)
+        self.action_dim = config.action_dim
+        self.action_horizon = config.future_action_window_size + 1
+        self.num_inference_timesteps = config.num_inference_timesteps
+
+        self.state_encoder = MLP(
+            input_dim=config.state_dim,
+            hidden_dim=self.hidden_size,
+            output_dim=self.input_embedding_dim,
+        ) if config.state_dim else None
+
+        self.action_encoder = ActionEncoder(
+            action_dim=config.action_dim,
+            hidden_size=self.input_embedding_dim,
+        )
+        self.action_decoder = MLP(
+            input_dim=self.model.config.output_dim,
+            hidden_dim=self.hidden_size,
+            output_dim=self.action_dim,
+        )
+        self.future_tokens = nn.Embedding(config.num_target_vision_tokens, self.input_embedding_dim)
+        nn.init.normal_(self.future_tokens.weight, mean=0.0, std=0.02)
+
+        if config.add_pos_embed:
+            self.position_embedding = nn.Embedding(config.max_seq_len, self.input_embedding_dim)
+            nn.init.normal_(self.position_embedding.weight, mean=0.0, std=0.02)
+
+        self.beta_dist = Beta(config.noise_beta_alpha, config.noise_beta_beta)
+        self.num_timestep_buckets = config.num_timestep_buckets
+        
+        self.t_eps = getattr(config, 't_eps', 5e-2)  
+        self.config = config
+
+    def sample_time(self, batch_size, device, dtype):
+        sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        return (self.config.noise_s - sample) / self.config.noise_s
+
+    def prepare_input(self, batch: dict) -> BatchFeature:
+        return BatchFeature(data=batch)
+
+
+    def forward(self, vl_embs: torch.Tensor, actions: torch.Tensor, state: torch.Tensor = None, encoder_attention_mask=None, action_mask: torch.Tensor = None):
+        """
+        AML-style sample prediction forward pass.
+        
+        Key difference from Flow Matching:
+        - Flow Matching: model directly predicts velocity = actions - noise
+        - AML: model predicts sample (actions), then compute velocity = (actions - noisy_trajectory) / (1 - t)
+        
+        vl_embs: shape (B, seq_length, feature_dim)
+        actions: shape (B, future_action_window_size, D_action)
+        action_mask: shape (B, D_action) - bool mask, True for real dims, False for padded dims
+        """
+        device = vl_embs.device
+
+        # ========== Step 1: Sample noise and timestep ==========
+        # Sample random noise with same shape as actions
+        noise = torch.randn(actions.shape, device=actions.device, dtype=actions.dtype)
+        # Sample timestep t ∈ [0, 1]
+        t = self.sample_time(actions.shape[0], device=actions.device, dtype=actions.dtype)
+        t = t[:, None, None]  # shape (B,1,1) for broadcast
+
+        # ========== Step 2: Create noisy trajectory  ==========
+        # Linear interpolation: z = t * actions + (1 - t) * noise
+        # When t=0: z = noise (pure noise)
+        # When t=1: z = actions (real actions)
+        noisy_trajectory = t * actions + (1 - t) * noise
+
+        # ========== Step 3: Compute true velocity field  ==========
+        # True velocity: v = (actions - noisy_trajectory) / (1 - t)
+        # This is the direction from noisy_trajectory to real actions
+        velocity = (actions - noisy_trajectory) / (1 - t).clamp_min(self.t_eps)
+
+        # ========== Step 4: Encode noisy trajectory ==========
+        # Convert (continuous) t -> discrete if needed
+        t_discretized = (t[:, 0, 0] * self.num_timestep_buckets).long()
+        action_features = self.action_encoder(noisy_trajectory, t_discretized)
+
+        # ========== Step 5: Encode state (if available) ==========
+        state_features = self.state_encoder(state) if state is not None else None
+
+        # ========== Step 6: Add position embedding ==========
+        if self.config.add_pos_embed:
+            pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+            pos_embs = self.position_embedding(pos_ids).unsqueeze(0)
+            action_features = action_features + pos_embs
+
+        # ========== Step 7: Concatenate state, future tokens, and action features ==========
+        future_tokens = self.future_tokens.weight.unsqueeze(0).expand(vl_embs.shape[0], -1, -1)
+        sa_embs = torch.cat((state_features, future_tokens, action_features), dim=1) \
+            if state_features is not None else torch.cat((future_tokens, action_features), dim=1)
+
+        # ========== Step 8: DiT forward pass ==========
+        # Model predicts action samples (not velocity directly)
+        model_output = self.model(
+            hidden_states=sa_embs,
+            encoder_hidden_states=vl_embs,
+            encoder_attention_mask=encoder_attention_mask,
+            timestep=t_discretized,
+            return_all_hidden_states=False,  # NOTE (YL): not using flare now
+        )
+        pred = self.action_decoder(model_output)
+        # ========== Step 9: Extract predicted action samples ==========
+        # Model output is predicted action samples (not velocity)
+        pred_actions = pred[:, -actions.shape[1] :]
+        
+        # ========== Step 10: Compute predicted velocity from samples (AML-style) ==========
+        # From predicted samples, compute velocity: v_pred = (pred_actions - noisy_trajectory) / (1 - t)
+        pred_velocity = (pred_actions - noisy_trajectory) / (1 - t).clamp_min(self.t_eps)
+
+        # ========== Step 11: Calculate loss (velocity field prediction error) ==========
+        # Loss is on velocity field, not on samples directly
+        if action_mask is not None:
+            # Expand action_mask from [B, action_dim] to [B, T, action_dim]
+            action_mask_expanded = action_mask.unsqueeze(1).expand(-1, pred_velocity.shape[1], -1)  # [B, T, action_dim]
+            # Calculate masked loss: only compute loss for real (non-padded) dimensions
+            squared_diff = (pred_velocity - velocity) ** 2  # [B, T, action_dim]
+            masked_squared_diff = squared_diff * action_mask_expanded.float()  # [B, T, action_dim]
+            # Sum over all dimensions, then divide by number of valid (masked) elements
+            loss = masked_squared_diff.sum() / (action_mask_expanded.sum().float() + 1e-8)
+        else:
+            # Original loss calculation when no mask is provided
+            loss = ((pred_velocity - velocity) ** 2).mean()
+        return loss
+
+    @torch.no_grad()
+    def predict_action(self, vl_embs: torch.Tensor, state: torch.Tensor = None) -> torch.Tensor:
+        """
+        AML-style sample prediction inference.
+        
+        Key difference from Flow Matching:
+        - Flow Matching: model directly predicts velocity, then actions = actions + dt * velocity
+        - AML: model predicts samples, compute velocity from samples, then integrate
+        
+        Process:
+        1. Start from pure noise: actions = N(0, I)
+        2. For each timestep:
+           a. Model predicts action samples: pred_actions = model(actions, t)
+           b. Compute velocity: v = (pred_actions - actions) / (1 - t)
+           c. Euler integration: actions = actions + dt * v
+        3. Return generated actions
+        """
+        # ========== Step 1: Initialize from pure noise ==========
+        batch_size = vl_embs.shape[0]
+        device = vl_embs.device
+        actions = torch.randn(
+            size=(batch_size, self.config.action_horizon, self.config.action_dim),
+            dtype=vl_embs.dtype,
+            device=device,
+        )
+
+        num_steps = self.num_inference_timesteps
+        dt = 1.0 / num_steps
+        
+        # ========== Step 2: Encode state (if available) ==========
+        state_features = self.state_encoder(state) if state is not None else None
+
+        # ========== Step 3: ODE integration loop ==========
+        # From t=0 (pure noise) to t=1 (real actions)
+        for t in range(num_steps):
+            # ========== Step 3a: Compute current continuous timestep ==========
+            t_cont = t / float(num_steps)  # e.g. goes 0, 1/N, 2/N, ...
+            t_discretized = int(t_cont * self.num_timestep_buckets)
+
+            # ========== Step 3b: Encode current action sequence ==========
+            timesteps_tensor = torch.full(
+                size=(batch_size,), fill_value=t_discretized, device=device
+            )
+            action_features = self.action_encoder(actions, timesteps_tensor)
+            
+            # ========== Step 3c: Add position embedding ==========
+            if self.config.add_pos_embed:
+                pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+                pos_embs = self.position_embedding(pos_ids).unsqueeze(0)
+                action_features = action_features + pos_embs
+
+            # ========== Step 3d: Concatenate features ==========
+            future_tokens = self.future_tokens.weight.unsqueeze(0).expand(vl_embs.shape[0], -1, -1)
+            sa_embs = torch.cat((state_features, future_tokens, action_features), dim=1) \
+                if state_features is not None else torch.cat((future_tokens, action_features), dim=1)
+
+            # ========== Step 3e: Model forward pass (predicts action samples) ==========
+            # Model predicts action samples, not velocity directly
+            model_output = self.model(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs,
+                timestep=timesteps_tensor,
+            )
+            pred = self.action_decoder(model_output)
+            
+            # ========== Step 3f: Extract predicted action samples ==========
+            pred_actions = pred[:, -self.action_horizon :]
+            
+            # ========== Step 3g: Compute velocity from predicted samples (AML-style) ==========
+            # Convert predicted samples to velocity field
+            # v = (pred_actions - actions) / (1 - t_cont)
+            # Broadcast t_cont to match actions shape (B, T, action_dim)
+            t_cont_broadcast = t_cont * torch.ones_like(actions[:, :1, :1])  # (B, 1, 1)
+            # pred_velocity = (pred_actions - actions) / (1.0 - t_cont_broadcast).clamp_min(self.t_eps)
+            pred_velocity = (pred_actions - actions) / (1.0 - t_cont_broadcast)
+
+            # ========== Step 3h: Euler integration ==========
+            # Update actions using velocity field
+            actions = actions + dt * pred_velocity
+            
+        return actions
+
+    @property
+    def device(self):
+        return next(iter(self.parameters())).device
+
+    @property
+    def dtype(self):
+        return next(iter(self.parameters())).dtype
+
+
+
+def get_action_model(config=None):
+    """
+    Factory: build AML-style FlowmatchingActionHead from global framework config.
+    
+    Args:
+        config: Global config (expects config.framework.action_model namespace).
+
+    Returns:
+        FlowmatchingActionHead: Initialized AML-style FlowMatchingActionHead.
+    """
+    return FlowmatchingActionHead(
+        full_config=config
+    )
+
+
+if __name__ == "__main__":
+    # TODO make each backbone.py can be debug independently
+
+    pass

--- a/starVLA/model/modules/vlm/CosmosReason2.py
+++ b/starVLA/model/modules/vlm/CosmosReason2.py
@@ -29,11 +29,13 @@ PIXELS_PER_TOKEN = 32**2
 class _CosmosReason2_Interface(nn.Module):
     def __init__(self, config: Optional[dict] = None, **kwargs):
         super().__init__()
+        qwenvl_config = config.framework.get("qwenvl", {})
         model_name = "nvidia/Cosmos-Reason2-2B"
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
         self.model = transformers.Qwen3VLForConditionalGeneration.from_pretrained(
             model_name,
             dtype=torch.bfloat16,
-            attn_implementation="sdpa"
+            attn_implementation=attn_implementation
         )
         self.processor = transformers.Qwen3VLProcessor.from_pretrained(model_name)
         self.config = config

--- a/starVLA/model/modules/vlm/QWen2_5.py
+++ b/starVLA/model/modules/vlm/QWen2_5.py
@@ -84,10 +84,11 @@ class _QWen_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen2.5-VL-3B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             torch_dtype="auto",
         )
         processor = AutoProcessor.from_pretrained(model_id)

--- a/starVLA/model/modules/vlm/QWen3.py
+++ b/starVLA/model/modules/vlm/QWen3.py
@@ -53,10 +53,11 @@ class _QWen3_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3-VL-4B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen3VLForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             dtype=torch.bfloat16,
         )
         processor = AutoProcessor.from_pretrained(model_id)

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -57,10 +57,11 @@ class _QWen3_5_VL_Interface(nn.Module):
 
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3.5-VL-4B-Instruct")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
         model = Qwen3_5ForConditionalGeneration.from_pretrained(
             model_id,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             torch_dtype=torch.bfloat16,
         )
         processor = AutoProcessor.from_pretrained(model_id)

--- a/starVLA/model/tools.py
+++ b/starVLA/model/tools.py
@@ -149,6 +149,11 @@ import os
 import json
 from pathlib import Path
 from omegaconf import OmegaConf
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
+from torchvision import transforms as TF
 
 # Initialize Overwatch =>> Wraps `logging.Logger`
 overwatch = initialize_overwatch(__name__)
@@ -194,3 +199,166 @@ def read_mode_config(pretrained_checkpoint):
         raise FileNotFoundError(f"Pretrained checkpoint `{pretrained_checkpoint}` does not exist.")
     return global_cfg, norm_stats
 
+
+
+class CrossAttention(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        d_hidden: int,
+        nhead: int = 8,
+        dropout: float = 0.0,
+        kv_dim: int = 2048
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_hidden = d_hidden if d_hidden is not None else d_model
+        self.nhead = nhead
+        self.head_dim = self.d_hidden // nhead
+        assert self.d_hidden % nhead == 0, "d_hidden must be divisible by nhead"
+
+        # Projections
+        self.q_proj = nn.Linear(d_model, self.d_hidden)
+        self.k_proj = nn.Linear(kv_dim, self.d_hidden)
+        self.v_proj = nn.Linear(kv_dim, self.d_hidden)
+        self.out_proj = nn.Linear(self.d_hidden, d_model)
+
+        self.dropout_attn = nn.Dropout(dropout)
+        self.dropout_out = nn.Dropout(dropout)
+        self.norm = nn.LayerNorm(d_model)
+
+    def forward(self, image_feature: torch.Tensor, spatial_feature: torch.Tensor):
+        """
+        Args:
+            image_feature: (B, N_img, d_model) — Query
+            vggt_feature:   (B, N_vggt, kv_dim) — Key and Value
+
+        Returns:
+            fused_image_feature: (B, N_img, d_model)
+        """
+        B, N_img, _ = image_feature.shape
+        _, N_spatial, _ = spatial_feature.shape
+
+        # Project to d_hidden
+        q = self.q_proj(image_feature)   # (B, N_img, d_hidden)
+        k = self.k_proj(spatial_feature)     # (B, N_vggt, d_hidden)
+        v = self.v_proj(spatial_feature)     # (B, N_vggt, d_hidden)
+
+        # Reshape for multi-head: (B, N, d_hidden) -> (B, N, nhead, head_dim) -> (B, nhead, N, head_dim)
+        q = q.view(B, N_img, self.nhead, self.head_dim).transpose(1, 2)  # (B, nhead, N_img, head_dim)
+        k = k.view(B, N_spatial, self.nhead, self.head_dim).transpose(1, 2)  # (B, nhead, N_vggt, head_dim)
+        v = v.view(B, N_spatial, self.nhead, self.head_dim).transpose(1, 2)  # (B, nhead, N_vggt, head_dim)
+
+        # Scaled Dot-Product Attention
+        scale = self.head_dim ** -0.5
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) * scale  # (B, nhead, N_img, N_vggt)
+        attn_weights = F.softmax(attn_weights, dim=-1)
+        attn_weights = self.dropout_attn(attn_weights)
+
+        # Weighted sum over values
+        attn_output = torch.matmul(attn_weights, v)  # (B, nhead, N_img, head_dim)
+
+        # Concatenate heads and project back
+        attn_output = attn_output.transpose(1, 2).contiguous()  # (B, N_img, nhead, head_dim)
+        attn_output = attn_output.view(B, N_img, self.d_hidden)  # (B, N_img, d_hidden)
+
+        # Final projection to d_model
+        output = self.out_proj(attn_output)  # (B, N_img, d_model)
+        output = self.dropout_out(output)
+
+        # Residual connection + LayerNorm
+        output = self.norm(image_feature + output)
+
+        return output
+
+
+def preprocess_images(image_list, target_size, mode='crop'): #  [B，[PLT]]
+    batch_images = []
+    shapes = set()
+    to_tensor = TF.ToTensor()
+    # target_size = 518
+
+    # First process all images and collect their shapes
+    for imgs in image_list:
+        epi_images = []
+        for img in imgs:
+            width, height = img.size
+
+            if mode == "pad":
+                # Make the largest dimension 518px while maintaining aspect ratio
+                if width >= height:
+                    new_width = target_size
+                    new_height = round(height * (new_width / width) / 14) * 14  # Make divisible by 14
+                else:
+                    new_height = target_size
+                    new_width = round(width * (new_height / height) / 14) * 14  # Make divisible by 14
+            else:  # mode == "crop"
+                # Original behavior: set width to 518px
+                new_width = target_size
+                # Calculate height maintaining aspect ratio, divisible by 14
+                new_height = round(height * (new_width / width) / 14) * 14
+
+            # Resize with new dimensions (width, height)
+            # img = img.resize((new_width, new_height), Image.Resampling.BICUBIC)
+            img = img.resize((new_width, new_height), Image.Resampling.BICUBIC)
+            img = to_tensor(img)  # Convert to tensor (0, 1)
+
+            # Center crop height if it's larger than 518 (only in crop mode)
+            if mode == "crop" and new_height > target_size:
+                start_y = (new_height - target_size) // 2
+                img = img[:, start_y : start_y + target_size, :]
+
+            # For pad mode, pad to make a square of target_size x target_size
+            if mode == "pad":
+                h_padding = target_size - img.shape[1]
+                w_padding = target_size - img.shape[2]
+
+                if h_padding > 0 or w_padding > 0:
+                    pad_top = h_padding // 2
+                    pad_bottom = h_padding - pad_top
+                    pad_left = w_padding // 2
+                    pad_right = w_padding - pad_left
+
+                    # Pad with white (value=1.0)
+                    img = torch.nn.functional.pad(
+                        img, (pad_left, pad_right, pad_top, pad_bottom), mode="constant", value=1.0
+                    )
+
+            shapes.add((img.shape[1], img.shape[2]))
+            epi_images.append(img)
+        batch_images.append(torch.stack(epi_images))
+
+    # Check if we have different shapes
+    # In theory our model can also work well with different shapes
+    if len(shapes) > 1:
+        print(f"Warning: Found images with different shapes: {shapes}")
+        # Find maximum dimensions
+        max_height = max(shape[0] for shape in shapes)
+        max_width = max(shape[1] for shape in shapes)
+
+        # Pad images if necessary
+        padded_images = []
+        for img in batch_images:
+            h_padding = max_height - img.shape[1]
+            w_padding = max_width - img.shape[2]
+
+            if h_padding > 0 or w_padding > 0:
+                pad_top = h_padding // 2
+                pad_bottom = h_padding - pad_top
+                pad_left = w_padding // 2
+                pad_right = w_padding - pad_left
+
+                img = torch.nn.functional.pad(
+                    img, (pad_left, pad_right, pad_top, pad_bottom), mode="constant", value=1.0
+                )
+            padded_images.append(img)
+        batch_images = padded_images
+
+    batch_images = torch.stack(batch_images)  # concatenate images
+
+    # Ensure correct shape when single image
+    if len(image_list) == 1:
+        # Verify shape is (1, C, H, W)
+        if batch_images.dim() == 3:
+            batch_images = batch_images.unsqueeze(0)
+    return batch_images


### PR DESCRIPTION
## Motivation and Context

This PR adds support for the OpenVLA / OpenVLA-OFT modified LIBERO RLDS datasets (`openvla/modified_libero_rlds`), including the commonly used task-suite subsets `libero_spatial_no_noops`, `libero_object_no_noops`, `libero_goal_no_noops`, and `libero_10_no_noops`.

This dataset family is the LIBERO fine-tuning path used in [OpenVLA](https://github.com/openvla/openvla) and carried forward by [OpenVLA-OFT](https://github.com/moojink/openvla-oft). It is also adopted or explicitly referenced by several follow-up open-source VLA codebases, including [VLA-Adapter](https://github.com/OpenHelix-Team/VLA-Adapter), [LightVLA](https://github.com/LiAutoAD/LightVLA/blob/main/LIBERO.md), [CogVLA](https://github.com/JiuTian-VL/CogVLA/blob/main/docs/LIBERO.md), [UniVLA](https://github.com/OpenDriveLab/UniVLA), and [RD-VLA](https://github.com/rd-vla/rd-vla).

Supporting this dataset family in starVLA reduces the gap between the current LeRobot-based LIBERO pipeline and a widely used OpenVLA-style training setup, improving reproducibility and lowering friction for comparing against prior and follow-up OFT-style baselines.

## Key Changes

- **RLDS dataloader adapter (`rlds_libero_datasets.py`)**: Added an `IterableDataset` to stream RLDS data into PyTorch efficiently. It handles action chunking (horizon padding), state precision formatting, and multi-node sharding in a way that is consistent with `starVLA/dataloader/lerobot_datasets.py`.
- **Dependency decoupling**: Updated `starVLA/dataloader/__init__.py` so that the RLDS-specific adapter is imported lazily. This keeps the existing LeRobot-only workflow unchanged and avoids introducing RLDS dependencies into code paths that do not use this dataset backend.
- **Data preparation and inspection**:
  - Added `data_preparation_rlds.sh` as a lightweight helper for preparing the expected local dataset layout from the Hugging Face dataset source.
  - Added validation utilities (`validate_rlds_statistics.py` and `inspect_rlds_orientation.py`) to inspect dataset statistics and verify image orientation for OpenVLA-style modified LIBERO RLDS datasets, since this dataset family requires dataset-specific handling during conversion and loading.
- **Config and entrypoints**: Added an example config (`starvla_cotrain_libero_rlds.yaml`) and a convenience launch script (`run_libero_train_rlds.sh`) for the new data path.

## Experimental Validation

I ran internal integration checks with this data path and confirmed that the training and evaluation pipeline complete normally on my side with current starVLA codebase.

## Usage

```bash
# 1. Prepare data
export DEST=/path/to/data
bash examples/LIBERO/data_preparation_rlds.sh

# 2. Start training
bash examples/LIBERO/train_files/run_libero_train_rlds.sh
```