### PR TITLE
[refactor] Extract BaseModelClient and deduplicate benchmark model clients

### DIFF
--- a/deployment/model_server/base_model_client.py
+++ b/deployment/model_server/base_model_client.py
@@ -1,0 +1,303 @@
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
+
+"""BaseModelClient — shared inference client for all evaluation benchmarks.
+
+This module extracts common logic that was previously duplicated across
+``model2libero_interface.py``, ``model2simpler_interface.py``,
+``model2robotwin_interface.py``, etc.  Benchmark-specific clients should
+inherit from :class:`BaseModelClient` and override only the parts that
+differ (e.g. action post-processing, step return format).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import Dict, Optional
+
+import cv2 as cv
+import numpy as np
+
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
+from starVLA.model.tools import read_mode_config
+
+try:
+    from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
+except ImportError:
+    AdaptiveEnsembler = None
+
+
+class BaseModelClient:
+    """Shared base class for all benchmark model clients.
+
+    Provides:
+        * WebSocket client setup and ``predict_action`` call
+        * Checkpoint-based action stats and chunk size loading
+        * Image resize
+        * Flexible un-normalization (``min_max`` / ``q99``)
+        * Action chunking with step-based cache
+        * Optional adaptive action ensemble
+
+    Subclasses typically only need to override :meth:`step` and, optionally,
+    :meth:`_format_raw_action`.
+    """
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+    def __init__(
+        self,
+        policy_ckpt_path: str,
+        unnorm_key: Optional[str] = None,
+        image_size: list[int] | None = None,
+        use_ddim: bool = True,
+        num_ddim_steps: int = 10,
+        normalization_mode: str = "min_max",
+        action_ensemble: bool = False,
+        action_ensemble_horizon: Optional[int] = None,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10093,
+    ) -> None:
+        if image_size is None:
+            image_size = [224, 224]
+
+        # WebSocket client
+        self.client = WebsocketClientPolicy(host, port)
+
+        # Inference config
+        self.use_ddim = use_ddim
+        self.num_ddim_steps = num_ddim_steps
+        self.image_size = image_size
+        self.normalization_mode = normalization_mode
+
+        # Load normalization stats and chunk size from checkpoint
+        self.unnorm_key = unnorm_key
+        self.action_norm_stats = self.load_action_stats(unnorm_key, policy_ckpt_path)
+        self.action_chunk_size = self.load_action_chunk_size(policy_ckpt_path)
+
+        # Optional action ensemble
+        self.action_ensemble = action_ensemble and (AdaptiveEnsembler is not None)
+        if self.action_ensemble and action_ensemble_horizon is not None:
+            self.action_ensembler = AdaptiveEnsembler(
+                action_ensemble_horizon, adaptive_ensemble_alpha
+            )
+        else:
+            self.action_ensembler = None
+
+        # Runtime state
+        self.task_description: Optional[str] = None
+        self._cached_actions: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def reset(self, task_description: str) -> None:
+        """Reset internal state for a new episode."""
+        self.task_description = task_description
+        self._cached_actions = None
+        if self.action_ensembler is not None:
+            self.action_ensembler.reset()
+
+    # ------------------------------------------------------------------
+    # Core inference helpers
+    # ------------------------------------------------------------------
+    def predict_normalized_actions(self, example: dict) -> np.ndarray:
+        """Send *example* to the policy server and return normalised actions.
+
+        Returns:
+            np.ndarray: Shape ``(chunk_size, action_dim)``.
+        """
+        vla_input = {
+            "examples": [example],
+            "do_sample": False,
+            "use_ddim": self.use_ddim,
+            "num_ddim_steps": self.num_ddim_steps,
+        }
+        response = self.client.predict_action(vla_input)
+        try:
+            normalized_actions = response["data"]["normalized_actions"]  # (B, chunk, D)
+        except KeyError:
+            raise KeyError(
+                f"Key 'normalized_actions' not found in response. "
+                f"Available keys: {list(response.get('data', {}).keys())}"
+            )
+        return np.asarray(normalized_actions[0])  # drop batch dim → (chunk, D)
+
+    def get_actions_for_step(self, example: dict, step: int) -> np.ndarray:
+        """Action-chunking helper: fetch a new chunk or reuse a cached one.
+
+        When ``step`` aligns with the chunk boundary the client issues a new
+        server call; otherwise the previously cached chunk is reused.
+
+        Returns:
+            np.ndarray: A single action vector of shape ``(action_dim,)``.
+        """
+        if step % self.action_chunk_size == 0 or self._cached_actions is None:
+            normalized_actions = self.predict_normalized_actions(example)
+            self._cached_actions = self.unnormalize_actions(
+                normalized_actions,
+                self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
+            )
+        return self._cached_actions[step % self.action_chunk_size]
+
+    # ------------------------------------------------------------------
+    # Un-normalization
+    # ------------------------------------------------------------------
+    @staticmethod
+    def unnormalize_actions(
+        normalized_actions: np.ndarray,
+        action_norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+        gripper_indices: list[int] | None = None,
+    ) -> np.ndarray:
+        """Un-normalize actions with support for ``min_max`` and ``q99`` modes.
+
+        Args:
+            normalized_actions: Shape ``(T, D)``, values in ``[-1, 1]``.
+            action_norm_stats: Dict containing bounds and optional ``"mask"``.
+            normalization_mode: ``"min_max"`` uses ``min``/``max`` keys;
+                ``"q99"`` uses ``q01``/``q99`` keys.
+            gripper_indices: Column indices treated as binary gripper outputs.
+                ``None`` (default) skips binarization entirely.  Pass an
+                explicit list (e.g. ``[6]``) to binarize specific columns.
+
+        Returns:
+            np.ndarray: Un-normalized actions, same shape as input.
+        """
+        action_high, action_low = BaseModelClient.get_normalization_bounds(
+            action_norm_stats, normalization_mode
+        )
+        mask = action_norm_stats.get("mask", np.ones_like(action_low, dtype=bool))
+        normalized_actions = np.clip(normalized_actions, -1, 1)
+
+        if gripper_indices is not None:
+            for idx in gripper_indices:
+                normalized_actions[:, idx] = np.where(
+                    normalized_actions[:, idx] < 0.5, 0, 1
+                )
+
+        actions = np.where(
+            mask,
+            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
+            normalized_actions,
+        )
+        return actions
+
+    # ------------------------------------------------------------------
+    # Image utilities
+    # ------------------------------------------------------------------
+    def resize_image(self, image: np.ndarray) -> np.ndarray:
+        """Resize *image* to :attr:`image_size` using INTER_AREA interpolation."""
+        return cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
+
+    # ------------------------------------------------------------------
+    # Checkpoint loading utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def load_action_stats(
+        unnorm_key: Optional[str],
+        policy_ckpt_path: str,
+        action_mode: str = "abs",
+    ) -> dict:
+        """Load action normalisation statistics from a checkpoint.
+
+        Supports two checkpoint stat formats:
+
+        * *New*: ``{key: {"abs": {…}, "delta": {…}, …}}``
+        * *Legacy*: ``{key: {"action": {…}, "state": {…}}}``
+        """
+        policy_ckpt_path = Path(policy_ckpt_path)
+        _, norm_stats = read_mode_config(policy_ckpt_path)
+        unnorm_key = BaseModelClient._resolve_unnorm_key(norm_stats, unnorm_key)
+        stats = norm_stats[unnorm_key]
+
+        # New format: per-action-mode stats
+        if action_mode in stats:
+            mode_stats = stats[action_mode]
+            return mode_stats.get("action", mode_stats)
+        # Legacy format
+        if "action" in stats:
+            if action_mode != "abs":
+                raise ValueError(
+                    f"Statistics for '{unnorm_key}' only provide 'abs' action stats, "
+                    f"but action_mode='{action_mode}' was requested."
+                )
+            return stats["action"]
+        raise ValueError(
+            f"Invalid statistics format for key '{unnorm_key}'. "
+            f"Available sub-keys: {sorted(stats.keys())}"
+        )
+
+    @staticmethod
+    def load_state_stats(
+        unnorm_key: Optional[str],
+        policy_ckpt_path: str,
+    ) -> dict:
+        """Load state normalisation statistics from a checkpoint."""
+        policy_ckpt_path = Path(policy_ckpt_path)
+        _, norm_stats = read_mode_config(policy_ckpt_path)
+        unnorm_key = BaseModelClient._resolve_unnorm_key(norm_stats, unnorm_key)
+        return norm_stats[unnorm_key]["state"]
+
+    @staticmethod
+    def load_action_chunk_size(policy_ckpt_path: str) -> int:
+        """Read the action chunk size from the model config."""
+        model_config, _ = read_mode_config(Path(policy_ckpt_path))
+        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
+
+    # ------------------------------------------------------------------
+    # Normalization bound helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_normalization_bounds(
+        norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return ``(high, low)`` bounds for un-normalization.
+
+        Args:
+            normalization_mode: ``"min_max"`` → ``(max, min)`` keys;
+                ``"q99"`` → ``(q99, q01)`` keys.
+        """
+        key_map = {
+            "min_max": ("max", "min"),
+            "q99": ("q99", "q01"),
+        }
+        if normalization_mode not in key_map:
+            raise ValueError(
+                f"Unsupported normalization_mode '{normalization_mode}'. "
+                f"Expected one of {sorted(key_map.keys())}."
+            )
+        high_key, low_key = key_map[normalization_mode]
+        if high_key not in norm_stats or low_key not in norm_stats:
+            raise KeyError(
+                f"Normalization mode '{normalization_mode}' requires keys "
+                f"'{high_key}' and '{low_key}', but available keys are: "
+                f"{sorted(norm_stats.keys())}"
+            )
+        return np.array(norm_stats[high_key]), np.array(norm_stats[low_key])
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_unnorm_key(
+        norm_stats: dict, unnorm_key: Optional[str]
+    ) -> str:
+        """Pick the correct dataset key inside *norm_stats*."""
+        if unnorm_key is None:
+            if len(norm_stats) == 1:
+                return next(iter(norm_stats.keys()))
+            raise ValueError(
+                "Model was trained on multiple datasets; please supply "
+                f"`unnorm_key` from: {sorted(norm_stats.keys())}"
+            )
+        if unnorm_key not in norm_stats:
+            raise KeyError(
+                f"Unknown unnorm_key '{unnorm_key}'. "
+                f"Available: {sorted(norm_stats.keys())}"
+            )
+        return unnorm_key

--- a/examples/Behavior/model2behavior_interface.py
+++ b/examples/Behavior/model2behavior_interface.py
@@ -1,6 +1,16 @@
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
+
+"""BEHAVIOR benchmark model client (R1Pro robot).
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+BEHAVIOR-specific features: multi-camera observation extraction, 23-DoF
+R1Pro action decomposition, and chunked adaptive action ensembling.
+"""
+
+from __future__ import annotations
+
 import os
-from collections import deque
-from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
 import cv2 as cv
@@ -11,31 +21,30 @@ import torch
 # Import BEHAVIOR-specific utilities
 from omnigibson.learning.utils.eval_utils import PROPRIOCEPTION_INDICES, ROBOT_CAMERA_NAMES
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from examples.Behavior.adaptive_ensemble import AdaptiveEnsembler, ChunkedAdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
+from deployment.model_server.base_model_client import BaseModelClient
+from examples.Behavior.adaptive_ensemble import ChunkedAdaptiveEnsembler
 
 
-def start_debugpy_once():
-    """start debugpy once"""
-    import debugpy
+class M1Inference(BaseModelClient):
+    """Model client for the BEHAVIOR benchmark with R1Pro robot.
 
-    if getattr(start_debugpy_once, "_started", False):
-        return
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Waiting for VSCode attach on 0.0.0.0:10092 ...")
-    debugpy.wait_for_client()
-    start_debugpy_once._started = True
+    23-DoF action space decomposition::
 
+        base_pose        (3)  — indices  0:3
+        torso_pose       (4)  — indices  3:7
+        left_arm_pose    (7)  — indices  7:14
+        left_gripper     (1)  — index   14
+        right_arm_pose   (7)  — indices 15:22
+        right_gripper    (1)  — index   22
+    """
 
