### PR TITLE
[feat] Add full training state checkpointing for seamless resume

### DIFF
--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -120,6 +120,7 @@ class VLATrainer(TrainerUtils):
         self.accelerator = accelerator
 
         self.completed_steps = 0
+        self._pending_state_restore = None  # set by _init_checkpointing, consumed after prepare
         self.total_batch_size = self._calculate_total_batch_size()
 
     def prepare_training(self):
@@ -138,12 +139,19 @@ class VLATrainer(TrainerUtils):
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
         self.print_trainable_parameters(self.model)
 
-        self.model, self.optimizer, self.vla_train_dataloader = self.setup_distributed_training(
+        self.model, self.optimizer, self.lr_scheduler, self.vla_train_dataloader = self.setup_distributed_training(
             self.accelerator,
             self.model,
             self.optimizer,
+            self.lr_scheduler,
             self.vla_train_dataloader,
         )
+
+        # Restore full training state if deferred from _init_checkpointing
+        if self._pending_state_restore:
+            self.accelerator.load_state(self._pending_state_restore)
+            logger.info(f"Restored full training state from {self._pending_state_restore}")
+            self._pending_state_restore = None
 
         self._init_wandb()
 
@@ -179,10 +187,21 @@ class VLATrainer(TrainerUtils):
             resume_from_checkpoint, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
             if resume_from_checkpoint:
                 self.resume_from_checkpoint = resume_from_checkpoint
-                self.model = self.load_pretrained_backbones(self.model, self.resume_from_checkpoint, reload_modules=None)
-                logger.info(
-                    f"Resuming training from checkpoint: {self.resume_from_checkpoint}, steps: {self.completed_steps}"
-                )
+                state_dir = self._get_training_state_dir(self.checkpoint_dir, self.completed_steps)
+                if state_dir:
+                    # Defer full state restore to after accelerator.prepare()
+                    self._pending_state_restore = state_dir
+                    logger.info(
+                        f"Will restore full training state from: {state_dir} (step {self.completed_steps})"
+                    )
+                else:
+                    # Legacy: model-only checkpoint, no optimizer state
+                    self.model = self.load_pretrained_backbones(
+                        self.model, self.resume_from_checkpoint, reload_modules=None
+                    )
+                    logger.info(
+                        f"Resuming from model-only checkpoint: {self.resume_from_checkpoint} (step {self.completed_steps})"
+                    )
                 return
 
             logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting training from scratch.")
@@ -200,6 +219,9 @@ class VLATrainer(TrainerUtils):
 
     def _adjust_lr_scheduler_for_resume(self):
         """Adjust LR scheduler state after resuming from non-zero steps."""
+        if self._pending_state_restore:
+            logger.info("Skipping manual LR scheduler adjustment — full state will be restored from checkpoint")
+            return
         if self.completed_steps > 0:
             logger.info(f"Adjusting LR scheduler for resume from step {self.completed_steps}")
             for _ in range(self.completed_steps):
@@ -215,6 +237,11 @@ class VLATrainer(TrainerUtils):
 
     def _save_checkpoint(self):
         """Save current training state."""
+        # Save full training state (collective op — all ranks must participate for ZeRO)
+        training_state_dir = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}_training_state")
+        self.accelerator.save_state(training_state_dir)
+        logger.info(f"Full training state saved to {training_state_dir}")
+
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
@@ -240,7 +267,7 @@ class VLATrainer(TrainerUtils):
                 self.config.save_accessed_config(output_dir / "config.yaml", use_original_values=False)
                 full_cfg_path = output_dir / "config.full.yaml"
                 logger.info(f"📦 Saving full merged configuration to `{full_cfg_path}`...")
-                self.config.save_full_config(full_cfg_path, resolve=True)
+                self.config.save_full_config(full_cfg_path)
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -139,11 +139,12 @@ class VLAMTrainer(TrainerUtils):
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
         self.print_trainable_parameters(self.model)
 
