### PR TITLE
[fix] resolve undefined variable and dead statement in websocket policy server message routing

### DIFF
--- a/deployment/model_server/tools/websocket_policy_server.py
+++ b/deployment/model_server/tools/websocket_policy_server.py
@@ -96,7 +96,7 @@ class WebsocketPolicyServer:
         """
         req_id = msg.get("request_id", "default")
         mtype = msg.get("type", "infer")  # default = infer
-        msg  # when no explicit payload, treat top-level as payload
+        payload = msg.get("payload", msg)  # when no explicit payload, treat top-level as payload
 
         # ping
         if mtype == "ping":
@@ -105,7 +105,7 @@ class WebsocketPolicyServer:
         # infer --> framework.predict_action
         elif mtype == "infer" or mtype == "predict_action":
             # Basic payload sanity
-            if not isinstance(msg, dict):
+            if not isinstance(payload, dict):
                 return {
                     "status": "error",
                     "ok": False,
@@ -114,8 +114,7 @@ class WebsocketPolicyServer:
                     "error": {"message": "Payload must be a dict", "payload_type": str(type(payload))},
                 }
             try:
-
-                ouput_dict = self._policy.predict_action(**msg)
+                output_dict = self._policy.predict_action(**payload)
             except Exception as e:
                 logging.exception("Policy inference error (request_id=%s)", req_id)
                 logging.exception(e)
@@ -127,10 +126,9 @@ class WebsocketPolicyServer:
                     "request_id": req_id,
                     "error": {
                         "message": str(e),
-                        # "traceback": traceback.format_exc(),
                     },
                 }
-            data = ouput_dict
+            data = output_dict
             return {
                 "status": "ok",
                 "ok": True,


### PR DESCRIPTION
## Summary

Fix three bugs in `WebsocketPolicyServer._route_message()` that cause a `NameError` crash when processing non-dict payloads, and clean up a dead statement and a typo.

## Motivation

The current `_route_message` method has several issues:
1. **Line 99**: `msg` as a standalone expression is a no-op — the intent (per the comment) was to extract the payload from the message, falling back to the top-level message itself.
2. **Line 114**: References an undefined variable `payload`, causing a `NameError` if the payload type check fails.
3. **Line 118/133**: The variable is misspelled as `ouput_dict`.

These bugs were introduced during a refactoring that intended to support both nested (`{"type": ..., "payload": {...}}`) and flat dict message formats, but the payload extraction was never implemented.

## Changes

- Replace the dead statement `msg` on line 99 with `payload = msg.get("payload", msg)` to properly extract the payload, falling back to the full message for flat dicts
- Change `isinstance(msg, dict)` to `isinstance(payload, dict)` for correct validation target
- Fix typo `ouput_dict` → `output_dict`

## Validation

- Tested with both message formats:
  - Flat: `{"examples": [...], "do_sample": false}` → correctly treated as payload
  - Nested: `{"type": "infer", "payload": {"examples": [...]}}` → payload correctly extracted
- Verified that non-dict payloads now return a proper error response instead of crashing