-class M1Inference:
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         policy_setup: str = "R1Pro",
         horizon: int = 0,
         action_ensemble_horizon: Optional[int] = None,
-        image_size: list[int] = [224, 224],
+        image_size: list[int] | None = None,
         action_scale: float = 1.0,
         cfg_scale: float = 1.5,
         use_ddim: bool = True,
@@ -44,79 +53,80 @@ class M1Inference:
         adaptive_ensemble_alpha: float = 0.1,
         host: str = "0.0.0.0",
         port: int = 10093,
-        task_description: str = None,
+        task_description: Optional[str] = None,
         use_state: bool = False,
     ) -> None:
+        if policy_setup != "R1Pro":
+            raise NotImplementedError(
+                f"Policy setup '{policy_setup}' not supported for BEHAVIOR models."
+            )
 
-        # build client to connect server policy
-        self.client = WebsocketClientPolicy(host, port)
+        if image_size is None:
+            image_size = [224, 224]
 
+        # R1Pro defaults
+        unnorm_key = "R1Pro"
+        if action_ensemble_horizon is None:
+            action_ensemble_horizon = 5
+        # Force ensemble on for BEHAVIOR
         action_ensemble = True
 
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-        # Robot type for BEHAVIOR
-        if policy_setup == "R1Pro":
-            unnorm_key = "R1Pro"
-            if action_ensemble_horizon is None:
-                action_ensemble_horizon = 5
-            self.sticky_gripper_num_repeat = 3
-        else:
-            raise NotImplementedError(f"Policy setup {policy_setup} not supported for BEHAVIOR models.")
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode="min_max",
+            action_ensemble=False,  # We handle ensemble ourselves via ChunkedAdaptiveEnsembler
+            host=host,
+            port=port,
+        )
 
         self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
-        self.action_ensemble = action_ensemble
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
         self.policy_ckpt_path = policy_ckpt_path
-
-        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
         self.cfg_scale = cfg_scale
-        self.image_size = image_size
         self.action_scale = action_scale
         self.horizon = horizon
+        self.use_state = use_state
+        self.sticky_gripper_num_repeat = 3
 
-        # Gripper control state
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-        # initial
+        # BEHAVIOR uses 2-step action chunks with ChunkedAdaptiveEnsembler
         self.action_chunk_size = 2
         self.current_step = 0
 
-        # Task and image history
-        self.task_description = task_description
-        self.image_history = deque(maxlen=self.horizon)
+        # Gripper state
+        self.sticky_action_is_on = False
+        self.gripper_action_repeat = 0
+        self.sticky_gripper_action = 0.0
+        self.previous_gripper_action = None
+
+        # Override task description if provided at init
+        if task_description is not None:
+            self.task_description = task_description
+
+        # Chunked ensemble (BEHAVIOR-specific, handles multi-step chunks)
+        self.action_ensemble = action_ensemble
         if self.action_ensemble:
-            if self.action_chunk_size > 1:
-                self.action_ensembler = ChunkedAdaptiveEnsembler(
-                    self.action_ensemble_horizon, self.action_chunk_size, self.adaptive_ensemble_alpha
-                )
-            else:
-                self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
+            self.chunked_ensembler = ChunkedAdaptiveEnsembler(
+                action_ensemble_horizon, self.action_chunk_size, adaptive_ensemble_alpha
+            )
         else:
-            self.action_ensembler = None
-        self.num_image_history = 0
+            self.chunked_ensembler = None
 
-        # Load action normalization stats
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
 
-        self.use_state = use_state
-
-        # If want to debug, uncomment the following line
-        # if os.getenv("DEBUG", False):
-        #     start_debugpy_once()
-
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
     def reset(self, task_description: Optional[str] = None) -> None:
         if task_description is not None:
             self.task_description = task_description
-        if self.action_ensemble:
-            self.action_ensembler.reset()
+        if self.chunked_ensembler is not None:
+            self.chunked_ensembler.reset()
+        self._cached_actions = None
 
         self.sticky_action_is_on = False
         self.gripper_action_repeat = 0
@@ -124,64 +134,25 @@ class M1Inference:
         self.previous_gripper_action = None
         self.current_step = 0
 
-    def _generate_prop_state(self, proprio: np.ndarray) -> np.ndarray:
-        """Generate proprioceptive state for R1Pro robot."""
-        idx = PROPRIOCEPTION_INDICES[self.policy_setup]
-        qpos_list = [
-            proprio[idx["joint_qpos_sin"]][6:],  # First 6 are base joints, which is NOT allowed in standard track
-            proprio[idx["joint_qpos_cos"]][6:],  # First 6 are base joints, which is NOT allowed in standard track
-        ]
-        assert qpos_list[0].shape == (22,)
-        assert qpos_list[1].shape == (22,)
-        return np.concatenate(qpos_list, axis=0)
-
-    def _process_behavior_obs(self, obs: Dict[str, Any]) -> Dict[str, Any]:
-        """Process BEHAVIOR observations to extract images and proprioception."""
-        # Extract images from different camera views
-        try:
-            head_camera_key = ROBOT_CAMERA_NAMES[self.policy_setup]["head"] + "::rgb"
-            left_wrist_camera_key = ROBOT_CAMERA_NAMES[self.policy_setup]["left_wrist"] + "::rgb"
-            right_wrist_camera_key = ROBOT_CAMERA_NAMES[self.policy_setup]["right_wrist"] + "::rgb"
-
-            full_image = obs[head_camera_key][:, :, :3]  # [224, 224, 3]
-            left_wrist_image = obs[left_wrist_camera_key][:, :, :3]  # [224, 224, 3]
-            right_wrist_image = obs[right_wrist_camera_key][:, :, :3]  # [224, 224, 3]
-            prop_state = self._generate_prop_state(obs["robot_r1::proprio"])
-
-        except KeyError as e:
-            print(f"Error extracting observations: {e}")
-            print(f"Available keys in obs: {list(obs.keys())}")
-            raise
-
-        # Resize images to policy input size
-        full_image = self._resize_image(full_image)
-        left_wrist_image = self._resize_image(left_wrist_image)
-        right_wrist_image = self._resize_image(right_wrist_image)
-
-        return {
-            "full_image": full_image,
-            "left_wrist_image": left_wrist_image,
-            "right_wrist_image": right_wrist_image,
-            "state": prop_state,
-        }
-
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def forward(self, obs: Dict[str, Any]) -> torch.Tensor:
-        """
-        Forward pass for BEHAVIOR environment.
+        """Forward pass for BEHAVIOR environment.
 
         Args:
-            obs: Dictionary containing observations from BEHAVIOR environment
+            obs: Observation dict from BEHAVIOR/OmniGibson environment.
 
         Returns:
-            torch.Tensor: Action tensor for the robot
+            torch.Tensor: Action tensor of shape ``(23,)`` for R1Pro.
         """
-        # Process observations to extract images and proprioception
         processed_obs = self._process_behavior_obs(obs)
 
-        # Use the head camera image as the primary input
+        # Build image inputs
         primary_image = processed_obs["full_image"]
         left_wrist_image = processed_obs["left_wrist_image"]
         right_wrist_image = processed_obs["right_wrist_image"]
+
         if "dual" in self.policy_ckpt_path.lower():
             image_input = [primary_image]
             wrist_image_input = [left_wrist_image, right_wrist_image]
@@ -189,84 +160,62 @@ class M1Inference:
             image_input = [primary_image, left_wrist_image, right_wrist_image]
             wrist_image_input = None
 
-        # Get task description from environment if not already set
         if self.task_description is None:
-            # Try to get task description from the environment
-            # This assumes the environment has a task attribute with show_instruction method
             print("Warning: Could not get task description")
             self.task_description = "Turn on the radio receiver that's on the table in the living room."
 
-        # Prepare proprioceptive state.
-        # GR00T action header expects state tensor to have shape (B, T_s, state_dim)
-        # so that after the MLP it becomes (B, T_s, hidden).  If we pass a simple
-        # 1-D vector the downstream `torch.cat` fails because the ranks differ.
-        # Therefore, when state is enabled we reshape it to (1, 1, state_dim).
-
-        if self.use_state:
-            raw_state = processed_obs["state"]  # shape (state_dim,)
-            state = raw_state[None, :]  # → (1, state_dim)
-            example = {
-                "image": image_input,
-                "wrist_views": wrist_image_input,
-                "state": state,
-                "lang": self.task_description,
-            }
-        else:
-            example = {
-                "image": image_input,
-                "wrist_views": wrist_image_input,
-                "lang": self.task_description,
-            }
-
-        vla_input = {
-            "examples": [example],
+        # Build example dict
+        example = {
+            "image": image_input,
+            "wrist_views": wrist_image_input,
+            "lang": self.task_description,
         }
+        if self.use_state:
+            raw_state = processed_obs["state"]  # (state_dim,)
+            example["state"] = raw_state[None, :]  # → (1, state_dim)
 
-        # Get action from websocket server
-        action_chunk_size = self.action_chunk_size
-        if self.current_step % action_chunk_size == 0:
+        vla_input = {"examples": [example]}
+
+        # Action chunking with ensemble
+        if self.current_step % self.action_chunk_size == 0:
             if self.current_step % 100 == 0:
                 print("Step:", self.current_step)
-            response = self.client.infer(vla_input)
 
-            # Check if the response indicates an error
-            if response.get("ok", True) == False or response.get("status") == "error":
+            response = self.client.predict_action(vla_input)
+
+            if response.get("ok", True) is False or response.get("status") == "error":
                 error_info = response.get("error", {})
-                print("Websocket server returned an error:")
-                print(f"Status: {response.get('status')}")
-                print(f"Error details: {error_info}")
                 raise RuntimeError(f"Websocket server error: {error_info}")
 
-            # Extract and unnormalize actions
             try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError as e:
-                print(f"KeyError accessing response: {e}")
-                print(f"Available keys in response: {list(response.keys())}")
-                if "data" in response:
-                    print(f"Keys in 'data': {list(response['data'].keys())}")
-                raise
-            # Take the first batch element (B dimension) → shape (T, D)
-            normalized_actions = normalized_actions[0]
-            # Un-normalize to get real-valued actions. Still shape (T, D)
+                normalized_actions = response["data"]["normalized_actions"]  # (B, chunk, D)
+            except KeyError:
+                raise KeyError(
+                    f"Key 'normalized_actions' not found. "
+                    f"Available: {list(response.get('data', {}).keys())}"
+                )
+
+            normalized_actions = normalized_actions[0]  # drop batch → (T, D)
             self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
+                normalized_actions,
+                self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
+                gripper_indices=None,  # No gripper binarization for BEHAVIOR
             )
 
-            # Apply action ensembling if enabled
-            if self.action_ensemble and action_chunk_size > 1:
-                self.action_ensembler.ensemble_action(self.raw_actions)
+            # Feed chunk to chunked ensembler
+            if self.action_ensemble and self.action_chunk_size > 1:
+                self.chunked_ensembler.ensemble_action(self.raw_actions)
 
+        # Get single action from ensemble or cache
         if self.action_ensemble:
-            if action_chunk_size == 1:
-                raw_actions = self.action_ensembler.ensemble_action(self.raw_actions)[None]
-            else:
-                raw_actions = self.action_ensembler.step()[None]
+            raw_actions = self.chunked_ensembler.step()[None]
         else:
-            raw_actions = self.raw_actions[self.current_step % action_chunk_size][None]
+            raw_actions = self.raw_actions[self.current_step % self.action_chunk_size][None]
+
         self.current_step += 1
 
-        # Process raw actions for BEHAVIOR environment
+        # Decompose into R1Pro body parts
         raw_action = {
             "base_pose": np.array(raw_actions[0, :3]),
             "torso_pose": np.array(raw_actions[0, 3:7]),
@@ -276,103 +225,103 @@ class M1Inference:
             "right_gripper_pose": np.array(raw_actions[0, 22:23]),
         }
 
-        # Convert to BEHAVIOR action format
         action = self._process_action_for_behavior(raw_action)
-
         return torch.from_numpy(action).float()
 
-    def _process_action_for_behavior(self, raw_action: Dict[str, np.ndarray]) -> np.ndarray:
-        """Process raw action to BEHAVIOR environment format."""
-        # Process base, torso, left arm, right arm
-        base_pose = raw_action["base_pose"]
-        torso_pose = raw_action["torso_pose"]
-        left_arm_pose = raw_action["left_arm_pose"]
-        right_arm_pose = raw_action["right_arm_pose"]
+    # ------------------------------------------------------------------
+    # BEHAVIOR-specific observation processing
+    # ------------------------------------------------------------------
+    def _process_behavior_obs(self, obs: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract and resize images + proprioception from BEHAVIOR obs."""
+        try:
+            head_key = ROBOT_CAMERA_NAMES[self.policy_setup]["head"] + "::rgb"
+            left_key = ROBOT_CAMERA_NAMES[self.policy_setup]["left_wrist"] + "::rgb"
+            right_key = ROBOT_CAMERA_NAMES[self.policy_setup]["right_wrist"] + "::rgb"
 