-        self.model, self.optimizer, self.vla_train_dataloader, self.vlm_train_dataloader = (
+        self.model, self.optimizer, self.lr_scheduler, self.vla_train_dataloader, self.vlm_train_dataloader = (
             self.setup_distributed_training(
                 self.accelerator,
                 self.model,
                 self.optimizer,
+                self.lr_scheduler,
                 self.vla_train_dataloader,
                 self.vlm_train_dataloader,
             )
@@ -172,23 +173,33 @@ class VLAMTrainer(TrainerUtils):
             )
 
     def _init_checkpointing(self):
-        """Initialize checkpoint directory."""
+        """Initialize checkpoint directory and handle resume."""
         self.checkpoint_dir = os.path.join(self.config.output_dir, "checkpoints")
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 
-        pretrained_checkpoint = getattr(self.config.trainer, "pretrained_checkpoint", None)
         is_resume = getattr(self.config.trainer, "is_resume", False)
-
-        if pretrained_checkpoint and is_resume:
-            self._load_checkpoint(self.config.resume_from_checkpoint)
-
-    def _load_checkpoint(self, checkpoint_path):
-        """Load checkpoint."""
-        self.accelerator.load_state(checkpoint_path)
-        self.accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        if is_resume:
+            resume_ckpt, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
+            if resume_ckpt:
+                state_dir = self._get_training_state_dir(self.checkpoint_dir, self.completed_steps)
+                if state_dir:
+                    self.accelerator.load_state(state_dir)
+                    logger.info(f"Restored full training state from {state_dir} (step {self.completed_steps})")
+                else:
+                    # Legacy: model-only checkpoint
+                    unwrapped = self.accelerator.unwrap_model(self.model)
+                    self.load_pretrained_backbones(unwrapped, resume_ckpt, reload_modules=None)
+                    logger.info(f"Resumed from model-only checkpoint: {resume_ckpt} (step {self.completed_steps})")
+            else:
+                logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting from scratch.")
 
     def _save_checkpoint(self):
         """Save current training state."""
+        # Save full training state (collective op — all ranks must participate for ZeRO)
+        training_state_dir = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}_training_state")
+        self.accelerator.save_state(training_state_dir)
+        logger.info(f"Full training state saved to {training_state_dir}")
+
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -131,10 +131,11 @@ class VLAMTrainer(TrainerUtils):
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
         self.print_trainable_parameters(self.model)
 
-        self.model, self.optimizer, self.vlm_train_dataloader = self.setup_distributed_training(
+        self.model, self.optimizer, self.lr_scheduler, self.vlm_train_dataloader = self.setup_distributed_training(
             self.accelerator,
             self.model,
             self.optimizer,
+            self.lr_scheduler,
             self.vlm_train_dataloader,
         )
 
@@ -158,22 +159,33 @@ class VLAMTrainer(TrainerUtils):
             )
 
     def _init_checkpointing(self):
-        """Initialize checkpoint directory."""
+        """Initialize checkpoint directory and handle resume."""
         self.checkpoint_dir = os.path.join(self.config.output_dir, "checkpoints")
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 
-        pretrained_checkpoint = getattr(self.config.trainer, "pretrained_checkpoint", None)
         is_resume = getattr(self.config.trainer, "is_resume", False)
-        if pretrained_checkpoint and is_resume:
-            self._load_checkpoint(self.config.resume_from_checkpoint)
-
-    def _load_checkpoint(self, checkpoint_path):
-        """Load checkpoint."""
-        self.accelerator.load_state(checkpoint_path)
-        self.accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        if is_resume:
+            resume_ckpt, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
+            if resume_ckpt:
+                state_dir = self._get_training_state_dir(self.checkpoint_dir, self.completed_steps)
+                if state_dir:
+                    self.accelerator.load_state(state_dir)
+                    logger.info(f"Restored full training state from {state_dir} (step {self.completed_steps})")
+                else:
+                    # Legacy: model-only checkpoint
+                    unwrapped = self.accelerator.unwrap_model(self.model)
+                    self.load_pretrained_backbones(unwrapped, resume_ckpt, reload_modules=None)
+                    logger.info(f"Resumed from model-only checkpoint: {resume_ckpt} (step {self.completed_steps})")
+            else:
+                logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting from scratch.")
 
     def _save_checkpoint(self):
         """Save current training state."""
+        # Save full training state (collective op — all ranks must participate for ZeRO)
+        training_state_dir = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}_training_state")
+        self.accelerator.save_state(training_state_dir)
+        logger.info(f"Full training state saved to {training_state_dir}")
+
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
@@ -199,7 +211,7 @@ class VLAMTrainer(TrainerUtils):
                 self.config.save_accessed_config(output_dir / "config.yaml", use_original_values=False)
                 full_cfg_path = output_dir / "config.full.yaml"
                 logger.info(f"📦 Saving full merged configuration to `{full_cfg_path}`...")
-                self.config.save_full_config(full_cfg_path, resolve=True)
+                self.config.save_full_config(full_cfg_path)
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()

