### PR TITLE
Add session-scoped VLM cache reuse to the policy server

### DIFF
--- a/deployment/model_server/README.md
+++ b/deployment/model_server/README.md
@@ -9,14 +9,47 @@ your_ckpt=./results/Checkpoints/1003_qwenfast/checkpoints/steps_50000_pytorch_mo
 python deployment/model_server/server_policy.py \
     --ckpt_path ${your_ckpt} \
     --port 10093 \
+    --device auto \
     --use_bf16
 ```
+
+Use `--device cpu` for a functional smoke test on machines without CUDA. For meaningful latency numbers, prefer a real GPU-backed run.
 
 
 # connect to policy server for debug
 
 ```bash
-python deployment/model_server/debug_server_policy.py
+python deployment/model_server/tools/debug_server_policy.py
 
-# plus server_policy.py into your vla controler by ref to debug_server_policy.py
+# plus server_policy.py into your vla controler by ref to tools/debug_server_policy.py
 ```
+
+
+# benchmark cache reuse
+
+Use the same image/instruction repeatedly to compare cold requests against same-session reuse:
+
+```bash
+python deployment/model_server/tools/benchmark_policy_server.py \
+    --host 127.0.0.1 \
+    --port 10093 \
+    --image assets/table.jpeg \
+    --instruction "pick up the red block" \
+    --mode compare \
+    --runs 10 \
+    --warmup 1 \
+    --output-json benchmark-cache-report.json
+```
+
+What the benchmark reports:
+
+- end-to-end request latency
+- server-side `predict_action` latency
+- throughput in requests/sec
+- cache hit / miss counts from `return_cache_info`
+- cache footprint metadata (`cache_entries`, `cache_bytes`) so you can see the memory cost of reuse
+- server metadata in the JSON report, including the resolved device and checkpoint name
+- in `--mode compare`, an extra comparison block showing latency reduction, throughput uplift, and hit-rate change for same-session reuse vs forced cold requests
+
+When your controller switches tasks or instructions, call `client.reset_cache()` before the next request to clear stale server-side VLM features for that session.
+Set `--warmup 0` if you want the first measured request in reuse mode to include the initial cache miss instead of steady-state hits only.

--- a/deployment/model_server/README.md
+++ b/deployment/model_server/README.md
@@ -3,14 +3,13 @@
 
 
 ```bash
-
 your_ckpt=./results/Checkpoints/1003_qwenfast/checkpoints/steps_50000_pytorch_model.pt
 
-python deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port 10093 \
-    --device auto \
-    --use_bf16
+python -m deployment.model_server.server_policy \
+  --ckpt_path ${your_ckpt} \
+  --port 10093 \
+  --device auto \
+  --use_bf16
 ```
 
 Use `--device cpu` for a functional smoke test on machines without CUDA. For meaningful latency numbers, prefer a real GPU-backed run.
@@ -19,7 +18,9 @@ Use `--device cpu` for a functional smoke test on machines without CUDA. For mea
 # connect to policy server for debug
 
 ```bash
-python deployment/model_server/tools/debug_server_policy.py
+python -m deployment.model_server.tools.debug_server_policy \
+  --image assets/starVLA_LOGO.png \
+  --instruction "pick up the red block"
 
 # plus server_policy.py into your vla controler by ref to tools/debug_server_policy.py
 ```
@@ -30,16 +31,18 @@ python deployment/model_server/tools/debug_server_policy.py
 Use the same image/instruction repeatedly to compare cold requests against same-session reuse:
 
 ```bash