-        # Process gripper action
-        left_gripper_pose = self._process_gripper_action(raw_action["left_gripper_pose"])
-        right_gripper_pose = self._process_gripper_action(raw_action["right_gripper_pose"])
+            full_image = obs[head_key][:, :, :3]
+            left_wrist_image = obs[left_key][:, :, :3]
+            right_wrist_image = obs[right_key][:, :, :3]
+            prop_state = self._generate_prop_state(obs["robot_r1::proprio"])
+        except KeyError as e:
+            print(f"Error extracting observations: {e}")
+            print(f"Available keys in obs: {list(obs.keys())}")
+            raise
 
-        # Combine all actions into a single array
-        # BEHAVIOR expects "ACTION_DIM": 23
-        # See the following files:
-        # - ACTION_QPOS_INDICES in omnigibson/learning/utils/eval_utils.py
-        # - action_keys in omnigibson/learning/configs/robot/r1pro.yaml
-        action = np.concatenate(
-            [
-                base_pose,  # indices 0:3   (3 dims)
-                torso_pose,  # indices 3:7   (4 dims)
-                left_arm_pose,  # indices 7:14  (7 dims)
-                np.array([left_gripper_pose]),  # index  14:15  (1 dim)
-                right_arm_pose,  # indices 15:22 (7 dims)
-                np.array([right_gripper_pose]),  # index  22:23  (1 dim)
-            ]
-        )
+        return {
+            "full_image": self._resize_behavior_image(full_image),
+            "left_wrist_image": self._resize_behavior_image(left_wrist_image),
+            "right_wrist_image": self._resize_behavior_image(right_wrist_image),
+            "state": prop_state,
+        }
 
-        return action
+    def _generate_prop_state(self, proprio: np.ndarray) -> np.ndarray:
+        """Generate proprioceptive state for R1Pro robot."""
+        idx = PROPRIOCEPTION_INDICES[self.policy_setup]
+        qpos_list = [
+            proprio[idx["joint_qpos_sin"]][6:],  # Skip first 6 base joints (standard track)
+            proprio[idx["joint_qpos_cos"]][6:],
+        ]
+        assert qpos_list[0].shape == (22,)
+        assert qpos_list[1].shape == (22,)
+        return np.concatenate(qpos_list, axis=0)
 
-    def _process_gripper_action(self, open_gripper: np.ndarray) -> float:
-        """Process gripper action with sticky behavior for BEHAVIOR environment."""
-        # We currently don't apply any other sticky behavior for gripper action.
-        current_gripper_action = open_gripper[0]
+    def _resize_behavior_image(self, image: np.ndarray) -> np.ndarray:
+        """Resize image, handling both numpy arrays and torch tensors."""
+        if hasattr(image, "numpy"):
+            image = image.numpy()
+        return self.resize_image(image)
 
-        return current_gripper_action
-
+    # ------------------------------------------------------------------
+    # Action processing
+    # ------------------------------------------------------------------
     @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        """Unnormalize actions using the provided statistics."""
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
+    def _process_action_for_behavior(raw_action: Dict[str, np.ndarray]) -> np.ndarray:
+        """Combine body-part actions into the 23-D vector expected by BEHAVIOR."""
+        return np.concatenate([
+            raw_action["base_pose"],           # 0:3   (3 dims)
+            raw_action["torso_pose"],          # 3:7   (4 dims)
+            raw_action["left_arm_pose"],       # 7:14  (7 dims)
+            raw_action["left_gripper_pose"],   # 14:15 (1 dim)
+            raw_action["right_arm_pose"],      # 15:22 (7 dims)
+            raw_action["right_gripper_pose"],  # 22:23 (1 dim)
+        ])
 
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
     @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """Load action normalization statistics from checkpoint."""
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
+    def get_action_stats(unnorm_key, policy_ckpt_path, **kwargs):
+        return BaseModelClient.load_action_stats(unnorm_key, policy_ckpt_path)
 
-        return norm_stats[unnorm_key]["action"]
-
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        """Resize image to policy input size."""
-
-        image = image.numpy()
-
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
+    # ------------------------------------------------------------------
+    # Visualisation
+    # ------------------------------------------------------------------
     def visualize_epoch(
-        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+        self,
+        predicted_raw_actions: Sequence[np.ndarray],
+        images: Sequence[np.ndarray],
+        save_path: str,
     ) -> None:
-        """Visualize predicted actions and images."""
-        images = [self._resize_image(image) for image in images]
+        images = [self._resize_behavior_image(img) for img in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
 
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
 
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
-                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                np.concatenate(
+                    [a["world_vector"], a["rotation_delta"], a["open_gripper"]],
+                    axis=-1,
+                )
                 for a in predicted_raw_actions
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")

--- a/examples/LIBERO-plus/eval_files/model2libero_interface.py
+++ b/examples/LIBERO-plus/eval_files/model2libero_interface.py
@@ -1,220 +1,162 @@
-from collections import deque
-from pathlib import Path
-from typing import Dict, Optional, Sequence
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
 
-import cv2 as cv
+"""LIBERO-plus benchmark model client.
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+LIBERO-specific action formatting (7-DoF single-arm with binary gripper).
+
+This is functionally identical to the LIBERO client — both benchmarks use
+the same Franka action space and gripper convention.
+"""
+
+from typing import Optional, Sequence
+
 import matplotlib.pyplot as plt
 import numpy as np
-from ABot.model.tools import read_mode_config
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-
-
-class AdaptiveEnsembler:
-    def __init__(self, pred_action_horizon, adaptive_ensemble_alpha=0.0):
-        self.pred_action_horizon = pred_action_horizon
-        self.action_history = deque(maxlen=self.pred_action_horizon)
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-
-    def reset(self):
-        self.action_history.clear()
-
-    def ensemble_action(self, cur_action):
-        self.action_history.append(cur_action)
-        num_actions = len(self.action_history)
-        if cur_action.ndim == 1:
-            curr_act_preds = np.stack(self.action_history)
-        else:
-            curr_act_preds = np.stack(
-                [pred_actions[i] for (i, pred_actions) in zip(range(num_actions - 1, -1, -1), self.action_history)]
-            )
-
-        # calculate cosine similarity between the current prediction and all previous predictions
-        ref = curr_act_preds[num_actions - 1, :]
-        previous_pred = curr_act_preds
-        dot_product = np.sum(previous_pred * ref, axis=1)
-        norm_previous_pred = np.linalg.norm(previous_pred, axis=1)
-        norm_ref = np.linalg.norm(ref)
-        cos_similarity = dot_product / (norm_previous_pred * norm_ref + 1e-7)
-
-        # compute the weights for each prediction
-        weights = np.exp(self.adaptive_ensemble_alpha * cos_similarity)
-        weights = weights / weights.sum()
-
-        # compute the weighted average across all predictions for this timestep
-        cur_action = np.sum(weights[:, None] * curr_act_preds, axis=0)
-
-        return cur_action
+from deployment.model_server.base_model_client import BaseModelClient
 
 
-class ModelClient:
+class ModelClient(BaseModelClient):
+    """Model client for the LIBERO-plus benchmark.
+
+    Expected *example* dict layout::
+
+        {
+            "image": [primary_img, wrist_img],  # list[np.ndarray], uint8
+            "lang":  "task description",
+        }
+    """
+
+    # Gripper is the last (7th) column for LIBERO's single-arm Franka
+    _GRIPPER_INDICES = [6]
+
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "franka",
-        horizon: int = 0,
-        action_ensemble=True,
-        action_ensemble_horizon: Optional[int] = 3,  # different cross sim
-        image_size: list[int] = [224, 224],
+        image_size: list[int] | None = None,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        adaptive_ensemble_alpha=0.1,
-        host="0.0.0.0",
-        port=10095,
+        action_ensemble: bool = True,
+        action_ensemble_horizon: Optional[int] = 3,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10095,
+        # Legacy kwargs accepted for backward compatibility
+        **kwargs,
     ) -> None:
-
-        # build client to connect server policy
-        self.client = WebsocketClientPolicy(host, port)
-        self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
-
-        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
-        self.image_size = image_size
-        self.horizon = horizon  # 0
-        self.action_ensemble = action_ensemble
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-        self.task_description = None
-        self.image_history = deque(maxlen=self.horizon)
-        if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
-        else:
-            self.action_ensembler = None
-        self.num_image_history = 0
-
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
-
-    def _add_image_to_history(self, image: np.ndarray) -> None:
-        self.image_history.append(image)
-        self.num_image_history = min(self.num_image_history + 1, self.horizon)
-
-    def reset(self, task_description: str) -> None:
-        self.task_description = task_description
-        self.image_history.clear()
-        if self.action_ensemble:
-            self.action_ensembler.reset()
-        self.num_image_history = 0
-
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-    def step(self, example: dict, step: int = 0, **kwargs) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
-        """
-        Perform one step of inference
-        :param image: Input image in the format (H, W, 3), type uint8
-        :param task_description: Task description text
-        :return: (raw action, processed action)
-        """
-
-        task_description = example.get("lang", None)
-        images = example["image"]  # list of images for history
-
-        if example is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
-
-        images = [self._resize_image(image) for image in images]
-        example["image"] = images
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
-
-        action_chunk_size = self.action_chunk_size
-        if step % action_chunk_size == 0:
-            response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-            )
-
-        raw_actions = self.raw_actions[step % action_chunk_size][None]
-
-        raw_action = {
-            "world_vector": np.array(raw_actions[0, :3]),
-            "rotation_delta": np.array(raw_actions[0, 3:6]),
-            "open_gripper": np.array(raw_actions[0, 6:7]),  # range [0, 1]; 1 = open; 0 = close
-        }
-
-        return {"raw_action": raw_action}
-
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
+        if image_size is None:
+            image_size = [224, 224]
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode="min_max",
+            action_ensemble=action_ensemble,
+            action_ensemble_horizon=action_ensemble_horizon,
+            adaptive_ensemble_alpha=adaptive_ensemble_alpha,
+            host=host,
+            port=port,
         )
+        self.policy_setup = policy_setup
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
 