--- a/starVLA/training/train_unified.py
+++ b/starVLA/training/train_unified.py
@@ -129,6 +129,7 @@ class UnifiedTrainer(TrainerUtils):
         self.accelerator = accelerator
 
         self.completed_steps = 0
+        self._pending_state_restore = None  # set by _init_checkpointing, consumed after prepare
         self.supported_tags = [name for name in self.data_manager.names if self.model.supports_training_tag(name)]
         self.skipped_tags = [name for name in self.data_manager.names if name not in self.supported_tags]
 
@@ -164,14 +165,20 @@ class UnifiedTrainer(TrainerUtils):
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
         self.print_trainable_parameters(self.model)
 
-        # Distributed preparation: model + optimizer + dataloaders in ONE call
+        # Distributed preparation: model + optimizer + scheduler + dataloaders in ONE call
         # DeepSpeed requires at least one dataloader in prepare() to infer train_micro_batch_size_per_gpu
         dl_names = list(self.data_manager.dataloaders.keys())
         all_dls = [self.data_manager.dataloaders[n] for n in dl_names]
-        prepared = self.accelerator.prepare(self.model, self.optimizer, *all_dls)
-        self.model, self.optimizer = prepared[0], prepared[1]
+        prepared = self.accelerator.prepare(self.model, self.optimizer, self.lr_scheduler, *all_dls)
+        self.model, self.optimizer, self.lr_scheduler = prepared[0], prepared[1], prepared[2]
         for i, name in enumerate(dl_names):
-            self.data_manager.dataloaders[name] = prepared[2 + i]
+            self.data_manager.dataloaders[name] = prepared[3 + i]
+
+        # Restore full training state if deferred from _init_checkpointing
+        if self._pending_state_restore:
+            self.accelerator.load_state(self._pending_state_restore)
+            logger.info(f"Restored full training state from {self._pending_state_restore}")
+            self._pending_state_restore = None
 
         self._init_wandb()
 
@@ -201,10 +208,19 @@ class UnifiedTrainer(TrainerUtils):
             resume_from_checkpoint, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
             if resume_from_checkpoint:
                 self.resume_from_checkpoint = resume_from_checkpoint
-                self.model = self.load_pretrained_backbones(self.model, self.resume_from_checkpoint, reload_modules=None)
-                logger.info(
-                    f"Resuming training from checkpoint: {self.resume_from_checkpoint}, steps: {self.completed_steps}"
-                )
+                state_dir = self._get_training_state_dir(self.checkpoint_dir, self.completed_steps)
+                if state_dir:
+                    self._pending_state_restore = state_dir
+                    logger.info(
+                        f"Will restore full training state from: {state_dir} (step {self.completed_steps})"
+                    )
+                else:
+                    self.model = self.load_pretrained_backbones(
+                        self.model, self.resume_from_checkpoint, reload_modules=None
+                    )
+                    logger.info(
+                        f"Resuming from model-only checkpoint: {self.resume_from_checkpoint} (step {self.completed_steps})"
+                    )
                 return
 
             logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting training from scratch.")
@@ -222,6 +238,9 @@ class UnifiedTrainer(TrainerUtils):
 
     def _adjust_lr_scheduler_for_resume(self):
         """Adjust LR scheduler state after resuming from non-zero steps."""
+        if self._pending_state_restore:
+            logger.info("Skipping manual LR scheduler adjustment — full state will be restored from checkpoint")
+            return
         if self.completed_steps > 0:
             logger.info(f"Adjusting LR scheduler for resume from step {self.completed_steps}")
             for _ in range(self.completed_steps):
@@ -237,6 +256,11 @@ class UnifiedTrainer(TrainerUtils):
 
     def _save_checkpoint(self):
         """Save current training state."""
+        # Save full training state (collective op — all ranks must participate for ZeRO)
+        training_state_dir = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}_training_state")
+        self.accelerator.save_state(training_state_dir)
+        logger.info(f"Full training state saved to {training_state_dir}")
+
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -508,6 +508,17 @@ class TrainerUtils:
         self.accelerator.print(f"Latest checkpoint found: {latest_checkpoint_path}")
         return latest_checkpoint_path, completed_steps
 
+    def _get_training_state_dir(self, checkpoint_dir, step_number):
+        """Return path to full training state directory if it exists, else None.
+
+        Full training state (optimizer, scheduler, RNG) is saved by
+        ``accelerator.save_state()`` into ``steps_<N>_training_state/``.
+        """
+        state_dir = os.path.join(checkpoint_dir, f"steps_{step_number}_training_state")
+        if os.path.isdir(state_dir):
+            return state_dir
+        return None
+
 
 import os
 