-python deployment/model_server/tools/benchmark_policy_server.py \
-    --host 127.0.0.1 \
-    --port 10093 \
-    --image assets/table.jpeg \
-    --instruction "pick up the red block" \
-    --mode compare \
-    --runs 10 \
-    --warmup 1 \
-    --output-json benchmark-cache-report.json
+python -m deployment.model_server.tools.benchmark_policy_server \
+  --host 127.0.0.1 \
+  --port 10093 \
+  --image assets/starVLA_LOGO.png \
+  --instruction "pick up the red block" \
+  --mode compare \
+  --runs 10 \
+  --warmup 1 \
+  --output-json benchmark-cache-report.json
 ```
+
+Replace `assets/starVLA_LOGO.png` with a real observation frame if you want more meaningful latency numbers.
 
 What the benchmark reports:
 

--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -2,13 +2,21 @@
 # Licensed under the MIT License, Version 1.0 (the "License"); 
 # Implemented by [Jinhui YE / HKUST University] in [2025].
 
-import logging
-import socket
 import argparse
+import logging
+import os
+import socket
+import sys
+from pathlib import Path
+
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+if str(_WORKSPACE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKSPACE_ROOT))
+
 from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
 from deployment.model_server.server_policy_utils import build_server_metadata, resolve_server_device
 from starVLA.model.framework.base_framework import baseframework
-import torch, os
+import torch
 
 
 def debug_enabled() -> bool:
@@ -62,11 +70,15 @@ def build_argparser():
 
 def start_debugpy_once():
     """start debugpy once"""
-    import debugpy
+    try:
+        import debugpy
+    except ImportError:
+        logging.warning("DEBUGPY requested but debugpy is not installed; skipping debugger attach.")
+        return
     if getattr(start_debugpy_once, "_started", False):
         return
     debugpy.listen(("0.0.0.0", 10095))
-    print("🔍 Waiting for VSCode attach on 0.0.0.0:10095 ...")
+    logging.info("Waiting for VSCode attach on 0.0.0.0:10095 ...")
     debugpy.wait_for_client()
     start_debugpy_once._started = True
 

--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -6,8 +6,13 @@ import logging
 import socket
 import argparse
 from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
+from deployment.model_server.server_policy_utils import build_server_metadata, resolve_server_device
 from starVLA.model.framework.base_framework import baseframework
 import torch, os
+
+
+def debug_enabled() -> bool:
+    return os.getenv("DEBUG", "").strip().lower() not in {"", "0", "false", "no"}
 
 
 def main(args) -> None:
@@ -20,13 +25,18 @@ def main(args) -> None:
         args.ckpt_path,
     )
 
-    if args.use_bf16: # False
+    device = resolve_server_device(args.device)
+
+    if args.use_bf16 and device.startswith("cuda"): # False
         vla = vla.to(torch.bfloat16)
-    vla = vla.to("cuda").eval()
+    elif args.use_bf16:
+        logging.warning("Ignoring --use_bf16 because device '%s' does not support the intended CUDA fast path.", device)
+
+    vla = vla.to(device).eval()
 
     hostname = socket.gethostname()
     local_ip = socket.gethostbyname(hostname)
-    logging.info("Creating server (host: %s, ip: %s)", hostname, local_ip)
+    logging.info("Creating server (host: %s, ip: %s, device: %s)", hostname, local_ip, device)
 
     # start websocket server
     server = WebsocketPolicyServer(
@@ -34,7 +44,7 @@ def main(args) -> None:
         host="0.0.0.0",
         port=args.port,
         idle_timeout=args.idle_timeout,
-        metadata={"env": "simpler_env"},
+        metadata=build_server_metadata(vla=vla, ckpt_path=args.ckpt_path, device=device),
     )
     logging.info("server running ...")
     server.serve_forever()
@@ -44,6 +54,7 @@ def build_argparser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--ckpt_path", type=str, default="Qwen/Qwen2.5-VL-3B-Instruct")
     parser.add_argument("--port", type=int, default=10093)
+    parser.add_argument("--device", type=str, default="auto", help="Device to place the policy on: auto, cpu, cuda, cuda:0, ...")
     parser.add_argument("--use_bf16", action="store_true")
     parser.add_argument("--idle_timeout" , type=int, default=1800, help="Idle timeout in seconds, -1 means never close")
     return parser
@@ -64,7 +75,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, force=True)
     parser = build_argparser()
     args = parser.parse_args()
-    if os.getenv("DEBUG", False):
-        print("🔍 DEBUGPY is enabled")
+    if debug_enabled():
+        logging.info("DEBUGPY is enabled")
         start_debugpy_once()
     main(args)

--- a/deployment/model_server/server_policy_utils.py
+++ b/deployment/model_server/server_policy_utils.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import torch
+
+
+def resolve_server_device(requested_device: str) -> str:
+    if requested_device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+
+    if requested_device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but no CUDA device is available.")
+
+    return requested_device
+
+
+def build_server_metadata(vla, ckpt_path: str, device: str) -> dict:
+    return {
+        "env": "simpler_env",
+        "device": device,
+        "framework": vla.__class__.__name__,
+        "checkpoint": Path(ckpt_path).name,
+        "supports_vlm_cache": hasattr(vla, "get_inference_cache_stats"),
+    }

--- a/deployment/model_server/tools/benchmark_policy_server.py
+++ b/deployment/model_server/tools/benchmark_policy_server.py
@@ -1,11 +1,16 @@
 import argparse
 import json
+import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List
 
 import numpy as np
 from PIL import Image
+
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+if str(_WORKSPACE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKSPACE_ROOT))
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 

--- a/deployment/model_server/tools/benchmark_policy_server.py
+++ b/deployment/model_server/tools/benchmark_policy_server.py
@@ -1,0 +1,388 @@
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+from PIL import Image
+
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
+
+
+def load_images(image_paths: List[str]) -> List[np.ndarray]:
+    loaded_images = []
+    for image_path in image_paths:
+        image = Image.open(image_path).convert("RGB")
+        loaded_images.append(np.asarray(image, dtype=np.uint8))
+    return loaded_images
+
+
+def parse_state(state_text: str | None) -> List[float] | None:
+    if not state_text:
+        return None
+
+    state_text = state_text.strip()
+    if not state_text:
+        return None
+
+    if state_text.startswith("["):
+        parsed = json.loads(state_text)
+    else:
+        parsed = [float(token.strip()) for token in state_text.split(",") if token.strip()]
+    return [float(value) for value in parsed]
+
+
+def build_request_payload(
+    *,
+    image_paths: List[str],
+    instruction: str,
+    state: List[float] | None = None,
+    use_vlm_cache: bool = True,
+) -> Dict[str, Any]:
+    example: Dict[str, Any] = {
+        "image": load_images(image_paths),
+        "lang": instruction,
+    }
+    if state is not None:
+        example["state"] = state
+
+    return {
+        "examples": [example],
+        "use_vlm_cache": use_vlm_cache,
+        "return_cache_info": True,
+    }
+
+
+def summarize_measurements(name: str, measurements: List[Dict[str, Any]]) -> Dict[str, Any]:
+    request_latencies = np.asarray([entry["request_latency_ms"] for entry in measurements], dtype=np.float64)
+    server_latencies = np.asarray(
+        [entry["predict_action_ms"] for entry in measurements if entry["predict_action_ms"] is not None],
+        dtype=np.float64,
+    )
+    cache_bytes = [int(entry["cache_bytes"]) for entry in measurements if entry.get("cache_bytes") is not None]
+    cache_entries = [int(entry["cache_entries"]) for entry in measurements if entry.get("cache_entries") is not None]
+    cache_hits = sum(1 for entry in measurements if entry.get("cache_hit") is True)
+    cache_misses = sum(1 for entry in measurements if entry.get("cache_hit") is False)
+
+    summary = {
+        "scenario": name,
+        "requests": len(measurements),
+        "cache_hits": int(cache_hits),
+        "cache_misses": int(cache_misses),
+        "cache_hit_rate": float(cache_hits / len(measurements)) if measurements else None,
+        "request_latency_ms": {
+            "mean": float(request_latencies.mean()),
+            "p50": float(np.percentile(request_latencies, 50)),
+            "p95": float(np.percentile(request_latencies, 95)),
+            "min": float(request_latencies.min()),
+            "max": float(request_latencies.max()),
+        },
+        "throughput_rps": float(1000.0 / request_latencies.mean()) if request_latencies.mean() > 0 else None,
+    }
+
+    if server_latencies.size > 0:
+        summary["predict_action_ms"] = {
+            "mean": float(server_latencies.mean()),
+            "p50": float(np.percentile(server_latencies, 50)),
+            "p95": float(np.percentile(server_latencies, 95)),
+            "min": float(server_latencies.min()),
+            "max": float(server_latencies.max()),
+        }
+
+    if cache_bytes:
+        summary["cache_bytes"] = {
+            "last": int(cache_bytes[-1]),
+            "max": int(max(cache_bytes)),
+        }
+
+    if cache_entries:
+        summary["cache_entries"] = {
+            "last": int(cache_entries[-1]),
+            "max": int(max(cache_entries)),
+        }
+
+    return summary
+
+
+def build_comparison_summary(
+    baseline_summary: Dict[str, Any],
+    candidate_summary: Dict[str, Any],
+) -> Dict[str, Any]:
+    def _compare_metric(metric_name: str) -> Dict[str, float] | None:
+        baseline_metric = baseline_summary.get(metric_name)
+        candidate_metric = candidate_summary.get(metric_name)
+        if baseline_metric is None or candidate_metric is None:
+            return None
+
+        baseline_mean = float(baseline_metric["mean"])
+        candidate_mean = float(candidate_metric["mean"])
+        mean_delta = baseline_mean - candidate_mean
+        mean_delta_pct = (mean_delta / baseline_mean * 100.0) if baseline_mean else None
+        speedup = (baseline_mean / candidate_mean) if candidate_mean else None
+        return {
+            "baseline_mean": baseline_mean,
+            "candidate_mean": candidate_mean,
+            "mean_delta": mean_delta,
+            "mean_delta_pct": mean_delta_pct,
+            "speedup_factor": speedup,
+        }
+
+    baseline_throughput = baseline_summary.get("throughput_rps")
+    candidate_throughput = candidate_summary.get("throughput_rps")
+    throughput = None
+    if baseline_throughput is not None and candidate_throughput is not None:
+        throughput_delta = candidate_throughput - baseline_throughput
+        throughput_delta_pct = (throughput_delta / baseline_throughput * 100.0) if baseline_throughput else None
+        throughput = {
+            "baseline": float(baseline_throughput),
+            "candidate": float(candidate_throughput),
+            "delta": float(throughput_delta),
+            "delta_pct": float(throughput_delta_pct) if throughput_delta_pct is not None else None,
+            "speedup_factor": (float(candidate_throughput / baseline_throughput) if baseline_throughput else None),
+        }
+
+    return {
+        "baseline_scenario": baseline_summary["scenario"],
+        "candidate_scenario": candidate_summary["scenario"],
+        "request_latency_ms": _compare_metric("request_latency_ms"),
+        "predict_action_ms": _compare_metric("predict_action_ms"),
+        "throughput_rps": throughput,
+        "cache_hit_rate": {
+            "baseline": baseline_summary.get("cache_hit_rate"),
+            "candidate": candidate_summary.get("cache_hit_rate"),
+        },
+    }
+
+
+def run_scenario(
+    *,
+    client: WebsocketClientPolicy,
+    scenario_name: str,
+    request_payload: Dict[str, Any],
+    warmup: int,
+    runs: int,
+    reset_between_requests: bool,
+    sleep_ms: int,
+) -> Dict[str, Any]:
+    client.reset_cache(request_id=f"{scenario_name}-start")
+
+    for warmup_idx in range(warmup):
+        if reset_between_requests:
+            client.reset_cache(request_id=f"{scenario_name}-warmup-reset-{warmup_idx}")
+        warmup_payload = dict(request_payload)
+        warmup_payload["request_id"] = f"{scenario_name}-warmup-{warmup_idx}"
+        client.infer(warmup_payload)
+
+    measurements: List[Dict[str, Any]] = []
+    for run_idx in range(runs):
+        if reset_between_requests:
+            client.reset_cache(request_id=f"{scenario_name}-reset-{run_idx}")
+
+        request = dict(request_payload)
+        request["request_id"] = f"{scenario_name}-run-{run_idx}"
+        started_at = time.perf_counter()
+        response = client.infer(request)
+        elapsed_ms = (time.perf_counter() - started_at) * 1000.0
+
+        if response.get("status") != "ok":
+            raise RuntimeError(f"Server returned error for {scenario_name}: {response}")
+
+        cache_info = response.get("data", {}).get("cache_info", {})
+        measurements.append(
+            {
+                "request_latency_ms": elapsed_ms,
+                "predict_action_ms": response.get("metrics", {}).get("predict_action_ms"),
+                "cache_hit": cache_info.get("hit"),
+                "cache_bytes": cache_info.get("cache_bytes"),
+                "cache_entries": cache_info.get("cache_entries"),
+                "cache_info": cache_info,
+            }
+        )
+
+        if sleep_ms > 0:
+            time.sleep(sleep_ms / 1000.0)
+
+    return {
+        "summary": summarize_measurements(scenario_name, measurements),
+        "measurements": measurements,
+    }
+
+
+def print_summary(result: Dict[str, Any]) -> None:
+    summary = result["summary"]
+    request_stats = summary["request_latency_ms"]
+    print(f"\n[{summary['scenario']}]")
+    print(
+        "requests={requests} cache_hits={cache_hits} cache_misses={cache_misses} hit_rate={hit_rate:.2%} throughput={throughput:.2f} req/s".format(
+            requests=summary["requests"],
+            cache_hits=summary["cache_hits"],
+            cache_misses=summary["cache_misses"],
+            hit_rate=summary["cache_hit_rate"] or 0.0,
+            throughput=summary["throughput_rps"] or 0.0,
+        )
+    )
+    print(
+        "request_latency_ms: mean={mean:.2f} p50={p50:.2f} p95={p95:.2f} min={min:.2f} max={max:.2f}".format(
+            **request_stats,
+        )
+    )
+
+    predict_action_stats = summary.get("predict_action_ms")
+    if predict_action_stats is not None:
+        print(
+            "predict_action_ms: mean={mean:.2f} p50={p50:.2f} p95={p95:.2f} min={min:.2f} max={max:.2f}".format(
+                **predict_action_stats,
+            )
+        )
+
+    cache_bytes = summary.get("cache_bytes")
+    cache_entries = summary.get("cache_entries")
+    if cache_bytes is not None or cache_entries is not None:
+        print(
+            "cache_footprint: entries_last={entries_last} entries_max={entries_max} bytes_last={bytes_last} bytes_max={bytes_max}".format(
+                entries_last=(cache_entries or {}).get("last", 0),
+                entries_max=(cache_entries or {}).get("max", 0),
+                bytes_last=(cache_bytes or {}).get("last", 0),
+                bytes_max=(cache_bytes or {}).get("max", 0),
+            )
+        )
+
+
+def print_comparison(comparison: Dict[str, Any]) -> None:
+    print(
+        "\n[comparison] {candidate} vs {baseline}".format(
+            candidate=comparison["candidate_scenario"],
+            baseline=comparison["baseline_scenario"],
+        )
+    )
+
+    request_latency = comparison.get("request_latency_ms")
+    if request_latency is not None:
+        print(
+            "request_latency_ms: {baseline_mean:.2f} -> {candidate_mean:.2f} ({mean_delta_pct:.2f}% lower, {speedup_factor:.2f}x faster)".format(
+                **request_latency,
+            )
+        )
+
+    predict_action = comparison.get("predict_action_ms")
+    if predict_action is not None:
+        print(
+            "predict_action_ms: {baseline_mean:.2f} -> {candidate_mean:.2f} ({mean_delta_pct:.2f}% lower, {speedup_factor:.2f}x faster)".format(
+                **predict_action,
+            )
+        )
+
+    throughput = comparison.get("throughput_rps")
+    if throughput is not None:
+        print(
+            "throughput_rps: {baseline:.2f} -> {candidate:.2f} ({delta_pct:.2f}% higher, {speedup_factor:.2f}x)".format(
+                **throughput,
+            )
+        )
+
+    cache_hit_rate = comparison.get("cache_hit_rate")
+    if cache_hit_rate is not None:
+        print(
+            "cache_hit_rate: baseline={baseline:.2%} candidate={candidate:.2%}".format(
+                baseline=cache_hit_rate.get("baseline") or 0.0,
+                candidate=cache_hit_rate.get("candidate") or 0.0,
+            )
+        )
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Benchmark repeated policy-server requests with and without cache reuse.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=10093)
+    parser.add_argument("--api-key", default="")
+    parser.add_argument("--image", action="append", required=True, help="Path to an RGB image. Repeat for multiview input.")
+    parser.add_argument("--instruction", required=True, help="Instruction text sent to the policy.")
+    parser.add_argument("--state", default="", help="Optional state as JSON list or comma-separated floats.")
+    parser.add_argument("--runs", type=int, default=10, help="Measured requests per scenario.")
+    parser.add_argument("--warmup", type=int, default=1, help="Warmup requests per scenario.")
+    parser.add_argument(
+        "--mode",
+        choices=["compare", "reuse", "cold"],
+        default="compare",
+        help="compare: run both repeated reuse and reset-per-request. reuse: one reset then repeated requests. cold: reset before every request.",
+    )
+    parser.add_argument("--sleep-ms", type=int, default=0, help="Optional pause between measured requests.")
+    parser.add_argument("--disable-vlm-cache", action="store_true", help="Send use_vlm_cache=False in requests.")
+    parser.add_argument("--output-json", default="", help="Optional path for a JSON report.")
+    return parser
+
+
+def main() -> None:
+    args = build_argparser().parse_args()
+
+    for image_path in args.image:
+        if not Path(image_path).exists():
+            raise FileNotFoundError(f"Image not found: {image_path}")
+
+    request_payload = build_request_payload(
+        image_paths=args.image,
+        instruction=args.instruction,
+        state=parse_state(args.state),
+        use_vlm_cache=not args.disable_vlm_cache,
+    )
+
+    client = WebsocketClientPolicy(host=args.host, port=args.port, api_key=(args.api_key or None))
+    report: Dict[str, Any] = {
+        "server_metadata": client.get_server_metadata(),
+        "request_config": {
+            "images": args.image,
+            "instruction": args.instruction,
+            "runs": args.runs,
+            "warmup": args.warmup,
+            "mode": args.mode,
+            "sleep_ms": args.sleep_ms,
+            "use_vlm_cache": not args.disable_vlm_cache,
+        },
+        "results": [],
+    }
+
+    try:
+        scenarios = []
+        if args.mode == "compare":
+            scenarios = [
+                ("cold_reset_each_request", True),
+                ("reuse_same_session", False),
+            ]
+        elif args.mode == "cold":
+            scenarios = [("cold_reset_each_request", True)]
+        else:
+            scenarios = [("reuse_same_session", False)]
+
+        for scenario_name, reset_between_requests in scenarios:
+            result = run_scenario(
+                client=client,
+                scenario_name=scenario_name,
+                request_payload=request_payload,
+                warmup=args.warmup,
+                runs=args.runs,
+                reset_between_requests=reset_between_requests,
+                sleep_ms=args.sleep_ms,
+            )
+            print_summary(result)
+            report["results"].append(result)
+
+        if len(report["results"]) == 2:
+            comparison = build_comparison_summary(
+                report["results"][0]["summary"],
+                report["results"][1]["summary"],
+            )
+            report["comparison"] = comparison
+            print_comparison(comparison)
+    finally:
+        client.close()
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"\nWrote benchmark report to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/model_server/tools/debug_server_policy.py
+++ b/deployment/model_server/tools/debug_server_policy.py
@@ -3,37 +3,45 @@ Debug / smoke-test client for deployment/model_server/server_policy.py.
 
 Purpose:
   - Establish a WebSocket connection to the policy server.
-  - Initialize device on the server side.
-  - Optionally run a very simple inference request to verify end-to-end transport
-    (serialization + server handling).
+  - Optionally run a simple inference request to verify end-to-end transport.
 
 Usage example:
-  python debug_server_policy.py --host 127.0.0.1 --port 10093 --device cuda --test infer
-
-Notes:
-  - The random observation is synthetic and only meant to validate the interface.
-  - Adjust keys (e.g. 'images', 'task_description') to match the server's expected schema.
+  python -m deployment.model_server.tools.debug_server_policy --host 127.0.0.1 --port 10093 --test infer
 """
 
 import argparse
 import logging
+import sys
+from pathlib import Path
+
 import numpy as np
+from PIL import Image
 
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+if str(_WORKSPACE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKSPACE_ROOT))
 
-from tools.websocket_policy_client import WebsocketClientPolicy
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 
 
 def _build_argparser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="WebSocket policy client smoke test (msgpack protocol)")
     ap.add_argument("--host", default="127.0.0.1", help="server hostname/IP (do not use 0.0.0.0)")
     ap.add_argument("--port", type=int, default=10093, help="server port")
-    ap.add_argument("--api_key", default="", help="optional: API key for authentication")
-    ap.add_argument("--device", default="cuda", choices=["cuda", "cpu"], help="initialize device")
-    ap.add_argument(
-        "--test", choices=["init", "infer"], default="infer", help="test mode: only initialize, or try simple inference"
-    )
+    ap.add_argument("--api_key", default="", help="optional API key")
+    ap.add_argument("--image", default="assets/starVLA_LOGO.png", help="local RGB image used for the smoke test")
+    ap.add_argument("--instruction", default="pick up the red block", help="instruction text for smoke-test inference")
+    ap.add_argument("--test", choices=["connect", "infer"], default="infer", help="connect only, or run one inference")
     ap.add_argument("--log_level", default="INFO")
     return ap
+
+
+def _load_image(image_path: str) -> np.ndarray:
+    resolved_path = Path(image_path)
+    if not resolved_path.is_absolute():
+        resolved_path = (_WORKSPACE_ROOT / resolved_path).resolve()
+    image = Image.open(resolved_path).convert("RGB")
+    return np.asarray(image, dtype=np.uint8)
 
 
 def _main():
@@ -43,45 +51,22 @@ def _main():
     client = WebsocketClientPolicy(host=args.host, port=args.port, api_key=(args.api_key or None))
     logging.info("Connected. Server metadata: %s", client.get_server_metadata())
 
-    # 1) device initialization
-    init_ret = client.init_device(args.device)  # here to set some things on the server
-    logging.info("Init device resp: %s", init_ret)
-
-    # 2) optional: try one simple inference
     if args.test == "infer":
         try:
-            # build observation aligned with model API
-            H, W = 224, 224
-            img = np.random.randint(0, 256, (H, W, 3), dtype=np.uint8)
-            wrist_img = np.random.randint(0, 256, (H, W, 3), dtype=np.uint8)
-            state = np.zeros((7,), dtype=np.float32)  # [x,y,z, ax,ay,az, gripper]
-
-            observation = {  # key to align with model API
+            image_primary_np = _load_image(args.image)
+            request = {
+                "type": "infer",
                 "request_id": "smoke-test",
-                "observation.primary": np.expand_dims(img, axis=0),  # (1,H,W,C), uint8 0-255
-                "observation.wrist_image": np.expand_dims(wrist_img, axis=0),  # (1,H,W,C)
-                "observation.state": np.expand_dims(state, axis=0),  # (1,7), float32
-                "instruction": ["debug: pick up the red block"],  # single element list
+                "examples": [{
+                    "image": [image_primary_np],
+                    "lang": args.instruction,
+                }],
+                "return_cache_info": True,
             }
-
-            image_path = "assets/table.jpeg"
-            # read image as PIL
-            from PIL import Image
-            image_primary = Image.open(image_path).convert("RGB")
-            # Convert PIL -> numpy uint8 (H,W,3)
-            image_primary_np = np.asarray(image_primary, dtype=np.uint8)
-
-            instruction_lang="pick up the red block"
-            obs = {
-                "request_id": "smoke-test",
-                "batch_images": [[image_primary_np]],
-                "instructions": [instruction_lang],  # assume batch task description
-            }
-
-            infer_ret = client.infer(obs)
+            infer_ret = client.infer(request)
             logging.info("Infer resp: %s", infer_ret)
-        except Exception as e:
-            logging.error("Infer error (this still proves transport OK): %s", e)
+        except Exception as exc:
+            logging.error("Infer error (transport may still be fine): %s", exc)
 
     client.close()
     logging.info("Smoke test done.")

--- a/deployment/model_server/tools/websocket_policy_client.py
+++ b/deployment/model_server/tools/websocket_policy_client.py
@@ -6,7 +6,15 @@ import logging, argparse
 import time, os
 from typing import Dict, Optional, Tuple
 
-from typing_extensions import override
+try:
+    from typing import override
+except ImportError:
+    try:
+        from typing_extensions import override
+    except ImportError:
+        def override(func):
+            return func
+
 import websockets.sync.client
 
 from . import msgpack_numpy
@@ -63,15 +71,26 @@ class WebsocketClientPolicy:
             self._ws.close()
         except Exception:
             pass
-    
-    @override
-    def predict_action(self, query_info: Dict) -> Dict:
-        data = self._packer.pack(query_info)
+
+    def _send_message(self, message: Dict) -> Dict:
+        data = self._packer.pack(message)
         self._ws.send(data)
         response = self._ws.recv()
         if isinstance(response, str):
             raise RuntimeError(f"Error in inference server:\n{response}")
         return msgpack_numpy.unpackb(response)
+
+    @override
+    def predict_action(self, query_info: Dict) -> Dict:
+        return self._send_message(query_info)
+
+    def infer(self, query_info: Dict) -> Dict:
+        message = dict(query_info)
+        message.setdefault("type", "infer")
+        return self._send_message(message)
+
+    def reset_cache(self, request_id: str = "reset-cache") -> Dict:
+        return self._send_message({"type": "reset", "request_id": request_id})
 
 
 

--- a/deployment/model_server/tools/websocket_policy_server.py
+++ b/deployment/model_server/tools/websocket_policy_server.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import traceback
 import time
+import uuid
 
 import websockets.asyncio.server
 import websockets.frames
@@ -65,19 +66,22 @@ class WebsocketPolicyServer:
     async def _handler(self, websocket: websockets.asyncio.server.ServerConnection):
         logging.info(f"Connection from {websocket.remote_address} opened")
         packer = msgpack_numpy.Packer()
+        session_id = str(uuid.uuid4())
 
-        await websocket.send(packer.pack(self._metadata))
+        await websocket.send(packer.pack({**self._metadata, "session_id": session_id}))
 
         while True:
             try:
                 msg = msgpack_numpy.unpackb(await websocket.recv())
                 self._last_active = time.time()  # 每次收到消息刷新活跃时间
-                ret = self._route_message(msg)  # route message
+                ret = self._route_message(msg, session_id=session_id)  # route message
                 await websocket.send(packer.pack(ret))
             except websockets.ConnectionClosed:
                 logging.info(f"Connection from {websocket.remote_address} closed")
+                self._clear_policy_cache(session_id=session_id)
                 break
             except Exception:
+                self._clear_policy_cache(session_id=session_id)
                 await websocket.send(traceback.format_exc())
                 await websocket.close(
                     code=websockets.frames.CloseCode.INTERNAL_ERROR,
@@ -85,8 +89,12 @@ class WebsocketPolicyServer:
                 )
                 raise
 
+    def _clear_policy_cache(self, session_id: str | None = None) -> None:
+        if hasattr(self._policy, "clear_inference_cache"):
+            self._policy.clear_inference_cache(session_id=session_id)
+
     # route logic: recognize request from client
-    def _route_message(self, msg: dict) -> dict:
+    def _route_message(self, msg: dict, session_id: str | None = None) -> dict:
         """
         Route rules (fault-tolerant):
         - Supports messages of form:
@@ -96,16 +104,27 @@ class WebsocketPolicyServer:
         """
         req_id = msg.get("request_id", "default")
         mtype = msg.get("type", "infer")          # default = infer
-        msg       # when no explicit payload, treat top-level as payload
+        payload = msg.get("payload", msg)
+        if isinstance(payload, dict):
+            payload = dict(payload)
 
         # ping
         if mtype == "ping":
             return {"status": "ok", "ok": True, "type": "ping", "request_id": req_id}
 
+        elif mtype == "reset":
+            self._clear_policy_cache(session_id=session_id)
+            return {
+                "status": "ok",
+                "ok": True,
+                "type": "reset",
+                "request_id": req_id,
+            }
+
         # infer --> framework.predict_action
         elif mtype == "infer" or mtype == "predict_action":
             # Basic payload sanity
-            if not isinstance(msg, dict):
+            if not isinstance(payload, dict):
                 return {
                     "status": "error",
                     "ok": False,
@@ -114,8 +133,12 @@ class WebsocketPolicyServer:
                     "error": {"message": "Payload must be a dict", "payload_type": str(type(payload))}
                 }
             try:
-
-                ouput_dict = self._policy.predict_action(**msg)
+                payload.pop("type", None)
+                payload.pop("request_id", None)
+                payload["cache_session_id"] = session_id
+                start_time = time.perf_counter()
+                ouput_dict = self._policy.predict_action(**payload)
+                predict_action_ms = (time.perf_counter() - start_time) * 1000.0
             except Exception as e:
                 logging.exception("Policy inference error (request_id=%s)", req_id)
                 logging.exception(e)
@@ -137,6 +160,9 @@ class WebsocketPolicyServer:
                 "type": "inference_result",
                 "request_id": req_id,
                 "data": data,
+                "metrics": {
+                    "predict_action_ms": predict_action_ms,
+                },
             }
 
         # unknow request type

--- a/examples/eval_protocol.md
+++ b/examples/eval_protocol.md
@@ -35,26 +35,34 @@ import WebsocketClientPolicy
 
 client = WebsocketClientPolicy(
     host="127.0.0.1",
-    port=10092
+    port=10093
 )
 
 while True:
     images = capture_multiview()          # returns List[np.ndarray]
     lang = get_instruction()              # may come from task scripts
-    example = {
-        "image": images,
-        "lang": lang,
+    request = {
+        "examples": [{
+            "image": images,
+            "lang": lang,
+        }],
+        "use_vlm_cache": True,            # optional: enable server-side VLM reuse
+        "return_cache_info": True,        # optional: return hit/miss metadata for profiling
     }
 
-    result = client.predict_action(example)  # --> forwarded to framework.predict_action
-    action = result["normalized_actions"][0] # take the first item in the batch
+    result = client.predict_action(request)   # --> forwarded to framework.predict_action
+    action = result["data"]["normalized_actions"][0]
     apply_action(action)
 ```
 
 ### Notes