-        return actions
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        example: dict,
+        step: int = 0,
+        **kwargs,
+    ) -> dict[str, dict[str, np.ndarray]]:
+        """Run one inference step and return the raw 7-DoF action.
+
+        Returns:
+            ``{"raw_action": {"world_vector": (3,), "rotation_delta": (3,),
+            "open_gripper": (1,)}}``
+        """
+        task_description = example.get("lang", None)
+        if task_description != self.task_description:
+            self.reset(task_description)
+
+        # Resize images in-place
+        example["image"] = [self.resize_image(img) for img in example["image"]]
+
+        # Fetch (or reuse cached) un-normalized action
+        raw_action_vec = self.get_actions_for_step(example, step)
+
+        return {"raw_action": self._format_raw_action(raw_action_vec)}
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+    def get_actions_for_step(self, example: dict, step: int) -> np.ndarray:
+        """Override to use LIBERO-specific gripper binarization."""
+        if step % self.action_chunk_size == 0 or self._cached_actions is None:
+            normalized = self.predict_normalized_actions(example)
+            self._cached_actions = self.unnormalize_actions(
+                normalized,
+                self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
+                gripper_indices=self._GRIPPER_INDICES,
+            )
+        return self._cached_actions[step % self.action_chunk_size]
 
     @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
+    def _format_raw_action(action: np.ndarray) -> dict[str, np.ndarray]:
+        """Split a flat 7-D action into the named dict expected by LIBERO."""
+        return {
+            "world_vector": action[:3],
+            "rotation_delta": action[3:6],
+            "open_gripper": action[6:7],  # range [0, 1]; 1 = open, 0 = close
+        }
 
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_action_stats(unnorm_key, policy_ckpt_path, **kwargs):
+        return BaseModelClient.load_action_stats(unnorm_key, policy_ckpt_path)
 
     @staticmethod
     def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-        # import ipdb; ipdb.set_trace()
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
+        return BaseModelClient.load_action_chunk_size(policy_ckpt_path)
 
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
+    # ------------------------------------------------------------------
+    # Visualisation
+    # ------------------------------------------------------------------
     def visualize_epoch(
-        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+        self,
+        predicted_raw_actions: Sequence[np.ndarray],
+        images: Sequence[np.ndarray],
+        save_path: str,
     ) -> None:
-        images = [self._resize_image(image) for image in images]
+        images = [self.resize_image(img) for img in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
 
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
 
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
-                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                np.concatenate(
+                    [a["world_vector"], a["rotation_delta"], a["open_gripper"]],
+                    axis=-1,
+                )
                 for a in predicted_raw_actions
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")
@@ -223,23 +165,3 @@ class ModelClient:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key

--- a/examples/LIBERO/eval_files/model2libero_interface.py
+++ b/examples/LIBERO/eval_files/model2libero_interface.py
@@ -1,184 +1,159 @@
-from collections import deque
-from pathlib import Path
-from typing import Dict, Optional, Sequence
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
 
-import cv2 as cv
+"""LIBERO benchmark model client.
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+LIBERO-specific action formatting (7-DoF single-arm with binary gripper).
+"""
+
+from typing import Optional, Sequence
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
+from deployment.model_server.base_model_client import BaseModelClient
 
 
-class ModelClient:
+class ModelClient(BaseModelClient):
+    """Model client for the LIBERO benchmark family.
+
+    Expected *example* dict layout::
+
+        {
+            "image": [primary_img, wrist_img],  # list[np.ndarray], uint8
+            "lang":  "task description",
+        }
+    """
+
+    # Gripper is the last (7th) column for LIBERO's single-arm Franka
+    _GRIPPER_INDICES = [6]
+
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "franka",
-        horizon: int = 0,
-        action_ensemble=True,
-        action_ensemble_horizon: Optional[int] = 3,  # different cross sim
-        image_size: list[int] = [224, 224],
+        image_size: list[int] | None = None,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        adaptive_ensemble_alpha=0.1,
-        host="0.0.0.0",
-        port=10095,
+        action_ensemble: bool = True,
+        action_ensemble_horizon: Optional[int] = 3,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10095,
+        # Legacy kwargs accepted for backward compatibility
+        **kwargs,
     ) -> None:
-
-        # build client to connect server policy
-        self.client = WebsocketClientPolicy(host, port)
-        self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
-
-        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
-        self.image_size = image_size
-        self.horizon = horizon  # 0
-        self.action_ensemble = action_ensemble
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-        self.task_description = None
-        self.image_history = deque(maxlen=self.horizon)
-        if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
-        else:
-            self.action_ensembler = None
-        self.num_image_history = 0
-
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
-
-    def _add_image_to_history(self, image: np.ndarray) -> None:
-        self.image_history.append(image)
-        self.num_image_history = min(self.num_image_history + 1, self.horizon)
-
-    def reset(self, task_description: str) -> None:
-        self.task_description = task_description
-        self.image_history.clear()
-        if self.action_ensemble:
-            self.action_ensembler.reset()
-        self.num_image_history = 0
-
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-    def step(self, example: dict, step: int = 0, **kwargs) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
-        """
-        Perform one step of inference
-        :param image: Input image in the format (H, W, 3), type uint8
-        :param task_description: Task description text
-        :return: (raw action, processed action)
-        """
-
-        task_description = example.get("lang", None)
-        images = example["image"]  # list of images for history
-
-        if example is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
-
-        images = [self._resize_image(image) for image in images]
-        example["image"] = images
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
-
-        action_chunk_size = self.action_chunk_size
-        if step % action_chunk_size == 0:
-            response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-            )
-
-        raw_actions = self.raw_actions[step % action_chunk_size][None]
-
-        raw_action = {
-            "world_vector": np.array(raw_actions[0, :3]),
-            "rotation_delta": np.array(raw_actions[0, 3:6]),
-            "open_gripper": np.array(raw_actions[0, 6:7]),  # range [0, 1]; 1 = open; 0 = close
-        }
-
-        return {"raw_action": raw_action}
-
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
+        if image_size is None:
+            image_size = [224, 224]
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode="min_max",
+            action_ensemble=action_ensemble,
+            action_ensemble_horizon=action_ensemble_horizon,
+            adaptive_ensemble_alpha=adaptive_ensemble_alpha,
+            host=host,
+            port=port,
         )
+        self.policy_setup = policy_setup
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
 
-        return actions
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        example: dict,
+        step: int = 0,
+        **kwargs,
+    ) -> dict[str, dict[str, np.ndarray]]:
+        """Run one inference step and return the raw 7-DoF action.
+
+        Returns:
+            ``{"raw_action": {"world_vector": (3,), "rotation_delta": (3,),
+            "open_gripper": (1,)}}``
+        """
+        task_description = example.get("lang", None)
+        if task_description != self.task_description:
+            self.reset(task_description)
+
+        # Resize images in-place
+        example["image"] = [self.resize_image(img) for img in example["image"]]
+
+        # Fetch (or reuse cached) un-normalized action
+        raw_action_vec = self.get_actions_for_step(example, step)
+
+        return {"raw_action": self._format_raw_action(raw_action_vec)}
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+    def get_actions_for_step(self, example: dict, step: int) -> np.ndarray:
+        """Override to use LIBERO-specific gripper binarization."""
+        if step % self.action_chunk_size == 0 or self._cached_actions is None:
+            normalized = self.predict_normalized_actions(example)
+            self._cached_actions = self.unnormalize_actions(
+                normalized,
+                self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
+                gripper_indices=self._GRIPPER_INDICES,
+            )
+        return self._cached_actions[step % self.action_chunk_size]
 
     @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
+    def _format_raw_action(action: np.ndarray) -> dict[str, np.ndarray]:
+        """Split a flat 7-D action into the named dict expected by LIBERO."""
+        return {
+            "world_vector": action[:3],
+            "rotation_delta": action[3:6],
+            "open_gripper": action[6:7],  # range [0, 1]; 1 = open, 0 = close
+        }
 
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_action_stats(unnorm_key, policy_ckpt_path, **kwargs):
+        return BaseModelClient.load_action_stats(unnorm_key, policy_ckpt_path)
 
     @staticmethod
     def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-        # import ipdb; ipdb.set_trace()
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
+        return BaseModelClient.load_action_chunk_size(policy_ckpt_path)
 
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
+    # ------------------------------------------------------------------
+    # Visualisation
+    # ------------------------------------------------------------------
     def visualize_epoch(
-        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+        self,
+        predicted_raw_actions: Sequence[np.ndarray],
+        images: Sequence[np.ndarray],
+        save_path: str,
     ) -> None:
-        images = [self._resize_image(image) for image in images]
+        images = [self.resize_image(img) for img in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
 
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
 
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
-                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                np.concatenate(
+                    [a["world_vector"], a["rotation_delta"], a["open_gripper"]],
+                    axis=-1,
+                )
                 for a in predicted_raw_actions
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")
@@ -187,23 +162,3 @@ class ModelClient:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key

--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -1,124 +1,138 @@
-from collections import deque
-from pathlib import Path
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
+
+"""Robocasa tabletop benchmark model client.
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+Robocasa-specific features: batched multi-view inference, sin/cos state
+encoding, and structured multi-body-part action outputs.
+"""
+
+from __future__ import annotations
+
 from typing import Dict, Optional, Sequence
 
 import cv2 as cv
 import matplotlib.pyplot as plt
 import numpy as np
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from examples.Robocasa_tabletop.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.framework.share_tools import read_mode_config
+from deployment.model_server.base_model_client import BaseModelClient
 
 
-class PolicyWarper:
+class PolicyWarper(BaseModelClient):
+    """Model client for the Robocasa tabletop benchmark.
+
+    Key differences from other benchmark clients:
+
+    * Supports **batched** inputs — multiple samples per ``step()`` call.
+    * State is encoded via **sin/cos** transformation before being sent
+      to the policy server.
+    * Returns a structured action dict with separate keys for each
+      body part: ``left_arm``, ``right_arm``, ``left_hand``,
+      ``right_hand``, ``waist``.
+
+    Expected *observations* dict layout::
+
+        {
+            "annotation.human.coarse_action": [task_str, ...],
+            "video.ego_view": np.ndarray,     # (B, N_view, H, W, 3)
+            "state.left_arm":  np.ndarray,    # (B, 1, 7)
+            "state.right_arm": np.ndarray,    # (B, 1, 7)
+            "state.left_hand": np.ndarray,    # (B, 1, 6)
+            "state.right_hand": np.ndarray,   # (B, 1, 6)
+            "state.waist":     np.ndarray,    # (B, 1, 3)
+        }
+    """
+
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "franka",
         horizon: int = 0,
-        action_ensemble=False,  # @Jinhui
-        action_ensemble_horizon: Optional[int] = 3,  # different cross sim
-        image_size: list[int] = [224, 224],
+        action_ensemble: bool = False,
+        action_ensemble_horizon: Optional[int] = 3,
+        image_size: list[int] | None = None,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        adaptive_ensemble_alpha=0.1,
-        host="0.0.0.0",
-        port=10095,
-        n_action_steps=2,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10095,
+        n_action_steps: int = 2,
+        # Legacy kwargs accepted for backward compatibility
+        **kwargs,
     ) -> None:
-
-        # build client to connect server policy
-        self.client = WebsocketClientPolicy(host, port)
+        if image_size is None:
+            image_size = [224, 224]
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode="min_max",
+            action_ensemble=action_ensemble,
+            action_ensemble_horizon=action_ensemble_horizon,
+            adaptive_ensemble_alpha=adaptive_ensemble_alpha,
+            host=host,
+            port=port,
+        )
         self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
+        self.n_action_steps = n_action_steps
+        self.horizon = horizon
 
         print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
-        self.image_size = image_size
-        self.horizon = horizon  # 0
-        self.action_ensemble = action_ensemble
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-        self.n_action_steps = n_action_steps
 