### PR DESCRIPTION
## Summary

- **Save/restore full training state** (optimizer, LR scheduler, RNG) via `accelerator.save_state()`/`load_state()` across all 4 trainers (`train_starvla`, `train_unified`, `train_starvla_cotrain`, `train_starvlm`)
- **Backward compatible** — old model-only `.pt` checkpoints still work as a fallback when no `_training_state/` directory is found
- **Fix broken resume** in `train_starvla_cotrain` and `train_starvlm` where `self.config.resume_from_checkpoint` was referenced but never defined

## Motivation

Currently, `is_resume: true` only restores model weights. Optimizer momentum/variance buffers, LR scheduler internal state, and RNG states are lost. The LR scheduler is approximated by manually replaying `N` `.step()` calls, which is fragile (especially with warmup + cosine schedules) and doesn't recover optimizer state at all. This causes:

- **Optimizer cold start** — AdamW momentum buffers reset to zero, leading to noisier gradient updates for hundreds of steps after resume
- **LR scheduler drift** — manual replay doesn't perfectly reconstruct scheduler state for all schedule types
- **Reproducibility loss** — RNG states not restored means different data ordering and dropout patterns post-resume

## Changes

### `trainer_tools.py`
- Add `_get_training_state_dir()` helper that checks for `steps_<N>_training_state/` directory

### `train_starvla.py` & `train_unified.py` (deferred pattern)
These trainers call `_init_checkpointing()` **before** `accelerator.prepare()`, but `load_state()` requires wrapped model/optimizer. Solution:
1. `_init_checkpointing()` detects full state dir → sets `self._pending_state_restore`
2. `_adjust_lr_scheduler_for_resume()` skips manual replay when pending restore
3. After `accelerator.prepare()`, calls `accelerator.load_state()` to restore everything
4. Register `lr_scheduler` with `accelerator.prepare()` so `save_state()` includes it

### `train_starvla_cotrain.py` & `train_starvlm.py` (direct pattern)
These trainers call `_init_checkpointing()` **after** `accelerator.prepare()`, so `load_state()` works directly — no deferral needed. Also fixes the broken resume path that referenced the nonexistent `self.config.resume_from_checkpoint`.

### All trainers — checkpoint save
`accelerator.save_state()` added **outside** the `if is_main_process:` guard since it's a collective operation (all ranks must participate under DeepSpeed ZeRO).

### Checkpoint layout (after)
```
checkpoints/
  steps_5000_pytorch_model.pt          # kept: model-only for eval/from_pretrained
  steps_5000_training_state/           # NEW: full accelerator state
    model/
    optimizer.bin
    scheduler.bin
    random_states_0.pkl ... random_states_N.pkl
  steps_10000_pytorch_model.pt
  steps_10000_training_state/
```

### Bug fixes (included)
- `save_full_config(resolve=True)` → `save_full_config()` — the `resolve` kwarg doesn't exist and crashes at checkpoint save time

## Overlap with #271

This PR includes a fix for the same `save_full_config(resolve=True)` crash addressed by #271, but takes the **caller-side approach**: remove the `resolve=True` kwarg from the 3 call sites (`train_starvla.py`, `train_starvla_cotrain.py` [already gone after `_init_checkpointing` rewrite], `train_starvlm.py`) since `save_full_config` already hardcodes `resolve=True` internally.

PR #271 takes the **callee-side approach**: restores the `resolve` parameter in the `save_full_config` signature. Either fix is correct. If #271 is merged first, the `resolve=True` calls in our diff would simply become redundant (passing the default value) rather than conflicting — no merge conflict expected in either order.

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Old checkpoint (`.pt` only) + `is_resume: true` | Falls back to model-only load + manual LR stepping |
| New checkpoint (`.pt` + `_training_state/`) + `is_resume: true` | Full state restore via accelerator |
| `pretrained_checkpoint` without `is_resume` | Unchanged — model weights only |
| `from_pretrained()` for eval | Unchanged — reads `.pt` file directly |

## Test plan

- [ ] Run training for 100 steps with `save_interval: 50`, verify `_training_state/` dirs are created alongside `.pt` files
- [ ] Resume from the checkpoint, verify optimizer state dict and LR values match pre-save values
- [ ] Delete `_training_state/` dir, resume from `.pt` only — verify graceful fallback with warning
- [ ] Verify `git diff` shows no changes to training loop logic, loss computation, or eval code

🤖 Generated with [Claude Code](https://claude.com/claude-code)