-- Ensure every field in `example` is JSON-serializable or convertible (lists, floats, ints, strings); convert custom objects explicitly.
+- Ensure every field in the request payload is JSON-serializable or convertible (lists, floats, ints, strings); convert custom objects explicitly.
 - Images must be sent as `np.ndarray`. Perform `PIL.Image -> np.ndarray` before transmission and convert back on the server (`to_pil_preserve`) if required.
 - Keep auxiliary metadata (episode IDs, timestamps, etc.) in dedicated keys so the framework can forward or log them without collisions.
+- When instruction or task context changes, call `client.reset_cache()` before the next request so the server drops stale cached VLM features.
+- Several provided evaluation wrappers now do this inside their `reset(...)` path automatically; if you build a custom client, follow the same pattern.
+- `return_cache_info=True` adds cache hit / miss counters plus cache footprint metadata (`cache_entries`, `cache_bytes`) to the response, which is useful for latency benchmarks and debugging reuse behavior.
+- The benchmark helper under `deployment/model_server/tools/benchmark_policy_server.py` uses the same request shape and, in compare mode, prints the latency delta and throughput uplift between forced cold requests and same-session reuse.
 
 
 ### PolicyClient Interface Design

--- a/starVLA/model/framework/LangForce.py
+++ b/starVLA/model/framework/LangForce.py
@@ -548,27 +548,52 @@ class LangForce(baseframework):
         if train_obs_image_size:
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
-            images=batch_images,
-            instructions=instructions_posteriori
-        )
+        cache_session_id = kwargs.get("cache_session_id")
+        use_vlm_cache = bool(kwargs.get("use_vlm_cache", True))
+        return_cache_info = bool(kwargs.get("return_cache_info", False))
+        cache_key_override = kwargs.get("cache_key")
+        cache_info = {
+            "enabled": use_vlm_cache,
+            "hit": False,
+            "session_id": str(cache_session_id or "default"),
+        }
 
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-                use_cache=False,
+        action_hidden = None
+        if use_vlm_cache:
+            cache_key = self.build_inference_cache_key(
+                images=batch_images,
+                instructions=instructions_posteriori,
+                cache_key=cache_key_override,
+                extra={"framework": self.__class__.__name__},
+            )
+            cache_info["key"] = cache_key
+            action_hidden, cache_info["hit"] = self.get_inference_cache(cache_session_id, cache_key)
+
+        if action_hidden is None:
+            qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
+                images=batch_images,
+                instructions=instructions_posteriori
             )
 
