### PR TITLE
[fix(training)] Restore resolve kwarg for save_full_config

### DIFF
--- a/starVLA/training/trainer_utils/config_tracker.py
+++ b/starVLA/training/trainer_utils/config_tracker.py
@@ -503,7 +503,7 @@ class AccessTrackedConfig:
             else:
                 raise ValueError(f"Unsupported file format: {filepath.suffix}")
 
-    def save_full_config(self, filepath: Path):
+    def save_full_config(self, filepath: Path, resolve: bool = True):
         """Save the complete configuration (all parameters) to file."""
         filepath = Path(filepath)
         filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -512,9 +512,9 @@ class AccessTrackedConfig:
             source = self.get_root()._cfg
         with open(filepath, "w") as f:
             if filepath.suffix == ".json":
-                json.dump(_original_to_container(source, resolve=True), f, indent=2)
+                json.dump(_original_to_container(source, resolve=resolve), f, indent=2)
             elif filepath.suffix in (".yaml", ".yml"):
-                _original_save(source, f, resolve=True)
+                _original_save(source, f, resolve=resolve)
             else:
                 raise ValueError(f"Unsupported file format: {filepath.suffix}")
 


### PR DESCRIPTION
## Summary

`VLATrainer._save_checkpoint` calls

```python
self.config.save_full_config(full_cfg_path, resolve=True)
```

but the current signature of `AccessTrackedConfig.save_full_config` in `starVLA/training/trainer_utils/config_tracker.py` only accepts `filepath`, causing a `TypeError` on the first checkpoint save:

```
TypeError: AccessTrackedConfig.save_full_config() got an unexpected keyword argument 'resolve'
```

## Root cause

Two near-simultaneous changes left caller and callee out of sync:

- #234 (`[fix(training)] Save full merged config backup during checkpointing`) added the call site with `resolve=True`.
- A subsequent refactor of `AccessTrackedConfig.save_full_config` dropped the `resolve` parameter from the signature and hardcoded `resolve=True` inside the function body.

Result: any call that explicitly passes `resolve=True` (there are three: `train_starvla.py:243`, `train_starvla_cotrain.py:217`, `train_starvlm.py:202`) crashes at runtime.

## Fix

Restore `resolve: bool = True` in the signature and thread it through to the underlying `_original_to_container` / `_original_save` calls:

```diff
-    def save_full_config(self, filepath: Path):
+    def save_full_config(self, filepath: Path, resolve: bool = True):
         ...
         with open(filepath, "w") as f:
             if filepath.suffix == ".json":
-                json.dump(_original_to_container(source, resolve=True), f, indent=2)
+                json.dump(_original_to_container(source, resolve=resolve), f, indent=2)
             elif filepath.suffix in (".yaml", ".yml"):
-                _original_save(source, f, resolve=True)
+                _original_save(source, f, resolve=resolve)
```

- **Backward compatible**: default `True` preserves the previously hardcoded behavior for callers that do not pass `resolve`.
- Callers that pass `resolve=True` now work; callers that omit it (`train_starvla.py:71`, `train_starvla_cotrain.py:66`, `train_starvlm.py:64`, `train_unified.py:70`) continue to resolve by default.

## Verified

Reproduced on 8×H200 / DeepSpeed ZeRO-2 with QwenOFT + RoboTwin all-50 training:

- **Before**: crashes at step 10000 (first `save_interval`) with the TypeError above.
- **After**: 10-step smoke test (`max_train_steps=10, save_interval=10`) completes cleanly with `EXIT_CODE:0`, writes `checkpoints/steps_10_pytorch_model.pt` (9.8 GB) and `config.full.yaml`, and logs `✅ Configuration files saved`.

## Test plan

- [x] 10-step smoke run on 8×H200: checkpoint + `config.full.yaml` both saved, no TypeError
- [ ] Full 150K-step all-50 run to confirm all 15 scheduled checkpoints land cleanly