### PR TITLE
[fix] add optional action decoder LayerNorm to QwenPI for stabler training

### DIFF
--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -51,12 +51,24 @@ class CategorySpecificMLP(nn.Module):
 
 
 class MLP(nn.Module):
-    def __init__(self, input_dim, hidden_dim=1024, output_dim=2048):
+    def __init__(
+        self,
+        input_dim,
+        hidden_dim=1024,
+        output_dim=2048,
+        use_input_norm=False,
+    ):
         super().__init__()
+        self.norm = (
+            nn.LayerNorm(input_dim, elementwise_affine=False, eps=1e-6)
+            if use_input_norm
+            else nn.Identity()
+        )
         self.layer1 = nn.Linear(input_dim, hidden_dim)
         self.layer2 = nn.Linear(hidden_dim, output_dim)
 
     def forward(self, x):
+        x = self.norm(x)
         return self.layer2(F.relu(self.layer1(x)))
 
 
@@ -249,6 +261,7 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
             input_dim=self.input_embedding_dim,
             hidden_dim=1024,
             output_dim=self.action_dim,
+            use_input_norm=False, # set this to True will make the training loss start from a normal value
         )
         self.future_tokens = nn.Embedding(action_config.num_target_vision_tokens, self.input_embedding_dim)
         nn.init.normal_(self.future_tokens.weight, mean=0.0, std=0.02)


### PR DESCRIPTION
Refs #217

## Summary

This PR adds an optional `LayerNorm` before the QwenPI action decoder output MLP.

The placement follows the `norm_out` position used in QwenGR00T's DiT output path, so the normalization is applied at the final action-prediction stage instead of changing the earlier action/state encoder stack.

## What Changed

- Added an optional input `LayerNorm` to the action decoder MLP in QwenPI.
- Placed the normalization at the decoder output path, aligned with the `norm_out` design used by QwenGR00T's DiT.
- **Set the new switch to `false` by default so existing released checkpoints remain behaviorally compatible.**

## Validation

I validated this change on my own dataset. With this normalization enabled, the training loss starts from a smaller value.
<img width="482" height="282" alt="image" src="https://github.com/user-attachments/assets/6d1ab1c9-4460-43cc-93ec-65470feea8e7" />