-            last_hidden = qwenvl_outputs.hidden_states[-1]
-            action_hidden = self._extract_action_query_hidden_states(
-                last_hidden,
-                qwen_inputs["input_ids"],
-                self.qwen_vl_interface.processor.tokenizer,
-                return_starts=False
-            )  # [B, K, H]
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                qwenvl_outputs = self.qwen_vl_interface(
+                    **qwen_inputs,
+                    output_attentions=False,
+                    output_hidden_states=True,
+                    return_dict=True,
+                    use_cache=False,
+                )
+
+                last_hidden = qwenvl_outputs.hidden_states[-1]
+                action_hidden = self._extract_action_query_hidden_states(
+                    last_hidden,
+                    qwen_inputs["input_ids"],
+                    self.qwen_vl_interface.processor.tokenizer,
+                    return_starts=False
+                )  # [B, K, H]
+
+            if use_vlm_cache:
+                self.put_inference_cache(cache_session_id, cache_key, action_hidden)
 
         state_tensor = None
         if state is not None:
@@ -577,7 +602,11 @@ class LangForce(baseframework):
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action(action_hidden, state_tensor)
 
-        return {"normalized_actions": pred_actions.detach().cpu().numpy()}
+        output = {"normalized_actions": pred_actions.detach().cpu().numpy()}
+        if return_cache_info:
+            cache_info.update(self.get_inference_cache_stats(cache_session_id))
+            output["cache_info"] = cache_info
+        return output
 
 
 if __name__ == "__main__":