-        self.task_description = None
-        self.image_history = deque(maxlen=self.horizon)
-        if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
-        else:
-            self.action_ensembler = None
-        self.num_image_history = 0
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        observations: dict,
+        **kwargs,
+    ) -> dict[str, dict[str, np.ndarray]]:
+        """Run one batched inference step.
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-
-    def _add_image_to_history(self, image: np.ndarray) -> None:
-        self.image_history.append(image)
-        self.num_image_history = min(self.num_image_history + 1, self.horizon)
-
-    def reset(self, task_description: str or tuple) -> None:
-
-        self.task_description = task_description
-        self.image_history.clear()
-        if self.action_ensemble:
-            self.action_ensembler.reset()
-        self.num_image_history = 0
-
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-    def step(self, observations, **kwargs) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+        Returns:
+            ``{"actions": {"action.left_arm": (B, n, 7), ...}}``
         """
-        Execute one inference step.
-        :param image: Input image (H, W, 3) in uint8 format
-        :param task_description: Task description text
-        :return: (raw_actions, processed_actions)
-        """
+        task_description = observations["annotation.human.coarse_action"][0]
+        images = observations["video.ego_view"]  # (B, N_view, H, W, 3)
 
-        task_description = observations["annotation.human.coarse_action"][0]  # tuple
-        ego_view = observations["video.ego_view"]  # (N, 1, H, W, 3)
-        images = ego_view
-        state = {}
-        state["left_arm"] = observations["state.left_arm"]
-        state["right_arm"] = observations["state.right_arm"]  # (N, 1, 7)
-        state["left_hand"] = observations["state.left_hand"]  # (N, 1, 6)
-        state["right_hand"] = observations["state.right_hand"]  # (N, 1, 6)
-        state["waist"] = observations["state.waist"]  # (N, 1, 3)
-
+        # Build per-body-part state dict and encode via sin/cos
+        state = {
+            "left_arm": observations["state.left_arm"],
+            "right_arm": observations["state.right_arm"],
+            "left_hand": observations["state.left_hand"],
+            "right_hand": observations["state.right_hand"],
+            "waist": observations["state.waist"],
+        }
         state = self.normalize_state(state)
-        input_state = []
-        for key in state.keys():
-            input_state.append(state[key])
-        input_state = np.concatenate(input_state, axis=-1)
+        input_state = np.concatenate(list(state.values()), axis=-1)
 
-        if task_description is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
+        if task_description is not None and task_description != self.task_description:
+            self.reset(task_description)
 
-        # image: Image.Image = Image.fromarray(image)
+        # Resize all images: (B, N_view, H, W, 3)
+        images = [
+            [self.resize_image(img) for img in sample] for sample in images
+        ]
+        input_state = [s for s in input_state]  # list of (N_history, state_dim)
 
-        images = [[self._resize_image(img) for img in sample] for sample in images]  # (B, N_view, H, W, 3)
-        input_state = [input_s for input_s in input_state]  # B, state_dim*(sin, cos)
-
-        # prepare vla input
-        examples = []
+        # Build batched examples
+        instructions = (
+            [self.task_description]
+            if isinstance(self.task_description, str)
+            else self.task_description
+        )
         batch_size = len(images)
-        instructions = [self.task_description] if isinstance(self.task_description, str) else self.task_description
+        examples = []
         for b in range(batch_size):
-            example = {
-                "image": images[b],  # A list of multi-view images for a single sample
+            examples.append({
+                "image": images[b],
                 "lang": instructions[b] if isinstance(instructions, list) else instructions,
-                "state": input_state[b],  # N_history, 58 #Hack BUG
-            }
-            examples.append(example)
+                "state": input_state[b],
+            })
 
         vla_input = {
             "examples": examples,
@@ -129,94 +143,89 @@ class PolicyWarper:
 
         response = self.client.predict_action(vla_input)
 
-        # unnormalize the action
-        normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-
-        # unnormalize actions in batch form
+        # Un-normalize actions in batch form: (B, chunk, D)
+        normalized_actions = response["data"]["normalized_actions"]
         raw_actions = self.unnormalize_actions(
-            normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
+            normalized_actions,
+            self.action_norm_stats,
+            normalization_mode=self.normalization_mode,
+            gripper_indices=None,  # Robocasa uses mask, no gripper binarization
         )
 
-        # raw_actions shape: (B, chunk, D)
-        if self.action_ensemble:
-            # Ensemble each sample in the batch
-            batch_size = raw_actions.shape[0]
-            ensembled_actions = []
-            for b in range(batch_size):
-                ensembled = self.action_ensembler.ensemble_action(raw_actions[b])[None]  # (1, D)
-                ensembled_actions.append(ensembled)
-            raw_actions = np.stack(ensembled_actions, axis=0)  # (B, 1, D)
+        # Apply ensemble per sample if enabled
+        if self.action_ensembler is not None:
+            ensembled = []
+            for b in range(raw_actions.shape[0]):
+                ensembled.append(
+                    self.action_ensembler.ensemble_action(raw_actions[b])[None]
+                )
+            raw_actions = np.stack(ensembled, axis=0)  # (B, 1, D)
 
+        # Slice to n_action_steps and split into body parts
+        n = self.n_action_steps
         raw_action = {
-            "action.left_arm": raw_actions[:, : self.n_action_steps, :7],  # (B, n_action_steps, 7)
-            "action.right_arm": raw_actions[:, : self.n_action_steps, 7:14],  # (B, n_action_steps, 7)
-            "action.left_hand": raw_actions[:, : self.n_action_steps, 14:20],  # (B, n_action_steps, 6)
-            "action.right_hand": raw_actions[:, : self.n_action_steps, 20:26],  # (B, n_action_steps, 6)
-            "action.waist": raw_actions[:, : self.n_action_steps, 26:29],  # (B, n_action_steps, 3)
+            "action.left_arm": raw_actions[:, :n, :7],
+            "action.right_arm": raw_actions[:, :n, 7:14],
+            "action.left_hand": raw_actions[:, :n, 14:20],
+            "action.right_hand": raw_actions[:, :n, 20:26],
+            "action.waist": raw_actions[:, :n, 26:29],
         }
 
         return {"actions": raw_action}
 
+    # ------------------------------------------------------------------
+    # State normalization (sin/cos encoding)
+    # ------------------------------------------------------------------
     @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        """