--- a/starVLA/model/framework/QwenPI.py
+++ b/starVLA/model/framework/QwenPI.py
@@ -172,28 +172,56 @@ class Qwen_PI(baseframework):
         train_obs_image_size = getattr(self.config.datasets.vla_data, "image_size", None)
         if train_obs_image_size:
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
-    
-        # Step 1: QWenVL input format
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-            )
-            all_hidden = qwenvl_outputs.hidden_states
-            expected_layers = len(self.action_model.model.transformer_blocks)
-            vl_embs_list = list(all_hidden[-expected_layers:])
-            base_hidden = vl_embs_list[-1]
 
+        cache_session_id = kwargs.get("cache_session_id")
+        use_vlm_cache = bool(kwargs.get("use_vlm_cache", True))
+        return_cache_info = bool(kwargs.get("return_cache_info", False))
+        cache_key_override = kwargs.get("cache_key")
+        cache_info = {
+            "enabled": use_vlm_cache,
+            "hit": False,
+            "session_id": str(cache_session_id or "default"),
+        }
+
+        vl_embs_list = None
+        if use_vlm_cache:
+            cache_key = self.build_inference_cache_key(
+                images=batch_images,
+                instructions=instructions,
+                cache_key=cache_key_override,
+                extra={"framework": self.__class__.__name__},
+            )
+            cache_info["key"] = cache_key
+            vl_embs_list, cache_info["hit"] = self.get_inference_cache(cache_session_id, cache_key)
+
+        if vl_embs_list is None:
+            qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                qwenvl_outputs = self.qwen_vl_interface(
+                    **qwen_inputs,
+                    output_attentions=False,
+                    output_hidden_states=True,
+                    return_dict=True,
+                )
+                all_hidden = qwenvl_outputs.hidden_states
+                expected_layers = len(self.action_model.model.transformer_blocks)
+                vl_embs_list = list(all_hidden[-expected_layers:])
+
+            if use_vlm_cache:
+                self.put_inference_cache(cache_session_id, cache_key, vl_embs_list)
+
+        base_hidden = vl_embs_list[-1]
         state = torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype) if state is not None else None
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action(vl_embs_list, state)  # (B, chunk_len, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()
-        return {"normalized_actions": normalized_actions}
+        output = {"normalized_actions": normalized_actions}
+        if return_cache_info:
+            cache_info.update(self.get_inference_cache_stats(cache_session_id))
+            output["cache_info"] = cache_info
+        return output
 
 
 

--- a/starVLA/model/framework/__init__.py
+++ b/starVLA/model/framework/__init__.py
@@ -26,11 +26,11 @@ except NameError:
 
 # Auto-import all framework submodules to trigger registration
 if pkg_path is not None:
-    try:
-        for _, module_name, _ in pkgutil.iter_modules(pkg_path):
+    for _, module_name, _ in sorted(pkgutil.iter_modules(pkg_path), key=lambda item: item[1]):
+        try:
             importlib.import_module(f"{__name__}.{module_name}")
-    except Exception as e:
-        logger.log(f"Warning: Failed to auto-import framework submodules: {e}")
+        except Exception as exc:
+            logger.warning(f"Failed to auto-import framework submodule `{module_name}`: {exc}")
         
 def build_framework(cfg):
     """

--- a/starVLA/model/framework/base_framework.py
+++ b/starVLA/model/framework/base_framework.py
@@ -27,6 +27,7 @@ from starVLA.model.framework.share_tools import read_mode_config
 from starVLA.training.trainer_utils import initialize_overwatch
 from starVLA.model.framework.share_tools import dict_to_namespace
 from starVLA.model.framework.__init__ import build_framework
+from starVLA.model.framework.inference_cache import SessionInferenceCache, build_multimodal_cache_key
 
 logger = initialize_overwatch(__name__)
 
@@ -52,6 +53,36 @@ class baseframework(PreTrainedModel):
         """
         
         super().__init__(hf_config)
+        self._inference_cache = SessionInferenceCache()
+
+    def build_inference_cache_key(
+        self,
+        *,
+        images,
+        instructions,
+        cache_key: str | None = None,
+        extra=None,
+    ) -> str:
+        return build_multimodal_cache_key(
+            images=images,
+            instructions=instructions,
+            override_key=cache_key,
+            extra=extra,
+        )
+
+    def get_inference_cache(self, session_id: str | None, cache_key: str):
+        return self._inference_cache.get(session_id=session_id, cache_key=cache_key)
+
+    def put_inference_cache(self, session_id: str | None, cache_key: str, value) -> None:
+        self._inference_cache.put(session_id=session_id, cache_key=cache_key, value=value)
+
+    def clear_inference_cache(self, session_id: str | None = None) -> None:
+        self._inference_cache.clear(session_id=session_id)
+        if hasattr(self, "qwen_vl_interface") and hasattr(self.qwen_vl_interface, "clear_cache"):
+            self.qwen_vl_interface.clear_cache()
+
+    def get_inference_cache_stats(self, session_id: str | None = None) -> Dict[str, int]:
+        return self._inference_cache.stats(session_id=session_id)
 
     @classmethod
     def from_pretrained(

--- a/starVLA/model/framework/inference_cache.py
+++ b/starVLA/model/framework/inference_cache.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import hashlib
+from typing import Any, Dict
+
+import numpy as np
+from PIL import Image
+try:
+    import torch
+except ImportError:  # pragma: no cover - runtime environments still install torch
+    torch = None
+
+
+def _update_hasher(hasher: "hashlib._Hash", value: Any) -> None:
+    if value is None:
+        hasher.update(b"n")
+        return
+
+    if isinstance(value, bool):
+        hasher.update(b"b")
+        hasher.update(b"1" if value else b"0")
+        return
+
+    if isinstance(value, (int, float, str)):
+        hasher.update(type(value).__name__.encode("utf-8"))
+        hasher.update(str(value).encode("utf-8"))
+        return
+
+    if isinstance(value, bytes):
+        hasher.update(b"bytes")
+        hasher.update(value)
+        return
+
+    if isinstance(value, Image.Image):
+        hasher.update(b"pil")
+        hasher.update(value.mode.encode("utf-8"))
+        hasher.update(str(value.size).encode("utf-8"))
+        hasher.update(value.tobytes())
+        return
+
+    if torch is not None and torch.is_tensor(value):
+        tensor = value.detach().cpu().contiguous()
+        hasher.update(b"torch")
+        hasher.update(str(tensor.dtype).encode("utf-8"))
+        hasher.update(str(tuple(tensor.shape)).encode("utf-8"))
+        hasher.update(tensor.numpy().tobytes())
+        return
+
+    if isinstance(value, np.ndarray):
+        array = np.ascontiguousarray(value)
+        hasher.update(b"numpy")
+        hasher.update(str(array.dtype).encode("utf-8"))
+        hasher.update(str(array.shape).encode("utf-8"))
+        hasher.update(array.tobytes())
+        return
+
+    if isinstance(value, dict):
+        hasher.update(b"dict")
+        for key in sorted(value.keys(), key=lambda item: str(item)):
+            _update_hasher(hasher, key)
+            _update_hasher(hasher, value[key])
+        return
+
+    if isinstance(value, (list, tuple)):
+        hasher.update(b"seq")
+        hasher.update(str(len(value)).encode("utf-8"))
+        for item in value:
+            _update_hasher(hasher, item)
+        return
+
+    hasher.update(type(value).__name__.encode("utf-8"))
+    hasher.update(repr(value).encode("utf-8"))
+
+
+def estimate_cache_value_bytes(value: Any) -> int:
+    if value is None:
+        return 0
+
+    if isinstance(value, bytes):
+        return len(value)
+
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+
+    if isinstance(value, Image.Image):
+        return len(value.tobytes())
+
+    if torch is not None and torch.is_tensor(value):
+        return int(value.nelement() * value.element_size())
+
+    if isinstance(value, np.ndarray):
+        return int(value.nbytes)
+
+    if isinstance(value, dict):
+        return sum(estimate_cache_value_bytes(item) for item in value.values())
+
+    if isinstance(value, (list, tuple)):
+        return sum(estimate_cache_value_bytes(item) for item in value)
+
+    return 0
+
+
+def build_multimodal_cache_key(
+    *,
+    images: Any,
+    instructions: Any,
+    override_key: str | None = None,
+    extra: Any = None,
+) -> str:
+    if override_key is not None:
+        return str(override_key)
+
+    hasher = hashlib.blake2b(digest_size=20)
+    _update_hasher(hasher, instructions)
+    _update_hasher(hasher, images)
+    if extra is not None:
+        _update_hasher(hasher, extra)
+    return hasher.hexdigest()
+
+
+@dataclass
+class CacheEntry:
+    key: str
+    value: Any
+    size_bytes: int
+
+
+class SessionInferenceCache:
+    def __init__(self) -> None:
+        self._entries: Dict[str, CacheEntry] = {}
+        self._stats = defaultdict(lambda: {"hits": 0, "misses": 0})
+
+    @staticmethod
+    def _normalize_session_id(session_id: str | None) -> str:
+        return str(session_id or "default")
+
+    def get(self, session_id: str | None, cache_key: str) -> tuple[Any, bool]:
+        normalized_session_id = self._normalize_session_id(session_id)
+        entry = self._entries.get(normalized_session_id)
+        if entry is not None and entry.key == cache_key:
+            self._stats[normalized_session_id]["hits"] += 1
+            return entry.value, True
+
+        self._stats[normalized_session_id]["misses"] += 1
+        return None, False
+
+    def put(self, session_id: str | None, cache_key: str, value: Any) -> None:
+        normalized_session_id = self._normalize_session_id(session_id)
+        self._entries[normalized_session_id] = CacheEntry(
+            key=cache_key,
+            value=value,
+            size_bytes=estimate_cache_value_bytes(value),
+        )
+
+    def clear(self, session_id: str | None = None) -> None:
+        if session_id is None:
+            self._entries.clear()
+            self._stats.clear()
+            return
+
+        normalized_session_id = self._normalize_session_id(session_id)
+        self._entries.pop(normalized_session_id, None)
+        self._stats.pop(normalized_session_id, None)
+
+    def stats(self, session_id: str | None = None) -> Dict[str, int]:
+        if session_id is not None:
+            normalized_session_id = self._normalize_session_id(session_id)
+            stats = self._stats[normalized_session_id]
+            entry = self._entries.get(normalized_session_id)
+            return {
+                "hits": int(stats["hits"]),
+                "misses": int(stats["misses"]),
+                "cache_entries": 1 if entry is not None else 0,
+                "cache_bytes": int(entry.size_bytes if entry is not None else 0),
+            }
+
+        hits = sum(stats["hits"] for stats in self._stats.values())
+        misses = sum(stats["misses"] for stats in self._stats.values())
+        cache_bytes = sum(entry.size_bytes for entry in self._entries.values())
+        return {
+            "hits": int(hits),
+            "misses": int(misses),
+            "sessions": len(self._entries),
+            "cache_entries": len(self._entries),
+            "cache_bytes": int(cache_bytes),
+        }

--- a/tests/test_benchmark_policy_server.py
+++ b/tests/test_benchmark_policy_server.py
@@ -1,0 +1,165 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from deployment.model_server.tools.benchmark_policy_server import (
+    build_comparison_summary,
+    build_request_payload,
+    parse_state,
+    run_scenario,
+    summarize_measurements,
+)
+
+
+class _FakeBenchmarkClient:
+    def __init__(self) -> None:
+        self.reset_calls = []
+        self.infer_calls = []
+        self._cache_primed = False
+
+    def reset_cache(self, request_id: str) -> dict:
+        self.reset_calls.append(request_id)
+        self._cache_primed = False
+        return {"status": "ok"}
+
+    def infer(self, payload: dict) -> dict:
+        self.infer_calls.append(payload["request_id"])
+        cache_hit = self._cache_primed
+        self._cache_primed = True
+        return {
+            "status": "ok",
+            "data": {
+                "cache_info": {
+                    "hit": cache_hit,
+                    "cache_bytes": 1024,
+                    "cache_entries": 1,
+                }
+            },
+            "metrics": {
+                "predict_action_ms": 10.0 if cache_hit else 20.0,
+            },
+        }
+
+
+class BenchmarkPolicyServerTests(unittest.TestCase):
+    def test_parse_state_accepts_json_or_csv(self):
+        self.assertEqual([0.0, 1.5, -2.0], parse_state("[0, 1.5, -2]"))
+        self.assertEqual([0.0, 1.5, -2.0], parse_state("0, 1.5, -2"))
+        self.assertIsNone(parse_state(""))
+
+    def test_build_request_payload_loads_images_and_state(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            image_path = Path(tmp_dir) / "sample.png"
+            image = Image.fromarray(np.full((4, 5, 3), 127, dtype=np.uint8), mode="RGB")
+            image.save(image_path)
+
+            payload = build_request_payload(
+                image_paths=[str(image_path)],
+                instruction="stack blocks",
+                state=[0.1, 0.2],
+                use_vlm_cache=True,
+            )
+
+        self.assertTrue(payload["use_vlm_cache"])
+        self.assertTrue(payload["return_cache_info"])
+        self.assertEqual("stack blocks", payload["examples"][0]["lang"])
+        self.assertEqual([0.1, 0.2], payload["examples"][0]["state"])
+        self.assertEqual((4, 5, 3), payload["examples"][0]["image"][0].shape)
+
+    def test_summarize_measurements_reports_cache_and_latency_stats(self):
+        summary = summarize_measurements(
+            "reuse_same_session",
+            [
+                {"request_latency_ms": 100.0, "predict_action_ms": 80.0, "cache_hit": False, "cache_bytes": 4096, "cache_entries": 1},
+                {"request_latency_ms": 60.0, "predict_action_ms": 40.0, "cache_hit": True, "cache_bytes": 4096, "cache_entries": 1},
+                {"request_latency_ms": 55.0, "predict_action_ms": 35.0, "cache_hit": True, "cache_bytes": 4096, "cache_entries": 1},
+            ],
+        )
+
+        self.assertEqual("reuse_same_session", summary["scenario"])
+        self.assertEqual(3, summary["requests"])
+        self.assertEqual(2, summary["cache_hits"])
+        self.assertEqual(1, summary["cache_misses"])
+        self.assertAlmostEqual(2.0 / 3.0, summary["cache_hit_rate"])
+        self.assertEqual({"last": 4096, "max": 4096}, summary["cache_bytes"])
+        self.assertEqual({"last": 1, "max": 1}, summary["cache_entries"])
+        self.assertAlmostEqual((100.0 + 60.0 + 55.0) / 3.0, summary["request_latency_ms"]["mean"])
+        self.assertAlmostEqual((80.0 + 40.0 + 35.0) / 3.0, summary["predict_action_ms"]["mean"])
+
+    def test_build_comparison_summary_reports_latency_and_throughput_deltas(self):
+        baseline = summarize_measurements(
+            "cold_reset_each_request",
+            [
+                {"request_latency_ms": 100.0, "predict_action_ms": 80.0, "cache_hit": False, "cache_bytes": 2048, "cache_entries": 1},
+                {"request_latency_ms": 90.0, "predict_action_ms": 70.0, "cache_hit": False, "cache_bytes": 2048, "cache_entries": 1},
+            ],
+        )
+        candidate = summarize_measurements(
+            "reuse_same_session",
+            [
+                {"request_latency_ms": 60.0, "predict_action_ms": 45.0, "cache_hit": True, "cache_bytes": 2048, "cache_entries": 1},
+                {"request_latency_ms": 50.0, "predict_action_ms": 35.0, "cache_hit": True, "cache_bytes": 2048, "cache_entries": 1},
+            ],
+        )
+
+        comparison = build_comparison_summary(baseline, candidate)
+
+        self.assertEqual("cold_reset_each_request", comparison["baseline_scenario"])
+        self.assertEqual("reuse_same_session", comparison["candidate_scenario"])
+        self.assertAlmostEqual(95.0, comparison["request_latency_ms"]["baseline_mean"])
+        self.assertAlmostEqual(55.0, comparison["request_latency_ms"]["candidate_mean"])
+        self.assertGreater(comparison["request_latency_ms"]["mean_delta_pct"], 0.0)
+        self.assertGreater(comparison["throughput_rps"]["delta_pct"], 0.0)
+        self.assertEqual(0.0, comparison["cache_hit_rate"]["baseline"])
+        self.assertEqual(1.0, comparison["cache_hit_rate"]["candidate"])
+
+    def test_run_scenario_resets_each_request_for_cold_mode(self):
+        client = _FakeBenchmarkClient()
+
+        result = run_scenario(
+            client=client,
+            scenario_name="cold_reset_each_request",
+            request_payload={"examples": [{"lang": "pick", "image": []}]},
+            warmup=0,
+            runs=3,
+            reset_between_requests=True,
+            sleep_ms=0,
+        )
+
+        self.assertEqual(
+            [
+                "cold_reset_each_request-start",
+                "cold_reset_each_request-reset-0",
+                "cold_reset_each_request-reset-1",
+                "cold_reset_each_request-reset-2",
+            ],
+            client.reset_calls,
+        )
+        self.assertEqual([False, False, False], [entry["cache_hit"] for entry in result["measurements"]])
+        self.assertEqual(0, result["summary"]["cache_hits"])
+        self.assertEqual(3, result["summary"]["cache_misses"])
+
+    def test_run_scenario_reuses_same_session_without_intermediate_resets(self):
+        client = _FakeBenchmarkClient()
+
+        result = run_scenario(
+            client=client,
+            scenario_name="reuse_same_session",
+            request_payload={"examples": [{"lang": "pick", "image": []}]},
+            warmup=0,
+            runs=3,
+            reset_between_requests=False,
+            sleep_ms=0,
+        )
+
+        self.assertEqual(["reuse_same_session-start"], client.reset_calls)
+        self.assertEqual([False, True, True], [entry["cache_hit"] for entry in result["measurements"]])
+        self.assertEqual({"last": 1024, "max": 1024}, result["summary"]["cache_bytes"])
+        self.assertEqual({"last": 1, "max": 1}, result["summary"]["cache_entries"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,0 +1,123 @@
+import unittest
+import importlib.util
+from pathlib import Path
+import sys
+
+import numpy as np
+from PIL import Image
+
+from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
+
+
+def _load_inference_cache_module():
+    module_path = Path(__file__).resolve().parents[1] / "starVLA" / "model" / "framework" / "inference_cache.py"
+    spec = importlib.util.spec_from_file_location("starvla_inference_cache", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_inference_cache = _load_inference_cache_module()
+SessionInferenceCache = _inference_cache.SessionInferenceCache
+build_multimodal_cache_key = _inference_cache.build_multimodal_cache_key
+estimate_cache_value_bytes = _inference_cache.estimate_cache_value_bytes
+
+
+class _DummyPolicy:
+    def __init__(self) -> None:
+        self.clear_calls = []
+        self.predict_calls = []
+
+    def clear_inference_cache(self, session_id=None) -> None:
+        self.clear_calls.append(session_id)
+
+    def predict_action(self, **kwargs):
+        self.predict_calls.append(kwargs)
+        return {"normalized_actions": np.zeros((1, 1, 7), dtype=np.float32)}
+
+
+class InferenceCacheTests(unittest.TestCase):
+    def test_cache_key_changes_with_instruction_and_pixels(self):
+        image = Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8), mode="RGB")
+        altered_image = Image.fromarray(np.ones((4, 4, 3), dtype=np.uint8), mode="RGB")
+
+        base_key = build_multimodal_cache_key(images=[[image]], instructions=["pick up block"])
+        same_key = build_multimodal_cache_key(images=[[image.copy()]], instructions=["pick up block"])
+        other_instruction_key = build_multimodal_cache_key(images=[[image]], instructions=["open drawer"])
+        other_image_key = build_multimodal_cache_key(images=[[altered_image]], instructions=["pick up block"])
+
+        self.assertEqual(base_key, same_key)
+        self.assertNotEqual(base_key, other_instruction_key)
+        self.assertNotEqual(base_key, other_image_key)
+
+    def test_session_cache_tracks_hits_and_misses_per_session(self):
+        cache = SessionInferenceCache()
+        cache.put("session-a", "key-a", np.zeros((2, 3), dtype=np.float32))
+
+        cached_value, hit = cache.get("session-a", "key-a")
+        self.assertTrue(hit)
+        self.assertEqual((2, 3), cached_value.shape)
+
+        _, hit = cache.get("session-a", "key-b")
+        self.assertFalse(hit)
+        cache.put("session-b", "key-b", np.zeros((1, 2), dtype=np.float16))
+        _, hit = cache.get("session-b", "key-b")
+        self.assertTrue(hit)
+
+        self.assertEqual(
+            {"hits": 1, "misses": 1, "cache_entries": 1, "cache_bytes": 24},
+            cache.stats("session-a"),
+        )
+        self.assertEqual(
+            {"hits": 1, "misses": 0, "cache_entries": 1, "cache_bytes": 4},
+            cache.stats("session-b"),
+        )
+
+    def test_clear_resets_session_entry_and_stats(self):
+        cache = SessionInferenceCache()
+        cache.put("session-a", "key-a", np.zeros((2, 3), dtype=np.float32))
+        cache.get("session-a", "key-a")
+        cache.get("session-a", "missing")
+
+        cache.clear("session-a")
+
+        self.assertEqual({"hits": 0, "misses": 0, "cache_entries": 0, "cache_bytes": 0}, cache.stats("session-a"))
+        _, hit = cache.get("session-a", "key-a")
+        self.assertFalse(hit)
+        self.assertEqual({"hits": 0, "misses": 1, "cache_entries": 0, "cache_bytes": 0}, cache.stats("session-a"))
+
+    def test_estimate_cache_value_bytes_handles_nested_tensors(self):
+        nested_value = {
+            "a": np.zeros((2, 2), dtype=np.float32),
+            "b": [np.zeros((1,), dtype=np.float16), np.zeros((3,), dtype=np.uint8)],
+        }
+
+        self.assertEqual(16 + 2 + 3, estimate_cache_value_bytes(nested_value))
+
+    def test_websocket_server_reset_and_infer_are_session_scoped(self):
+        policy = _DummyPolicy()
+        server = WebsocketPolicyServer(policy=policy, metadata={"env": "test"})
+
+        reset_response = server._route_message({"type": "reset", "request_id": "r1"}, session_id="session-a")
+        self.assertTrue(reset_response["ok"])
+        self.assertEqual(["session-a"], policy.clear_calls)
+
+        infer_response = server._route_message(
+            {
+                "type": "infer",
+                "request_id": "r2",
+                "payload": {"examples": [{"lang": "pick", "image": []}], "use_vlm_cache": True},
+            },
+            session_id="session-a",
+        )
+        self.assertTrue(infer_response["ok"])
+        self.assertEqual("session-a", policy.predict_calls[-1]["cache_session_id"])
+        self.assertTrue(policy.predict_calls[-1]["use_vlm_cache"])
+        self.assertIn("metrics", infer_response)
+        self.assertGreaterEqual(infer_response["metrics"]["predict_action_ms"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_policy.py
+++ b/tests/test_server_policy.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest import mock
+import importlib
+
+from deployment.model_server import server_policy_utils
+
+
+class _DummyPolicy:
+    pass
+
+
+class ServerPolicyTests(unittest.TestCase):
+    def test_server_policy_module_imports_without_optional_framework_dependencies(self):
+        module = importlib.import_module("deployment.model_server.server_policy")
+        self.assertTrue(hasattr(module, "main"))
+
+    def test_resolve_server_device_uses_cpu_when_auto_and_cuda_missing(self):
+        with mock.patch.object(server_policy_utils.torch.cuda, "is_available", return_value=False):
+            self.assertEqual("cpu", server_policy_utils.resolve_server_device("auto"))
+
+    def test_resolve_server_device_uses_cuda_when_auto_and_cuda_present(self):
+        with mock.patch.object(server_policy_utils.torch.cuda, "is_available", return_value=True):
+            self.assertEqual("cuda", server_policy_utils.resolve_server_device("auto"))
+
+    def test_resolve_server_device_raises_for_unavailable_cuda(self):
+        with mock.patch.object(server_policy_utils.torch.cuda, "is_available", return_value=False):
+            with self.assertRaises(RuntimeError):
+                server_policy_utils.resolve_server_device("cuda:0")
+
+    def test_build_server_metadata_includes_cache_support_and_checkpoint_name(self):
+        policy = _DummyPolicy()
+        policy.get_inference_cache_stats = lambda session_id=None: {}
+
+        metadata = server_policy_utils.build_server_metadata(
+            vla=policy,
+            ckpt_path="D:/models/checkpoints/demo_model.pt",
+            device="cpu",
+        )
+
+        self.assertEqual("cpu", metadata["device"])
+        self.assertEqual("demo_model.pt", metadata["checkpoint"])
+        self.assertEqual("_DummyPolicy", metadata["framework"])
+        self.assertTrue(metadata["supports_vlm_cache"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_policy.py
+++ b/tests/test_server_policy.py
@@ -1,8 +1,13 @@
+import subprocess
+import sys
 import unittest
 from unittest import mock
 import importlib
+from pathlib import Path
 
 from deployment.model_server import server_policy_utils
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _DummyPolicy:
@@ -10,9 +15,33 @@ class _DummyPolicy:
 
 
 class ServerPolicyTests(unittest.TestCase):
+    def _run_script_help(self, relative_script_path: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(REPO_ROOT / relative_script_path), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
     def test_server_policy_module_imports_without_optional_framework_dependencies(self):
         module = importlib.import_module("deployment.model_server.server_policy")
         self.assertTrue(hasattr(module, "main"))
+
+    def test_server_policy_help_runs_as_script(self):
+        proc = self._run_script_help("deployment/model_server/server_policy.py")
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn("--ckpt_path", proc.stdout)
+
+    def test_benchmark_policy_server_help_runs_as_script(self):
+        proc = self._run_script_help("deployment/model_server/tools/benchmark_policy_server.py")
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn("--image", proc.stdout)
+
+    def test_debug_server_policy_help_runs_as_script(self):
+        proc = self._run_script_help("deployment/model_server/tools/debug_server_policy.py")
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn("--instruction", proc.stdout)
 
     def test_resolve_server_device_uses_cpu_when_auto_and_cuda_missing(self):
         with mock.patch.object(server_policy_utils.torch.cuda, "is_available", return_value=False):


### PR DESCRIPTION
## What changed
This PR adds session-scoped VLM feature reuse for policy-server inference, plus a small benchmark tool to measure the effect.

The current StarVLA inference path does a full VLM forward and then predicts actions from hidden states, so this change focuses on reusing those VLM features across repeated same-session requests instead of framing the work as a full autoregressive KV-cache implementation.

In practice, this PR:
- adds a generic inference cache utility and base framework helpers
- wires cache-aware inference into `QwenPI` and `LangForce`
- adds per-connection `session_id` handling and `reset` support to the websocket policy server
- returns cache hit/miss and `predict_action_ms` metadata for measurement
- adds a standalone benchmark script and focused tests
- documents the expected cache lifecycle for repeated requests

## Why
Issue #224 is really about making repeated policy-server inference cheaper and easier to measure.

The existing deployment path already keeps a long-lived policy instance in memory, so server/session-scoped reuse is a natural fit. This keeps the scope practical and makes it possible to quantify the benefit directly in the current serving flow.

## Validation
Ran:
- `python -m unittest tests.test_inference_cache tests.test_benchmark_policy_server tests.test_server_policy`

Result:
- `16` tests passed

I also ran GPU benchmarks on an RTX 5070 Laptop GPU with `Qwen-PI-Bridge-RT-1`.

Repeated identical requests:
- `predict_action_ms`: `3822.53 -> 2177.51` (`43.03%` lower, `1.76x` faster)
- throughput: `0.26 -> 0.46 req/s` (`75.35%` higher)

Task-like `SimplerEnv bridge` real overlay input:
- `predict_action_ms`: `4118.61 -> 2448.07` (`40.56%` lower, `1.68x` faster)
- throughput: `0.24 -> 0.41 req/s` (`68.27%` higher)

In both runs, cache footprint stayed bounded at a single entry of roughly `7.4-7.5 MB`.

## Notes
This PR is intentionally scoped around cache reuse in the policy-server path. I kept broader example cleanup and extra compatibility work out of this branch so the review stays focused on the main issue.