-        Args:
-            normalized_actions: shape (B, chunk, D) (chunk, D)
-            action_norm_stats:
-        Returns:
-            actions
-        """
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
+    def normalize_state(state: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Encode each state component via sin/cos concatenation."""
+        encoded = {}
+        for key, val in state.items():
+            encoded[key] = np.concatenate(
+                [np.sin(val), np.cos(val)], axis=-1
+            )
+        return encoded
 
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-
-        actions = np.where(
-            mask,
-            (normalized_actions + 1) / 2 * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_action_stats(unnorm_key, policy_ckpt_path, **kwargs):
+        return BaseModelClient.load_action_stats(unnorm_key, policy_ckpt_path)
 
     @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
+    def _check_unnorm_key(norm_stats, unnorm_key):
+        return BaseModelClient._resolve_unnorm_key(norm_stats, unnorm_key)
 
-        unnorm_key = PolicyWarper._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
-
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
+    # ------------------------------------------------------------------
+    # Visualisation
+    # ------------------------------------------------------------------
     def visualize_epoch(
-        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+        self,
+        predicted_raw_actions: Sequence[np.ndarray],
+        images: Sequence[np.ndarray],
+        save_path: str,
     ) -> None:
-        images = [self._resize_image(image) for image in images]
+        images = [self.resize_image(img) for img in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
 
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
 
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
-                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                np.concatenate(
+                    [a["world_vector"], a["rotation_delta"], a["open_gripper"]],
+                    axis=-1,
+                )
                 for a in predicted_raw_actions
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")
@@ -225,33 +234,3 @@ class PolicyWarper:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key
-
-    def normalize_state(self, state: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        """
-        Normalize the state
-        """
-        for key in state.keys():
-            sin_state = np.sin(state[key])
-            cos_state = np.cos(state[key])
-            state[key] = np.concatenate([sin_state, cos_state], axis=-1)
-        return state

--- a/examples/Robotwin/eval_files/model2robotwin_interface.py
+++ b/examples/Robotwin/eval_files/model2robotwin_interface.py
@@ -1,382 +1,289 @@
-from collections import deque
-from pathlib import Path
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
+
+"""RoboTwin benchmark model client.
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+RoboTwin-specific features: delta/rel action modes, state normalisation,
+and dual-arm index reordering.
+"""
+
 from typing import Dict, Optional
 
-import cv2 as cv
 import numpy as np
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from starVLA.model.tools import read_mode_config
-
-try:
-    from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-except ImportError:
-    AdaptiveEnsembler = None
+from deployment.model_server.base_model_client import BaseModelClient
 
 
-class ModelClient:
+class ModelClient(BaseModelClient):
+    """Model client for the RoboTwin benchmark.
+
+    Supports three action modes:
+
+    * ``"abs"``   – absolute joint positions (no conversion)
+    * ``"delta"`` – delta actions accumulated from initial state
+    * ``"rel"``   – actions relative to the initial state
+
+    Expected *example* dict layout::
+
+        {
+            "image": [head_img, left_img, right_img],
+            "lang":  "task description",
+            "state": np.ndarray,  # required for delta/rel modes
+        }
+    """
+
+    # Dual-arm index reorder: starVLA convention → RoboTwin convention
+    _REORDER_INDICES = [0, 1, 2, 3, 4, 5, 12, 6, 7, 8, 9, 10, 11, 13]
+
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "robotwin",
-        horizon: int = 0,
-        action_ensemble=False,
-        action_ensemble_horizon: Optional[int] = 3,
-        image_size: list[int] = [224, 224],
+        image_size: list[int] | None = None,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        adaptive_ensemble_alpha=0.1,
-        host="127.0.0.1",
-        port=5694,
+        action_ensemble: bool = False,
+        action_ensemble_horizon: Optional[int] = 3,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "127.0.0.1",
+        port: int = 5694,
         action_mode: str = "abs",
         normalization_mode: str = "min_max",
+        # Legacy kwargs accepted for backward compatibility
+        **kwargs,
     ) -> None:
-
-        self.client = WebsocketClientPolicy(host, port)
+        if image_size is None:
+            image_size = [224, 224]
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode=normalization_mode,
+            action_ensemble=action_ensemble,
+            action_ensemble_horizon=action_ensemble_horizon,
+            adaptive_ensemble_alpha=adaptive_ensemble_alpha,
+            host=host,
+            port=port,
+        )
         self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
+        self.action_mode = action_mode
+
+        # State tracking for delta/rel action modes
+        self.initial_state: Optional[np.ndarray] = None
+        self.prev_action: Optional[np.ndarray] = None
+
+        # Load state stats (used by normalize_state)
+        self.state_norm_stats = self.load_state_stats(unnorm_key, policy_ckpt_path)
 
         print(
             f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, "
             f"action_mode: {action_mode}, normalization_mode: {normalization_mode} ***"
         )
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
-        self.image_size = image_size
-        self.horizon = horizon
-        self.action_ensemble = action_ensemble and (AdaptiveEnsembler is not None)
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
-        self.normalization_mode = normalization_mode
 
-        # Action mode: "abs", "delta", or "rel"
-        self.action_mode = action_mode
-        # State tracking for delta/rel modes
-        self.initial_state = None  # s_0 for rel mode
-        self.prev_action = None  # last absolute action for delta mode
-
-        self.task_description = None
-        self.image_history = deque(maxlen=self.horizon)
-        if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
-        else:
-            self.action_ensembler = None
-        self.num_image_history = 0
-
-        self.action_norm_stats = self.get_action_stats(
-            self.unnorm_key, policy_ckpt_path=policy_ckpt_path, action_mode=action_mode
-        )
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
-        self.state_norm_stats = self.get_state_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-        self.raw_actions = None
-
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
     def reset(self, task_description: str) -> None:
-        self.task_description = task_description
-        self.image_history.clear()
-        if self.action_ensemble:
-            self.action_ensembler.reset()
-        self.num_image_history = 0
-        self.raw_actions = None
-        # Reset state tracking for delta/rel modes
+        super().reset(task_description)
         self.initial_state = None
         self.prev_action = None
 
-    def step(
-        self,
-        example: dict,
-        step: int = 0,
-    ) -> np.ndarray:
-        state = example.get("state", None)
-        # if state is not None:
-        #     state = self.normalize_state(state, self.state_norm_stats)
-        #     state = state[[0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 6, 13]]
-        #     example["state"] = state.reshape(1, -1)
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def step(self, example: dict, step: int = 0) -> np.ndarray:
+        """Run one inference step and return a reordered absolute action.
 
-        # Store initial state for delta/rel modes
-        if self.action_mode in ["delta", "rel"] and self.initial_state is None:
+        Returns:
+            np.ndarray: Action vector of shape ``(14,)`` in RoboTwin order.
+        """
+        state = example.get("state", None)
+
+        # Capture initial state for delta/rel modes
+        if self.action_mode in ("delta", "rel") and self.initial_state is None:
             if state is None:
-                raise ValueError(f"action_mode='{self.action_mode}' requires state to be provided in example")
+                raise ValueError(
+                    f"action_mode='{self.action_mode}' requires 'state' in example"
+                )
             self.initial_state = np.array(state).copy()
 
         task_description = example.get("lang", None)
-        images = example["image"]
+        if task_description != self.task_description:
+            self.reset(task_description)
+            # Re-capture initial state after reset
+            if self.action_mode in ("delta", "rel") and state is not None:
+                self.initial_state = np.array(state).copy()
 
-        if example is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
-                # Re-store initial state after reset if in delta/rel mode
-                if self.action_mode in ["delta", "rel"] and state is not None:
-                    self.initial_state = np.array(state).copy()
+        # Resize images
+        example["image"] = [self.resize_image(img) for img in example["image"]]
 
-        images = [self._resize_image(image) for image in images]
-        example["image"] = images
-        example_copy = example.copy()
-        example_copy.pop("state")
-        vla_input = {
-            "examples": [example_copy],
-            "do_sample": False,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
+        # Strip state before sending to server (server doesn't use raw state)
+        server_example = {k: v for k, v in example.items() if k != "state"}
 
-        action_chunk_size = self.action_chunk_size
+        # Fetch (or reuse cached) action chunk
+        current_action = self._get_action_for_step(server_example, step, state)
 
-        if step % action_chunk_size == 0 or self.raw_actions is None:
-            response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            # Unnormalize to get delta/rel values
-            raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions,
-                action_norm_stats=self.action_norm_stats,
-                normalization_mode=self.normalization_mode,
-            )
-
-            # Convert delta/rel to absolute actions
-            if self.action_mode == "delta":
-                self.raw_actions = self._delta_to_absolute(raw_actions, state)
-            elif self.action_mode == "rel":
-                self.raw_actions = self._rel_to_absolute(raw_actions)
-            else:
-                self.raw_actions = raw_actions
-
-        action_idx = step % action_chunk_size
-        if action_idx >= len(self.raw_actions):
-            pass
-
-        current_action = self.raw_actions[action_idx]
-
-        # Update prev_action for delta mode (for cross-chunk continuity)
+        # Update delta-mode tracking
         if self.action_mode == "delta":
             self.prev_action = current_action.copy()
 
-        current_action = current_action[[0, 1, 2, 3, 4, 5, 12, 6, 7, 8, 9, 10, 11, 13]]
-        return current_action
+        # Reorder to RoboTwin convention
+        return current_action[self._REORDER_INDICES]
 
-    @staticmethod
-    def normalize_state(
-        state: dict[str, np.ndarray],
-        state_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> dict[str, np.ndarray]:
-        """
-        Normalize the state
-        """
-        continuous_mask = [True, True, True, True, True, True, True, True, True, True, True, True, False, False]
-        continuous_mask = np.array(continuous_mask, dtype=bool)
-        state_high, state_low = ModelClient._get_normalization_bounds(
-            state_norm_stats, normalization_mode=normalization_mode
-        )
-        valid_mask = continuous_mask & (state_high != state_low)
-        normalized_state = np.where(
-            valid_mask,
-            (state - state_low) / (state_high - state_low) * 2 - 1,
-            state,
-        )
-        normalized_state = np.where(
-            ~continuous_mask,
-            (normalized_state > 0.5).astype(normalized_state.dtype),
-            normalized_state,
-        )
-        return normalized_state
-
-    @staticmethod
-    def unnormalize_actions(
-        normalized_actions: np.ndarray,
-        action_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
+    # ------------------------------------------------------------------
+    # Action-mode-aware chunking
+    # ------------------------------------------------------------------
+    def _get_action_for_step(
+        self, example: dict, step: int, state: Optional[np.ndarray]
     ) -> np.ndarray:
-        action_high, action_low = ModelClient._get_normalization_bounds(
-            action_norm_stats, normalization_mode=normalization_mode
-        )
-        mask = action_norm_stats.get("mask", np.ones_like(action_low, dtype=bool))
-        normalized_actions = np.clip(normalized_actions, -1, 1)
+        if step % self.action_chunk_size == 0 or self._cached_actions is None:
+            normalized = self.predict_normalized_actions(example)
+            raw_actions = self.unnormalize_actions(
+                normalized,
+                self.action_norm_stats,
+                normalization_mode=self.normalization_mode,
+                gripper_indices=None,  # RoboTwin handles grippers via mask
+            )
+            # Convert to absolute coordinates if needed
+            if self.action_mode == "delta":
+                self._cached_actions = self._delta_to_absolute(raw_actions, state)
+            elif self.action_mode == "rel":
+                self._cached_actions = self._rel_to_absolute(raw_actions)
+            else:
+                self._cached_actions = raw_actions
 
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
+        action_idx = step % self.action_chunk_size
+        return self._cached_actions[min(action_idx, len(self._cached_actions) - 1)]
 
-        return actions
+    # ------------------------------------------------------------------
+    # Delta / Relative → Absolute conversion
+    # ------------------------------------------------------------------
+    def _delta_to_absolute(
+        self, delta_actions: np.ndarray, current_state: Optional[np.ndarray]
+    ) -> np.ndarray:
+        """Convert delta actions to absolute.
 
-    def _delta_to_absolute(self, delta_actions: np.ndarray, current_state: np.ndarray) -> np.ndarray:
+        Training convention: ``delta[0] = a[0] - s[0]``,
+        ``delta[t] = a[t] - a[t-1]``.
         """
-        Convert delta actions to absolute actions.
-
-        Training: delta[0] = a[0] - s[0], delta[t] = a[t] - a[t-1]
-        Deployment: a[0] = delta[0] + base, a[t] = delta[t] + a[t-1]
-
-        Where base is:
-        - First chunk: initial_state (s_0)
-        - Subsequent chunks: prev_action (last action from previous chunk)
-        """
-        abs_actions = np.zeros_like(delta_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(delta_actions.shape[-1], dtype=bool))
-
-        # Determine base action
+        mask = self.action_norm_stats.get(
+            "mask", np.ones(delta_actions.shape[-1], dtype=bool)
+        )
         base = self.prev_action if self.prev_action is not None else self.initial_state
-
+        abs_actions = np.zeros_like(delta_actions)
         for i in range(len(delta_actions)):
             abs_actions[i] = np.where(mask, delta_actions[i] + base, delta_actions[i])
             base = abs_actions[i]
-
         return abs_actions
 
     def _rel_to_absolute(self, rel_actions: np.ndarray) -> np.ndarray:
-        """
-        Convert relative actions to absolute actions.
+        """Convert relative actions to absolute.
 
-        Training: rel[t] = a[t] - s[0]
-        Deployment: a[t] = rel[t] + s[0]
+        Training convention: ``rel[t] = a[t] - s[0]``.
         """
+        mask = self.action_norm_stats.get(
+            "mask", np.ones(rel_actions.shape[-1], dtype=bool)
+        )
         abs_actions = np.zeros_like(rel_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(rel_actions.shape[-1], dtype=bool))
-
         for i in range(len(rel_actions)):
-            abs_actions[i] = np.where(mask, rel_actions[i] + self.initial_state, rel_actions[i])
-
+            abs_actions[i] = np.where(
+                mask, rel_actions[i] + self.initial_state, rel_actions[i]
+            )
         return abs_actions
 
+    # ------------------------------------------------------------------
+    # State normalization
+    # ------------------------------------------------------------------
     @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path, action_mode: str = "abs") -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
+    def normalize_state(
+        state: np.ndarray,
+        state_norm_stats: Dict[str, np.ndarray],
+        normalization_mode: str = "min_max",
+        continuous_mask: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Normalize proprioceptive state for model input.
 
-        stats = norm_stats[unnorm_key]
+        Continuous dimensions use linear normalization to ``[-1, 1]``;
+        discrete (gripper) dimensions are binarized.
+        """
+        if continuous_mask is None:
+            # Default for 14-DoF dual-arm: last 2 dims are binary grippers
+            continuous_mask = np.array(
+                [True] * 12 + [False, False], dtype=bool
+            )
+        state_high, state_low = BaseModelClient.get_normalization_bounds(
+            state_norm_stats, normalization_mode
+        )
+        valid = continuous_mask & (state_high != state_low)
+        normalized = np.where(
+            valid,
+            (state - state_low) / (state_high - state_low) * 2 - 1,
+            state,
+        )
+        normalized = np.where(
+            ~continuous_mask,
+            (normalized > 0.5).astype(normalized.dtype),
+            normalized,
+        )
+        return normalized
 
-        # Support two formats:
-        # New format: {"robotwin": {"abs": {...}, "delta": {...}, "rel": {...}}}
-        # Old format: {"robotwin": {"action": {...}, "state": {...}}}
-
-        if action_mode in stats:
-            # New format: directly use the corresponding mode stats
-            mode_stats = stats[action_mode]
-            return mode_stats.get("action", mode_stats)
-        if "action" in stats:
-            # Old format: only supports abs mode
-            if action_mode != "abs":
-                raise ValueError(
-                    f"Statistics key `{unnorm_key}` only provides `abs` action stats, "
-                    f"but action_mode=`{action_mode}` was requested."
-                )
-            return stats["action"]
-        raise ValueError(
-            f"Invalid statistics file format for key `{unnorm_key}`. "
-            f"Available top-level keys: {sorted(stats.keys())}"
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_action_stats(unnorm_key, policy_ckpt_path, action_mode="abs"):
+        return BaseModelClient.load_action_stats(
+            unnorm_key, policy_ckpt_path, action_mode=action_mode
         )
 
     @staticmethod
-    def get_state_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["state"]
+    def get_state_stats(unnorm_key, policy_ckpt_path):
+        return BaseModelClient.load_state_stats(unnorm_key, policy_ckpt_path)
 
     @staticmethod
     def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
-
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        available_keys = sorted(norm_stats.keys())
-        if unnorm_key is None:
-            if len(available_keys) == 1:
-                return available_keys[0]
-            raise ValueError(
-                "`unnorm_key` must be provided when multiple normalization statistics are available. "
-                f"Available keys: {available_keys}"
-            )
-
-        if unnorm_key not in norm_stats:
-            raise KeyError(
-                f"Unknown `unnorm_key`: `{unnorm_key}`. Available keys: {available_keys}"
-            )
-
-        return unnorm_key
-
-    @staticmethod
-    def _get_normalization_bounds(
-        norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> tuple[np.ndarray, np.ndarray]:
-        if normalization_mode == "q99":
-            if "q01" not in norm_stats or "q99" not in norm_stats:
-                raise KeyError(
-                    "Normalization mode `q99` requires statistics keys `q01` and `q99`."
-                )
-            return np.array(norm_stats["q99"]), np.array(norm_stats["q01"])
-        if normalization_mode == "min_max":
-            if "min" not in norm_stats or "max" not in norm_stats:
-                raise KeyError(
-                    "Normalization mode `min_max` requires statistics keys `min` and `max`."
-                )
-            return np.array(norm_stats["max"]), np.array(norm_stats["min"])
-        raise ValueError(
-            f"Unsupported normalization_mode: {normalization_mode}. Expected one of ['min_max', 'q99']."
-        )
+        return BaseModelClient.load_action_chunk_size(policy_ckpt_path)
 
 
-def get_model(usr_args):
-    policy_ckpt_path = usr_args.get("policy_ckpt_path")
-    host = usr_args.get("host", "127.0.0.1")
-    port = usr_args.get("port", 5694)
-    unnorm_key = usr_args.get("unnorm_key", None)
-    action_mode = usr_args.get("action_mode", "abs")
-    normalization_mode = usr_args.get(
-        "action_normalization_mode",
-        usr_args.get("normalization_mode", "min_max"),
-    )
+# ======================================================================
+# Convenience factory (used by RoboTwin eval scripts)
+# ======================================================================
 
-    if policy_ckpt_path is None:
-        raise ValueError("policy_ckpt_path must be provided in config")
-
+def get_model(usr_args: dict) -> ModelClient:
+    """Create a :class:`ModelClient` from a flat config dict."""
     return ModelClient(
-        policy_ckpt_path=policy_ckpt_path,
-        host=host,
-        port=port,
-        unnorm_key=unnorm_key,
-        action_mode=action_mode,
-        normalization_mode=normalization_mode,
+        policy_ckpt_path=usr_args["policy_ckpt_path"],
+        host=usr_args.get("host", "127.0.0.1"),
+        port=usr_args.get("port", 5694),
+        unnorm_key=usr_args.get("unnorm_key"),
+        action_mode=usr_args.get("action_mode", "abs"),
+        normalization_mode=usr_args.get(
+            "action_normalization_mode",
+            usr_args.get("normalization_mode", "min_max"),
+        ),
     )
 
 
-def reset_model(model):
+def reset_model(model: ModelClient) -> None:
     model.reset(task_description="")
 
 
-def eval(TASK_ENV, model, observation):
-    # Get instruction
+def eval(TASK_ENV, model: ModelClient, observation: dict) -> None:
+    """One-step eval loop helper for RoboTwin."""
     instruction = TASK_ENV.get_instruction()
-
-    # Prepare images
-    head_img = observation["observation"]["head_camera"]["rgb"]
-    left_img = observation["observation"]["left_camera"]["rgb"]
-    right_img = observation["observation"]["right_camera"]["rgb"]
-
-    # Order: [head, left, right] to match training order
-    images = [head_img, left_img, right_img]
-
-    state = observation["joint_action"]["vector"]
+    images = [
+        observation["observation"]["head_camera"]["rgb"],
+        observation["observation"]["left_camera"]["rgb"],
+        observation["observation"]["right_camera"]["rgb"],
+    ]
     example = {
         "lang": str(instruction),
         "image": images,
-        "state": state,  # Required for delta/rel action modes
+        "state": observation["joint_action"]["vector"],
     }
-
     action = model.step(example, step=TASK_ENV.take_action_cnt)
-
-    # Execute action
     TASK_ENV.take_action(action)

--- a/examples/SimplerEnv/eval_files/model2simpler_interface.py
+++ b/examples/SimplerEnv/eval_files/model2simpler_interface.py
@@ -1,265 +1,296 @@
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License");
+
+"""SimplerEnv benchmark model client.
+
+Inherits shared inference logic from :class:`BaseModelClient` and adds
+SimplerEnv-specific features: sticky gripper logic, euler-to-axis-angle
+conversion, and per-robot-setup defaults (widowx_bridge / google_robot).
+"""
+
+from __future__ import annotations
+
 import os
 from collections import deque
-from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Optional, Sequence
 
 import cv2 as cv
 import matplotlib.pyplot as plt
 import numpy as np
 from transforms3d.euler import euler2axangle
 
-from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
+from deployment.model_server.base_model_client import BaseModelClient
 
 
-class ModelClient:
+class ModelClient(BaseModelClient):
+    """Model client for the SimplerEnv (ManiSkill2) benchmark.
+
+    Unlike other benchmark clients, SimplerEnv's :meth:`step` takes a raw
+    ``image`` and ``task_description`` rather than an ``example`` dict, and
+    returns a ``(raw_action, action)`` tuple where ``action`` contains
+    axis-angle rotations and processed gripper values.
+
+    Supports two robot setups:
+
+    * ``"widowx_bridge"`` – WidowX arm, binary gripper, default
+      ``unnorm_key="oxe_bridge"``
+    * ``"google_robot"`` – Google Robot, sticky gripper with repeat=10,
+      default ``unnorm_key="oxe_rt1"``
+    """
+
+    # Default unnorm keys per policy setup
+    _DEFAULT_UNNORM_KEYS = {
+        "widowx_bridge": "oxe_bridge",
+        "google_robot": "oxe_rt1",
+    }
+
+    # Default ensemble horizon per policy setup
+    _DEFAULT_ENSEMBLE_HORIZONS = {
+        "widowx_bridge": 7,
+        "google_robot": 2,
+    }
+
+    # Sticky gripper repeat count per policy setup
+    _STICKY_GRIPPER_REPEATS = {
+        "widowx_bridge": 1,
+        "google_robot": 10,
+    }
+
     def __init__(
         self,
-        policy_ckpt_path,
+        policy_ckpt_path: str,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "widowx_bridge",
         horizon: int = 0,
         action_ensemble_horizon: Optional[int] = None,
-        image_size: list[int] = [224, 224],
+        image_size: list[int] | None = None,
         action_scale: float = 1.0,
         cfg_scale: float = 1.5,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        action_ensemble=True,
-        adaptive_ensemble_alpha=0.1,
-        host="0.0.0.0",
-        port=10093,
+        action_ensemble: bool = True,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10093,
     ) -> None:
+        if policy_setup not in self._DEFAULT_UNNORM_KEYS:
+            raise NotImplementedError(
+                f"Policy setup '{policy_setup}' not supported. "
+                f"Choose from: {sorted(self._DEFAULT_UNNORM_KEYS.keys())}."
+            )
 
-        # build client to connect server policy
-        self.client = WebsocketClientPolicy(host, port)
+        if image_size is None:
+            image_size = [224, 224]
+        if unnorm_key is None:
+            unnorm_key = self._DEFAULT_UNNORM_KEYS[policy_setup]
+        if action_ensemble_horizon is None:
+            action_ensemble_horizon = self._DEFAULT_ENSEMBLE_HORIZONS[policy_setup]
 
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
-        if policy_setup == "widowx_bridge":
-            unnorm_key = "oxe_bridge" if unnorm_key is None else unnorm_key
-            action_ensemble = action_ensemble
-            adaptive_ensemble_alpha = adaptive_ensemble_alpha
-            if action_ensemble_horizon is None:
-                # Set 7 for widowx_bridge to fix the window size of motion scale between each frame. see appendix in our paper for details
-                action_ensemble_horizon = 7
-            self.sticky_gripper_num_repeat = 1
-        elif policy_setup == "google_robot":
-            unnorm_key = "oxe_rt1" if unnorm_key is None else unnorm_key
-            action_ensemble = action_ensemble
-            adaptive_ensemble_alpha = adaptive_ensemble_alpha
-            if action_ensemble_horizon is None:
-                # Set 2 for google_robot to fix the window size of motion scale between each frame. see appendix in our paper for details
-                action_ensemble_horizon = 2
-            self.sticky_gripper_num_repeat = 10
-        else:
-            raise NotImplementedError(
-                f"Policy setup {policy_setup} not supported for octo models. The other datasets can be found in the huggingface config.json file."
-            )
+
+        super().__init__(
+            policy_ckpt_path=policy_ckpt_path,
+            unnorm_key=unnorm_key,
+            image_size=image_size,
+            use_ddim=use_ddim,
+            num_ddim_steps=num_ddim_steps,
+            normalization_mode="q99",
+            action_ensemble=action_ensemble,
+            action_ensemble_horizon=action_ensemble_horizon,
+            adaptive_ensemble_alpha=adaptive_ensemble_alpha,
+            host=host,
+            port=port,
+        )
+
         self.policy_setup = policy_setup
-        self.unnorm_key = unnorm_key
+        self.cfg_scale = cfg_scale
+        self.action_scale = action_scale
+        self.horizon = horizon
+        self.sticky_gripper_num_repeat = self._STICKY_GRIPPER_REPEATS[policy_setup]
+
+        # Image history (for potential multi-frame input)
+        self.image_history: deque[np.ndarray] = deque(maxlen=self.horizon)
+        self.num_image_history = 0
+
+        # Sticky gripper state
+        self.sticky_action_is_on = False
+        self.gripper_action_repeat = 0
+        self.sticky_gripper_action = 0.0
+        self.previous_gripper_action = None
 
         print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
-        self.use_ddim = use_ddim
-        self.num_ddim_steps = num_ddim_steps
 
-        self.cfg_scale = cfg_scale  # 1.5
-
-        self.image_size = image_size
-        self.action_scale = action_scale  # 1.0
-        self.horizon = horizon  # 0
-        self.action_ensemble = action_ensemble
-        self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
-        self.action_ensemble_horizon = action_ensemble_horizon
-        self.sticky_action_is_on = False
-        self.gripper_action_repeat = 0
-        self.sticky_gripper_action = 0.0
-        self.previous_gripper_action = None
-
-        self.task_description = None
-        self.image_history = deque(maxlen=self.horizon)
-        if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
-        else:
-            self.action_ensembler = None
-        self.num_image_history = 0
-
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-
-    def _add_image_to_history(self, image: np.ndarray) -> None:
-        self.image_history.append(image)
-        self.num_image_history = min(self.num_image_history + 1, self.horizon)
-
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
     def reset(self, task_description: str) -> None:
-        self.task_description = task_description
+        super().reset(task_description)
         self.image_history.clear()
-        if self.action_ensemble:
-            self.action_ensembler.reset()
         self.num_image_history = 0
-
         self.sticky_action_is_on = False
         self.gripper_action_repeat = 0
         self.sticky_gripper_action = 0.0
         self.previous_gripper_action = None
 
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def step(
-        self, image: np.ndarray, task_description: Optional[str] = None, *args, **kwargs
+        self,
+        image: np.ndarray,
+        task_description: Optional[str] = None,
+        *args,
+        **kwargs,
     ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+        """Run one inference step.
+
+        Args:
+            image: Shape ``(H, W, 3)``, dtype ``uint8``.
+            task_description: If different from previous, resets the client.
+
+        Returns:
+            ``(raw_action, action)`` where *raw_action* contains
+            ``world_vector``, ``rotation_delta``, ``open_gripper`` and
+            *action* contains ``world_vector``, ``rot_axangle``, ``gripper``,
+            ``terminate_episode`` formatted for ManiSkill2.
         """
-        Input:
-            image: np.ndarray of shape (H, W, 3), uint8
-            task_description: Optional[str], task description; if different from previous task description, policy state is reset
-        Output:
-            raw_action: dict; raw policy action output
-            action: dict; processed action to be sent to the maniskill2 environment, with the following keys:
-                - 'world_vector': np.ndarray of shape (3,), xyz translation of robot end-effector
-                - 'rot_axangle': np.ndarray of shape (3,), axis-angle representation of end-effector rotation
-                - 'gripper': np.ndarray of shape (1,), gripper action
-                - 'terminate_episode': np.ndarray of shape (1,), 1 if episode should be terminated, 0 otherwise
-        """
-        if task_description is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
+        if task_description is not None and task_description != self.task_description:
+            self.reset(task_description)
 
         assert image.dtype == np.uint8
-        self._add_image_to_history(self._resize_image(image))
-        # image: Image.Image = Image.fromarray(image)
+        resized = self.resize_image(image)
+        self._add_image_to_history(resized)
 
-        image = self._resize_image(image)
         example = {
-            "image": [image],
+            "image": [resized],
             "lang": self.task_description,
         }
 
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "cfg_scale": self.cfg_scale,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
-
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
-
-        response = self.client.predict_action(vla_input)
-
-        # unnormalize the action
-        normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-        normalized_actions = normalized_actions[0]
-
+        # Get un-normalized action chunk (first action only, no chunking cache)
+        normalized_actions = self.predict_normalized_actions(example)
         raw_actions = self.unnormalize_actions(
-            normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
+            normalized_actions,
+            self.action_norm_stats,
+            normalization_mode=self.normalization_mode,
+            gripper_indices=[6],
         )
 
-        if self.action_ensemble:
+        if self.action_ensembler is not None:
             raw_actions = self.action_ensembler.ensemble_action(raw_actions)[None]
 
-        raw_action = {
-            "world_vector": np.array(raw_actions[0, :3]),
-            "rotation_delta": np.array(raw_actions[0, 3:6]),
-            "open_gripper": np.array(raw_actions[0, 6:7]),  # range [0, 1]; 1 = open; 0 = close
+        raw_action = self._format_raw_action(raw_actions[0])
+
+        # Convert to ManiSkill2 action format
+        action = self._to_maniskill_action(raw_action)
+
+        return raw_action, action
+
+    # ------------------------------------------------------------------
+    # Action formatting
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _format_raw_action(action: np.ndarray) -> dict[str, np.ndarray]:
+        """Split flat 7-D action into named dict."""
+        return {
+            "world_vector": np.array(action[:3]),
+            "rotation_delta": np.array(action[3:6]),
+            "open_gripper": np.array(action[6:7]),  # [0, 1]; 1 = open, 0 = close
         }
 
-        # process raw_action to obtain the action to be sent to the maniskill2 environment
+    def _to_maniskill_action(
+        self, raw_action: dict[str, np.ndarray]
+    ) -> dict[str, np.ndarray]:
+        """Convert raw action to ManiSkill2 environment format."""
         action = {}
         action["world_vector"] = raw_action["world_vector"] * self.action_scale
-        action_rotation_delta = np.asarray(raw_action["rotation_delta"], dtype=np.float64)
 
+        action_rotation_delta = np.asarray(raw_action["rotation_delta"], dtype=np.float64)
         roll, pitch, yaw = action_rotation_delta
         axes, angles = euler2axangle(roll, pitch, yaw)
-        action_rotation_axangle = axes * angles
-        action["rot_axangle"] = action_rotation_axangle * self.action_scale
+        action["rot_axangle"] = axes * angles * self.action_scale
 
         if self.policy_setup == "google_robot":
-            action["gripper"] = 0
-            current_gripper_action = raw_action["open_gripper"]
-            if self.previous_gripper_action is None:
-                relative_gripper_action = np.array([0])
-                self.previous_gripper_action = current_gripper_action
-            else:
-                relative_gripper_action = self.previous_gripper_action - current_gripper_action
-            # fix a bug in the SIMPLER code here
-            # self.previous_gripper_action = current_gripper_action
-
-            if np.abs(relative_gripper_action) > 0.5 and (not self.sticky_action_is_on):
-                self.sticky_action_is_on = True
-                self.sticky_gripper_action = relative_gripper_action
-                self.previous_gripper_action = current_gripper_action
-
-            if self.sticky_action_is_on:
-                self.gripper_action_repeat += 1
-                relative_gripper_action = self.sticky_gripper_action
-
-            if self.gripper_action_repeat == self.sticky_gripper_num_repeat:
-                self.sticky_action_is_on = False
-                self.gripper_action_repeat = 0
-                self.sticky_gripper_action = 0.0
-
-            action["gripper"] = relative_gripper_action
-
+            action["gripper"] = self._sticky_gripper_action(raw_action["open_gripper"])
         elif self.policy_setup == "widowx_bridge":
             action["gripper"] = 2.0 * (raw_action["open_gripper"] > 0.5) - 1.0
 
         action["terminate_episode"] = np.array([0.0])
-        return raw_action, action
+        return action
 
+    # ------------------------------------------------------------------
+    # Sticky gripper logic (google_robot only)
+    # ------------------------------------------------------------------
+    def _sticky_gripper_action(
+        self, current_gripper_action: np.ndarray
+    ) -> np.ndarray:
+        """Apply sticky gripper repeat logic for google_robot."""
+        if self.previous_gripper_action is None:
+            relative_gripper_action = np.array([0])
+            self.previous_gripper_action = current_gripper_action
+        else:
+            relative_gripper_action = (
+                self.previous_gripper_action - current_gripper_action
+            )
+
+        if np.abs(relative_gripper_action) > 0.5 and (not self.sticky_action_is_on):
+            self.sticky_action_is_on = True
+            self.sticky_gripper_action = relative_gripper_action
+            self.previous_gripper_action = current_gripper_action
+
+        if self.sticky_action_is_on:
+            self.gripper_action_repeat += 1
+            relative_gripper_action = self.sticky_gripper_action
+
+        if self.gripper_action_repeat == self.sticky_gripper_num_repeat:
+            self.sticky_action_is_on = False
+            self.gripper_action_repeat = 0
+            self.sticky_gripper_action = 0.0
+
+        return relative_gripper_action
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _add_image_to_history(self, image: np.ndarray) -> None:
+        self.image_history.append(image)
+        self.num_image_history = min(self.num_image_history + 1, self.horizon)
+
+    # ------------------------------------------------------------------
+    # Backward-compatible static helpers  (deprecated – prefer base class)
+    # ------------------------------------------------------------------
     @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["q01"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["q99"]), np.array(action_norm_stats["q01"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
+    def get_action_stats(unnorm_key, policy_ckpt_path, **kwargs):
+        return BaseModelClient.load_action_stats(unnorm_key, policy_ckpt_path)
 
-        return actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-
-        # unnorm_key = baseframework._check_unnorm_key(norm_stats, unnorm_key) # This is also very environment-specific
-        return norm_stats[unnorm_key]["action"]
-
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
-
+    # ------------------------------------------------------------------
+    # Visualisation
+    # ------------------------------------------------------------------
     def visualize_epoch(
-        self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
+        self,
+        predicted_raw_actions: Sequence[np.ndarray],
+        images: Sequence[np.ndarray],
+        save_path: str,
     ) -> None:
-        images = [self._resize_image(image) for image in images]
+        images = [self.resize_image(img) for img in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
 
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
 
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
-                np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
+                np.concatenate(
+                    [a["world_vector"], a["rotation_delta"], a["open_gripper"]],
+                    axis=-1,
+                )
                 for a in predicted_raw_actions
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")


### PR DESCRIPTION
## Summary
- Extract shared inference logic from 6 benchmark-specific model clients into a new BaseModelClient base class (deployment/model_server/base_model_client.py)
- Refactor all benchmark clients (LIBERO, LIBERO-plus, SimplerEnv, RoboTwin, Robocasa, BEHAVIOR) to inherit from BaseModelClient, eliminating ~250 lines of duplicated code
- Fix unnormalize_actions default gripper binarization behavior that would have silently altered Robocasa/BEHAVIOR/RoboTwin inference outputs

## Motivation
The 6 benchmark model clients (model2*_interface.py) share a large amount of common logic:
- WebSocket client setup (WebsocketClientPolicy)
- Checkpoint-based action/state stats and chunk size loading (read_mode_config)
- Image resizing (cv2.resize)
- Action un-normalization (min_max / q99)
- Action chunking with step-based cache
- Backward-compatible static helper methods (get_action_stats, get_action_chunk_size, _check_unnorm_key)

This duplication made it error-prone to maintain — for example, bug fixes applied to one client's unnormalize_actions might not propagate to others, and the import paths (ABot.model.tools vs starVLA.model.tools vs starVLA.model.framework.share_tools) were inconsistent across files.

## Affected Benchmarks

| Benchmark | Client file | Key changes |
|---|---|---|
| **BEHAVIOR** | `examples/Behavior/model2behavior_interface.py` | Inherits base class; removes dead `AdaptiveEnsembler` fallback branch (only `ChunkedAdaptiveEnsembler` is used); removes leftover `start_debugpy_once()` helper |
| **LIBERO** | `examples/LIBERO/eval_files/model2libero_interface.py` | Inherits base class; inlines `AdaptiveEnsembler` usage into base; deduplicates `_check_unnorm_key` |
| **LIBERO-plus** | `examples/LIBERO-plus/eval_files/model2libero_interface.py` | Same as LIBERO — removes its own copy of `AdaptiveEnsembler` class and `_check_unnorm_key` |
| **Robocasa** | `examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py` | Inherits base class; keeps batched input and sin/cos state encoding as benchmark-specific logic |
| **RoboTwin** | `examples/Robotwin/eval_files/model2robotwin_interface.py` | Inherits base class; retains delta/rel action mode conversion and dual-arm index reordering |
| **SimplerEnv** | `examples/SimplerEnv/eval_files/model2simpler_interface.py` | Inherits base class; retains sticky gripper logic, euler-to-axis-angle conversion, and per-robot defaults |


## Changes
New file: deployment/model_server/base_model_client.py
- BaseModelClient provides: WebSocket client, predict_normalized_actions(), get_actions_for_step() (action chunking), unnormalize_actions() (with flexible min_max/q99 modes and explicit gripper binarization control), resize_image(), load_action_stats(), load_state_stats(), load_action_chunk_size(), get_normalization_bounds()

Modified benchmark clients — each now inherits from BaseModelClient and only implements benchmark-specific logic:
- LIBERO / LIBERO-plus: 7-DoF action formatting, gripper binarization at index 6
- SimplerEnv: sticky gripper, euler→axis-angle, per-robot-setup defaults
- RoboTwin: delta/rel→absolute conversion, dual-arm index reordering, state normalization
- Robocasa: batched inference, sin/cos state encoding, multi-body-part action splitting
- BEHAVIOR: ChunkedAdaptiveEnsembler, 23-DoF R1Pro action decomposition

## Key fixes surfaced during refactoring
- **`unnormalize_actions` gripper binarization**: the original LIBERO/LIBERO-plus clients unconditionally binarized column 6 (`normalized_actions[:, 6] = where(… < 0.5, 0, 1)`). The base class now defaults `gripper_indices=None` (no binarization) and lets each client opt in explicitly, matching what Robocasa/BEHAVIOR/RoboTwin originally did.
- **BEHAVIOR dead code**: removed an unreachable `AdaptiveEnsembler(…)` instantiation inside the `chunk_size == 1` branch — BEHAVIOR always uses `chunk_size = 2` with `ChunkedAdaptiveEnsembler`.

## Validation
- Verified each benchmark client's un-normalization formula is mathematically equivalent to the original
- Confirmed gripper binarization behavior matches original per-benchmark (LIBERO/SimplerEnv: explicit [6]; others: none)
- Checked that all action chunking, ensemble, delta/rel conversion, and state encoding logic is preserved
- No linter errors in any modified file

**Would appreciate a review to check whether there are any benchmark-specific edge cases I might have overlooked. Thanks!**