### PR TITLE
feat: Gemma 4 E2B backbone with PI head (96% LIBERO 4-suite)

### DIFF
--- a/examples/Gemma4/README.md
+++ b/examples/Gemma4/README.md
@@ -1,0 +1,66 @@
+# Gemma 4 E2B Backbone for starVLA
+
+Integrates [Google Gemma 4 E2B](https://huggingface.co/google/gemma-4-E2B-it) (2.3B effective / 5.1B raw via PLE) as a VLM backbone for starVLA, alongside the existing Qwen-VL family.
+
+## LIBERO 4-Suite Benchmark (50 trials/task, seed=7)
+
+**Gemma4-E2B + PI head, 40K optimizer steps, effective BS=128 (8×H100)**
+
+| Suite | Success Rate |
+|---|---|
+| LIBERO-Spatial | **98.4%** (492/500) |
+| LIBERO-Object | **98.6%** (493/500) |
+| LIBERO-Goal | **96.4%** (482/500) |
+| LIBERO-10 | **90.6%** (453/500) |
+| **Average** | **96.0%** (1920/2000) |
+
+## Quick Start
+
+### Requirements
+
+- `transformers >= 5.5.0` (for `Gemma4ForConditionalGeneration`)
+- `torch >= 2.1` with CUDA support
+- Gemma 4 E2B weights: `google/gemma-4-E2B-it` from Hugging Face
+
+### Smoke Test (single GPU)
+
+```bash
+conda activate <your_env>
+export PYTHONPATH=$PWD
+CUDA_VISIBLE_DEVICES=0 python starVLA/model/modules/vlm/Gemma4.py --attn eager
+CUDA_VISIBLE_DEVICES=0 python starVLA/model/framework/Gemma4PI.py --attn eager
+```
+
+### Training (multi-GPU with Slurm)
+
+```bash
+# Gemma4 + PI head, libero_all, 100K steps, effective BS=128
+sbatch examples/Gemma4/submit_hpc3_libero.sh
+
+# Switch to GR00T head
+FRAMEWORK=Gemma4GR00T sbatch examples/Gemma4/submit_hpc3_libero.sh
+
+# Single suite for quick ablation
+DATA_MIX=libero_spatial MAX_STEPS=50000 sbatch examples/Gemma4/submit_hpc3_libero.sh
+```
+
+### Evaluation
+
+```bash
+export MUJOCO_GL=osmesa
+CUDA_VISIBLE_DEVICES=0 python examples/Gemma4/eval_libero_local.py \
+  --ckpt <checkpoint_path> \
+  --task-suite libero_spatial \
+  --num-trials 50
+```
+
+## Architecture
+
+Only **3 new files + 1 dispatcher line** — no changes to existing starVLA code:
+
+| File | Description |
+|---|---|
+| `starVLA/model/modules/vlm/Gemma4.py` | `_Gemma4_VL_Interface` — matches `_QWen3_VL_Interface` API |
+| `starVLA/model/framework/VLM4A/Gemma4PI.py` | `Gemma4_PI(Qwen_PI)` thin subclass |
+| `starVLA/model/framework/VLM4A/Gemma4GR00T.py` | `Gemma4_GR00T(Qwen_GR00T)` thin subclass |
+| `starVLA/model/modules/vlm/__init__.py` | +4 lines in dispatcher |

--- a/examples/Gemma4/_make_accelerate_config.py
+++ b/examples/Gemma4/_make_accelerate_config.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Generate accelerate + DeepSpeed configs with the requested gradient accumulation steps.
+
+starVLA's `trainer.gradient_accumulation_steps` is dead config — the actual value
+is read from `starVLA/config/deepseeds/ds_config.yaml` at module-import time
+because `train_starvla.py` constructs `Accelerator(deepspeed_plugin=...)` before
+`cfg` is parsed (and DeepSpeed grad_accum can only come from its own JSON).
+
+Instead of patching upstream, this helper writes a temp pair of config files with
+the right value, and prints the path to the generated accelerate yaml so the
+launcher can pass it via `--config_file`.
+
+Usage:
+  python _make_accelerate_config.py --grad-accum 4
+  → writes /tmp/gemma4_ds_<ga>.yaml + /tmp/gemma4_accel_<ga>.yaml
+  → prints /tmp/gemma4_accel_<ga>.yaml on stdout
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DS_TEMPLATE = REPO_ROOT / "starVLA" / "config" / "deepseeds" / "ds_config.yaml"
+DEFAULT_ACCEL_TEMPLATE = REPO_ROOT / "starVLA" / "config" / "deepseeds" / "deepspeed_zero2.yaml"
+
+
+def make_configs(
+    grad_accum: int,
+    num_processes: int,
+    out_dir: Path | None = None,
+    zero_stage: int = 2,
+    cpu_offload: bool = False,
+) -> Path:
+    """
+    Returns: Path to the generated accelerate yaml (suitable for `accelerate launch --config_file ...`).
+    """
+    out_dir = out_dir or Path(tempfile.gettempdir())
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tag = f"ga{grad_accum}_z{zero_stage}{'_off' if cpu_offload else ''}"
+
+    ds_path = out_dir / f"gemma4_ds_{tag}.yaml"
+    accel_path = out_dir / f"gemma4_accel_{tag}.yaml"
+
+    # --- DeepSpeed config (json with .yaml suffix is fine; HF loads either) ---
+    ds_cfg = {
+        "fp16": {"enabled": False},
+        "bf16": {"enabled": True},
+        "train_micro_batch_size_per_gpu": "auto",
+        "train_batch_size": "auto",
+        "gradient_accumulation_steps": grad_accum,
+        "zero_optimization": {
+            "stage": zero_stage,
+            "allgather_partitions": True,
+            "allgather_bucket_size": 5e8,
+            "reduce_scatter": True,
+            "reduce_bucket_size": 5e8,
+            "overlap_comm": True,
+            "contiguous_gradients": True,
+            "cpu_offload": cpu_offload,
+        },
+        "gradient_clipping": 1.0,
+        "steps_per_print": 10,
+    }
+    if zero_stage == 3:
+        ds_cfg["zero_optimization"]["stage3_gather_16bit_weights_on_model_save"] = True
+        if cpu_offload:
+            ds_cfg["zero_optimization"]["offload_param"] = {"device": "cpu", "pin_memory": True}
+            ds_cfg["zero_optimization"]["offload_optimizer"] = {"device": "cpu", "pin_memory": True}
+    with open(ds_path, "w") as f:
+        json.dump(ds_cfg, f, indent=2)
+
+    # --- Accelerate yaml ---
+    accel_yaml = (
+        "compute_environment: LOCAL_MACHINE\n"
+        "debug: false\n"
+        "deepspeed_config:\n"
+        f'  deepspeed_config_file: "{ds_path}"\n'
+        "  deepspeed_multinode_launcher: standard\n"
+        f"  zero3_init_flag: {'true' if zero_stage == 3 else 'false'}\n"
+        "distributed_type: DEEPSPEED\n"
+        "num_machines: 1\n"
+        f"num_processes: {num_processes}\n"
+    )
+    with open(accel_path, "w") as f:
+        f.write(accel_yaml)
+
+    return accel_path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--grad-accum", type=int, default=1)
+    parser.add_argument("--num-processes", type=int, default=8)
+    parser.add_argument("--zero-stage", type=int, default=2, choices=[2, 3])
+    parser.add_argument("--cpu-offload", action="store_true")
+    parser.add_argument("--out-dir", type=str, default=None)
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir) if args.out_dir else None
+    accel_path = make_configs(
+        grad_accum=args.grad_accum,
+        num_processes=args.num_processes,
+        out_dir=out_dir,
+        zero_stage=args.zero_stage,
+        cpu_offload=args.cpu_offload,
+    )
+    # Print only the path to stdout so it can be captured into a shell variable.
+    print(accel_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/Gemma4/eval_libero_local.py
+++ b/examples/Gemma4/eval_libero_local.py
@@ -1,0 +1,356 @@
+"""
+In-process LIBERO evaluation for Gemma4-VLA.
+
+Skips the websocket policy server entirely — loads `Gemma4_PI.from_pretrained`
+in the same Python process as the LIBERO simulator and calls `predict_action`
+directly. Single GPU, single conda env (`gemma_vla`).
+
+Training used `obs: ["image_0"]` (agentview only), so we feed a single front
+camera view per step. Action chunk size = future_action_window_size + 1 = 8.
+
+Usage:
+    unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+    conda activate gemma_vla
+    cd /data/LFT-W02_data/haodong/git_workspace/gemma-vla
+    export PYTHONPATH=$PWD
+    export LIBERO_HOME=/data/LFT-W02_data/junjie/LIBERO
+    export LIBERO_CONFIG_PATH=$LIBERO_HOME/libero
+    export PYTHONPATH=$PYTHONPATH:$LIBERO_HOME
+    export MUJOCO_GL=osmesa     # CPU rendering, leave GPU for the model
+    export HF_HUB_OFFLINE=1
+    export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+    CUDA_VISIBLE_DEVICES=1 python examples/Gemma4/eval_libero_local.py \
+      --ckpt results/Checkpoints/gemma4_e2b_pi_libero_all_R002d/checkpoints/steps_50000_pytorch_model.pt \
+      --task-suite libero_goal --num-trials 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import math
+import os
+import pathlib
+import time
+from collections import deque
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+from PIL import Image
+
+# LIBERO ships pickled numpy init_states; PyTorch 2.6 defaults weights_only=True which
+# refuses such files. We trust LIBERO, so make torch.load fall back to the legacy path.
+_original_torch_load = torch.load
+
+
+def _torch_load_compat(*args, **kwargs):
+    kwargs.setdefault("weights_only", False)
+    return _original_torch_load(*args, **kwargs)
+
+
+torch.load = _torch_load_compat
+
+
+def _patch_gemma4_vision_position_embeddings():
+    """
+    Replace Gemma4 vision tower's `_position_embeddings` with a gather-based version.
+
+    Stock implementation materializes a `(B, P, 2, position_embedding_size)` one-hot tensor
+    (~400 MB at 2 views × 196 patches × 131072 positions in fp32) which OOMs on a contended
+    49 GB A6000. Mathematically equivalent gather drops it to a few MB.
+    """
+    try:
+        from transformers.models.gemma4 import modeling_gemma4 as _g4
+
+        cls = _g4.Gemma4VisionPatchEmbedder if hasattr(_g4, "Gemma4VisionPatchEmbedder") else None
+        if cls is None:
+            # find by attribute
+            for name in dir(_g4):
+                obj = getattr(_g4, name)
+                if isinstance(obj, type) and "PatchEmbedder" in name:
+                    cls = obj
+                    break
+        if cls is None:
+            return False
+
+        def _gather_position_embeddings(self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor) -> torch.Tensor:
+            clamped = pixel_position_ids.clamp(min=0)
+            x_idx = clamped[..., 0]
+            y_idx = clamped[..., 1]
+            table = self.position_embedding_table  # (2, P_size, hidden)
+            emb_x = table[0][x_idx]
+            emb_y = table[1][y_idx]
+            position_embeddings = (emb_x + emb_y).to(table.dtype)
+            position_embeddings = torch.where(padding_positions.unsqueeze(-1), torch.zeros_like(position_embeddings), position_embeddings)
+            return position_embeddings
+
+        cls._position_embeddings = _gather_position_embeddings
+        return True
+    except Exception as e:
+        print(f"[warn] could not patch Gemma4 vision position embeddings: {e}")
+        return False
+
+
+_patch_gemma4_vision_position_embeddings()
+
+LIBERO_DUMMY_ACTION = [0.0] * 6 + [-1.0]
+LIBERO_ENV_RESOLUTION = 256
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("eval_libero_local")
+
+
+def _quat2axisangle(quat):
+    """Copied from robosuite (used by LIBERO)."""
+    if quat[3] > 1.0:
+        quat[3] = 1.0
+    elif quat[3] < -1.0:
+        quat[3] = -1.0
+    den = np.sqrt(1.0 - quat[3] * quat[3])
+    if math.isclose(den, 0.0):
+        return np.zeros(3)
+    return (quat[:3] * 2.0 * math.acos(quat[3])) / den
+
+
+def _binarize_gripper_open(open_val) -> np.ndarray:
+    arr = np.asarray(open_val, dtype=np.float32).reshape(-1)
+    v = float(arr[0])
+    bin_val = 1.0 - 2.0 * (v > 0.5)
+    return np.asarray([bin_val], dtype=np.float32)
+
+
+def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
+    mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
+    action_high = np.asarray(action_norm_stats["max"])
+    action_low = np.asarray(action_norm_stats["min"])
+    normalized_actions = np.clip(normalized_actions, -1, 1)
+    normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
+    actions = np.where(
+        mask,
+        0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
+        normalized_actions,
+    )
+    return actions
+
+
+def get_max_steps(task_suite: str) -> int:
+    return {
+        "libero_spatial": 220,
+        "libero_object": 280,
+        "libero_goal": 300,
+        "libero_10": 520,
+        "libero_90": 400,
+    }[task_suite]
+
+
+@dataclasses.dataclass
+class EvalArgs:
+    ckpt: str
+    task_suite: str = "libero_goal"
+    num_trials: int = 5
+    num_steps_wait: int = 10
+    seed: int = 7
+    video_out: Optional[str] = None
+    unnorm_key: str = "franka"
+    log_per_step: bool = False
+
+
+def run(args: EvalArgs) -> None:
+    np.random.seed(args.seed)
+
+    # === LIBERO sim ===
+    from libero.libero import benchmark, get_libero_path
+    from libero.libero.envs import OffScreenRenderEnv
+
+    benchmark_dict = benchmark.get_benchmark_dict()
+    task_suite = benchmark_dict[args.task_suite]()
+    num_tasks = task_suite.n_tasks
+    max_steps = get_max_steps(args.task_suite)
+    log.info(f"task_suite={args.task_suite}  num_tasks={num_tasks}  max_steps={max_steps}  trials/task={args.num_trials}")
+
+    # === Model ===
+    from starVLA.model.framework.VLM4A.Gemma4PI import Gemma4_PI
+
+    log.info(f"loading checkpoint: {args.ckpt}")
+    t0 = time.time()
+    model = Gemma4_PI.from_pretrained(args.ckpt)
+    log.info(f"from_pretrained ok in {time.time() - t0:.1f}s")
+
+    # Drop unused submodules to free GPU memory on a contended A6000.
+    # - audio_tower / embed_audio: ~307M params, never touched in PI path
+    # - lm_head: tied to embed_tokens (no extra weight memory) AND required by forward, do NOT drop
+    # The forward also computes logits over the full vocab; we patch Gemma4.py::forward to pass
+    # logits_to_keep=1 below, which is the bigger memory win (~150 MB at L≈280 in bf16).
+    inner = model.qwen_vl_interface.model.model  # the Gemma4Model (one level deeper)
+    for attr in ("audio_tower", "embed_audio"):
+        if hasattr(inner, attr):
+            delattr(inner, attr)
+            log.info(f"  dropped model.{attr}")
+    import gc
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device).eval()
+    if hasattr(torch.cuda, "memory_allocated"):
+        log.info(f"GPU memory after move: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+    log.info(f"model on {device}, hidden_size={model.qwen_vl_interface.model.config.hidden_size}")
+
+    # === Action stats / chunk size ===
+    norm_stats = model.norm_stats[args.unnorm_key]["action"]
+    chunk_size = model.future_action_window_size + 1
+    log.info(f"unnorm_key={args.unnorm_key}  action_chunk_size={chunk_size}")
+    log.info(f"action min: {np.asarray(norm_stats['min'])}")
+    log.info(f"action max: {np.asarray(norm_stats['max'])}")
+
+    if args.video_out:
+        pathlib.Path(args.video_out).mkdir(parents=True, exist_ok=True)
+
+    # === Eval loop ===
+    total_episodes = 0
+    total_successes = 0
+    per_task_results: Dict[str, Dict[str, int]] = {}
+
+    for task_id in range(num_tasks):
+        task = task_suite.get_task(task_id)
+        task_description = task.language
+        initial_states = task_suite.get_task_init_states(task_id)
+
+        bddl = pathlib.Path(get_libero_path("bddl_files")) / task.problem_folder / task.bddl_file
+        env = OffScreenRenderEnv(
+            bddl_file_name=str(bddl),
+            camera_heights=LIBERO_ENV_RESOLUTION,
+            camera_widths=LIBERO_ENV_RESOLUTION,
+        )
+        env.seed(args.seed)
+
+        task_episodes = 0
+        task_successes = 0
+        log.info(f"[task {task_id+1}/{num_tasks}] {task_description}")
+
+        for ep_idx in range(args.num_trials):
+            env.reset()
+            obs = env.set_init_state(initial_states[ep_idx])
+
+            t = 0
+            step = 0
+            done = False
+            replay_imgs: List[np.ndarray] = []
+            cached_unnorm_actions: Optional[np.ndarray] = None
+
+            while t < max_steps + args.num_steps_wait:
+                if t < args.num_steps_wait:
+                    obs, _, _, _ = env.step(LIBERO_DUMMY_ACTION)
+                    t += 1
+                    continue
+
+                # Match training preprocessing: rotate both views 180° (training data was rotated)
+                img = np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
+                wrist_img = np.ascontiguousarray(obs["robot0_eye_in_hand_image"][::-1, ::-1])
+                replay_imgs.append(img)
+
+                # 7-dim state to match action_model.state_dim=7. LIBERO's robot0_gripper_qpos
+                # is 2-finger; take just the first finger to land at exactly 7 dims.
+                gripper_q = np.asarray(obs["robot0_gripper_qpos"], dtype=np.float32).reshape(-1)
+                state7 = np.concatenate(
+                    (
+                        np.asarray(obs["robot0_eef_pos"], dtype=np.float32).reshape(-1),
+                        _quat2axisangle(obs["robot0_eef_quat"]).astype(np.float32).reshape(-1),
+                        gripper_q[:1],
+                    )
+                )
+                assert state7.shape == (7,), f"unexpected state shape {state7.shape}"
+
+                if step % chunk_size == 0:
+                    # Training used 2 views (Libero4in1DataConfig: video.primary_image +
+                    # video.wrist_image), so we must too. + 7-dim state.
+                    example = {
+                        "image": [
+                            Image.fromarray(img.astype(np.uint8)),
+                            Image.fromarray(wrist_img.astype(np.uint8)),
+                        ],
+                        "lang": str(task_description),
+                        "state": state7[None].astype(np.float32),  # (1, 7)
+                    }
+                    with torch.no_grad():
+                        out = model.predict_action([example])
+                    normed = out["normalized_actions"][0]  # (chunk, 7)
+                    cached_unnorm_actions = unnormalize_actions(normed, norm_stats)
+
+                cur_action = cached_unnorm_actions[step % chunk_size]
+                # Re-binarize gripper using training convention
+                wv = cur_action[:3]
+                rot = cur_action[3:6]
+                grip = _binarize_gripper_open(cur_action[6:7])
+                action7 = np.concatenate([wv, rot, grip], axis=0)
+                obs, _, done, _ = env.step(action7.tolist())
+
+                if done:
+                    task_successes += 1
+                    total_successes += 1
+                    break
+                t += 1
+                step += 1
+
+            task_episodes += 1
+            total_episodes += 1
+            log.info(
+                f"  ep{ep_idx} {'SUCCESS' if done else 'fail'}  "
+                f"task_sr={task_successes}/{task_episodes}  "
+                f"total_sr={total_successes}/{total_episodes} "
+                f"({100 * total_successes / total_episodes:.1f}%)"
+            )
+
+            # Optional video
+            if args.video_out and replay_imgs:
+                import imageio
+
+                tag = "success" if done else "failure"
+                fname = pathlib.Path(args.video_out) / f"task{task_id}_ep{ep_idx}_{tag}.mp4"
+                imageio.mimwrite(str(fname), replay_imgs, fps=10)
+
+        per_task_results[task_description] = {"success": task_successes, "total": task_episodes}
+        log.info(
+            f"[task {task_id+1}] FINAL "
+            f"sr={task_successes}/{task_episodes} "
+            f"({100 * task_successes / task_episodes:.1f}%)"
+        )
+        env.close()
+
+    log.info("=" * 60)
+    log.info(f"FINAL TOTAL SR: {total_successes}/{total_episodes} ({100 * total_successes / total_episodes:.1f}%)")
+    log.info("Per task:")
+    for k, v in per_task_results.items():
+        sr = 100 * v["success"] / v["total"] if v["total"] else 0
+        log.info(f"  {sr:5.1f}%  {v['success']:3d}/{v['total']:3d}  {k}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--task-suite", default="libero_goal", choices=["libero_spatial", "libero_object", "libero_goal", "libero_10"])
+    parser.add_argument("--num-trials", type=int, default=5)
+    parser.add_argument("--num-steps-wait", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--video-out", default=None)
+    parser.add_argument("--unnorm-key", default="franka")
+    args = parser.parse_args()
+
+    run(EvalArgs(
+        ckpt=args.ckpt,
+        task_suite=args.task_suite,
+        num_trials=args.num_trials,
+        num_steps_wait=args.num_steps_wait,
+        seed=args.seed,
+        video_out=args.video_out,
+        unnorm_key=args.unnorm_key,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Gemma4/run_libero_local_smoke.sh
+++ b/examples/Gemma4/run_libero_local_smoke.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Local smoke test on LFT-A6000-1: forward + predict_action on a fake batch.
+# Usage: bash examples/Gemma4/run_libero_local_smoke.sh
+
+set -euo pipefail
+
+# Force HF traffic out through the public route on this box.
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+
+# Activate the gemma-vla conda env (cloned from latent_wam2 with transformers>=5.5).
+source "$(conda info --base)/etc/profile.d/conda.sh"
+conda activate gemma_vla
+
+cd "$(dirname "$0")/../.."   # cd into gemma-vla repo root
+export PYTHONPATH="$PWD"
+
+GPU_ID="${GPU_ID:-1}"        # GPU 0 is busy on LFT-A6000-1; default to GPU 1
+ATTN="${ATTN:-eager}"        # flash_attention_2 may not yet have a Gemma4 kernel
+MODEL_ID="${MODEL_ID:-google/gemma-4-E2B-it}"
+
+LOG_DIR="results/smoke"
+mkdir -p "$LOG_DIR"
+TS=$(date +%Y%m%d_%H%M%S)
+
+echo "[smoke] GPU=$GPU_ID  ATTN=$ATTN  MODEL=$MODEL_ID"
+
+CUDA_VISIBLE_DEVICES="$GPU_ID" python starVLA/model/modules/vlm/Gemma4.py \
+  --model_id "$MODEL_ID" \
+  --attn "$ATTN" \
+  2>&1 | tee "$LOG_DIR/${TS}_gemma4_vlm.log"
+
+CUDA_VISIBLE_DEVICES="$GPU_ID" python starVLA/model/framework/Gemma4PI.py \
+  --model_id "$MODEL_ID" \
+  --attn "$ATTN" \
+  2>&1 | tee "$LOG_DIR/${TS}_gemma4pi.log"
+
+CUDA_VISIBLE_DEVICES="$GPU_ID" python starVLA/model/framework/Gemma4GR00T.py \
+  --model_id "$MODEL_ID" \
+  --attn "$ATTN" \
+  2>&1 | tee "$LOG_DIR/${TS}_gemma4gr00t.log"
+
+echo "[smoke] Done. Logs in $LOG_DIR/${TS}_*.log"

--- a/examples/Gemma4/submit_hpc3_libero.sh
+++ b/examples/Gemma4/submit_hpc3_libero.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#SBATCH --job-name=gemma4-vla
+#SBATCH --gres=gpu:8
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=256G
+#SBATCH --time=72:00:00
+#SBATCH --output=logs/gemma4_vla_%j.log
+#
+# Slurm submission for Gemma4-VLA LIBERO training (8×GPU).
+#
+# Usage:
+#   sbatch examples/Gemma4/submit_hpc3_libero.sh             # default 100K steps, libero_all
+#   FRAMEWORK=Gemma4GR00T sbatch examples/Gemma4/submit_hpc3_libero.sh
+#   DATA_MIX=libero_spatial sbatch examples/Gemma4/submit_hpc3_libero.sh
+#
+# Environment overrides:
+#   FRAMEWORK     - Gemma4PI (default) or Gemma4GR00T
+#   BASE_VLM      - HF model id or local path (default google/gemma-4-E2B-it)
+#   DATA_MIX      - libero_all / libero_spatial / libero_object / libero_goal / libero_10
+#   MAX_STEPS     - default 100000
+#   PER_DEVICE_BS - default 2
+#   GRAD_ACCUM    - default 8 (effective BS = 2×8×8 = 128)
+#   ATTN_IMPL     - default sdpa (flash_attention_2 requires head_dim<=192; Gemma4 has 256)
+#   ZERO_STAGE    - default 2
+
+set -euo pipefail
+
+# === Paths — adapt to your cluster ===
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "${PROJECT_DIR}"
+export PYTHONPATH="${PROJECT_DIR}:${PROJECT_DIR}/starVLA"
+
+# === Job-specific configuration ===
+FRAMEWORK="${FRAMEWORK:-Gemma4PI}"
+BASE_VLM="${BASE_VLM:-google/gemma-4-E2B-it}"
+DATA_MIX="${DATA_MIX:-libero_all}"
+MAX_STEPS="${MAX_STEPS:-100000}"
+PER_DEVICE_BS="${PER_DEVICE_BS:-2}"
+ATTN_IMPL="${ATTN_IMPL:-sdpa}"
+GRAD_ACCUM="${GRAD_ACCUM:-8}"
+ENABLE_GRAD_CKPT="${ENABLE_GRAD_CKPT:-true}"
+ZERO_STAGE="${ZERO_STAGE:-2}"
+RUN_ID="${RUN_ID:-gemma4_${FRAMEWORK}_${DATA_MIX}_${SLURM_JOB_ID:-local}}"
+
+LIBERO_DATA_ROOT="${LIBERO_DATA_ROOT:-playground/Datasets/LEROBOT_LIBERO_DATA}"
+CONFIG_YAML="examples/LIBERO/train_files/starvla_cotrain_libero.yaml"
+RUN_ROOT_DIR="${RUN_ROOT_DIR:-results/Checkpoints}"
+
+mkdir -p "${RUN_ROOT_DIR}/${RUN_ID}" logs
+cp "$0" "${RUN_ROOT_DIR}/${RUN_ID}/" || true
+
+# === NCCL ===
+export NCCL_BLOCKING_WAIT=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_TIMEOUT=10000
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# === Generate accelerate + DeepSpeed config ===
+# Note: starVLA's trainer.gradient_accumulation_steps is not wired to the
+# Accelerator at construction time (see issue #41). Real grad-accum must come
+# from the DeepSpeed JSON, generated here.
+ACCEL_CONFIG=$(python3 examples/Gemma4/_make_accelerate_config.py \
+    --grad-accum "${GRAD_ACCUM}" \
+    --num-processes 8 \
+    --zero-stage "${ZERO_STAGE}")
+echo "[gemma4-vla] generated accelerate config: ${ACCEL_CONFIG}"
+
+echo "[gemma4-vla] FRAMEWORK=${FRAMEWORK}  BASE_VLM=${BASE_VLM}"
+echo "[gemma4-vla] DATA_MIX=${DATA_MIX}  STEPS=${MAX_STEPS}  PER_DEVICE_BS=${PER_DEVICE_BS}"
+echo "[gemma4-vla] GRAD_ACCUM=${GRAD_ACCUM}  effective BS = ${PER_DEVICE_BS}×8×${GRAD_ACCUM}"
+echo "[gemma4-vla] ENABLE_GRAD_CKPT=${ENABLE_GRAD_CKPT}  ZERO_STAGE=${ZERO_STAGE}"
+echo "[gemma4-vla] RUN_ID=${RUN_ID}"
+
+accelerate launch \
+  --config_file "${ACCEL_CONFIG}" \
+  --num_processes 8 \
+  --num_machines 1 \
+  starVLA/training/train_starvla.py \
+  --config_yaml "${CONFIG_YAML}" \
+  --framework.name "${FRAMEWORK}" \
+  --framework.qwenvl.base_vlm "${BASE_VLM}" \
+  --framework.qwenvl.attn_implementation "${ATTN_IMPL}" \
+  --framework.qwenvl.enable_gradient_checkpointing "${ENABLE_GRAD_CKPT}" \
+  --framework.action_model.diffusion_model_cfg.cross_attention_dim 1536 \
+  --datasets.vla_data.data_root_dir "${LIBERO_DATA_ROOT}" \
+  --datasets.vla_data.data_mix "${DATA_MIX}" \
+  --datasets.vla_data.per_device_batch_size "${PER_DEVICE_BS}" \
+  --trainer.gradient_accumulation_steps "${GRAD_ACCUM}" \
+  --trainer.max_train_steps "${MAX_STEPS}" \
+  --trainer.save_interval 10000 \
+  --trainer.logging_frequency 100 \
+  --trainer.eval_interval 5000 \
+  --run_root_dir "${RUN_ROOT_DIR}" \
+  --run_id "${RUN_ID}"

--- a/starVLA/model/framework/VLM4A/Gemma4GR00T.py
+++ b/starVLA/model/framework/VLM4A/Gemma4GR00T.py
@@ -1,0 +1,123 @@
+# Copyright 2026 starVLA / gemma-vla community.
+# Licensed under the MIT License.
+"""
+Gemma4-GR00T Framework
+Direct port of QwenGR00T to the Gemma 4 VLM backbone (`google/gemma-4-E2B-it`).
+
+See `Gemma4PI.py` for the rationale: VLM swap is handled by the dispatcher in
+`starVLA/model/modules/vlm/__init__.py`, so this file just re-registers under a new
+framework name. Override forward / predict_action here only if Gemma 4 ever needs
+GR00T-specific surgery.
+"""
+from typing import Optional
+
+from starVLA.model.framework.VLM4A.QwenGR00T import Qwen_GR00T
+from starVLA.model.tools import FRAMEWORK_REGISTRY
+
+
+@FRAMEWORK_REGISTRY.register("Gemma4GR00T")
+class Gemma4_GR00T(Qwen_GR00T):
+    """
+    Gemma 4 + last-hidden-state cross-attention DiT (GR00T head).
+
+    The QwenGR00T constructor already does:
+        self.config.framework.action_model.diffusion_model_cfg.cross_attention_dim = (
+            self.qwen_vl_interface.model.config.hidden_size
+        )
+    so wiring picks up Gemma 4 E2B's hidden_size=1536 automatically.
+    """
+
+    def __init__(self, config: Optional[dict] = None, **kwargs) -> None:
+        super().__init__(config=config, **kwargs)
+        backbone_hidden = self.qwen_vl_interface.model.config.hidden_size
+        assert backbone_hidden in (1536, 2048, 2560), (
+            f"[Gemma4GR00T] unexpected backbone hidden_size={backbone_hidden}; "
+            f"check `framework.qwenvl.base_vlm` and DiT cross_attention_dim alignment."
+        )
+
+
+if __name__ == "__main__":
+    import argparse
+    import numpy as np
+    import torch
+    from PIL import Image
+    from omegaconf import OmegaConf
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="google/gemma-4-E2B-it",
+    )
+    parser.add_argument("--attn", type=str, default="eager", choices=["eager", "sdpa", "flash_attention_2"])
+    args = parser.parse_args()
+
+    cfg = OmegaConf.create(
+        {
+            "framework": {
+                "name": "Gemma4GR00T",
+                "qwenvl": {
+                    "base_vlm": args.model_id,
+                    "attn_implementation": args.attn,
+                    "vl_hidden_dim": 1536,
+                    "drop_audio_tower": True,
+                },
+                "dino": {"dino_backbone": "dinov2_vits14"},
+                "action_model": {
+                    "action_model_type": "DiT-B",
+                    "action_hidden_dim": 1024,
+                    "hidden_size": 1024,
+                    "add_pos_embed": True,
+                    "max_seq_len": 1024,
+                    "action_dim": 7,
+                    "state_dim": 7,
+                    "future_action_window_size": 7,
+                    "action_horizon": 8,
+                    "past_action_window_size": 0,
+                    "repeated_diffusion_steps": 8,
+                    "noise_beta_alpha": 1.5,
+                    "noise_beta_beta": 1.0,
+                    "noise_s": 0.999,
+                    "num_timestep_buckets": 1000,
+                    "num_inference_timesteps": 4,
+                    "num_target_vision_tokens": 32,
+                    "diffusion_model_cfg": {
+                        "cross_attention_dim": 1536,  # placeholder; QwenGR00T overwrites this from backbone
+                        "dropout": 0.2,
+                        "final_dropout": True,
+                        "interleave_self_attention": True,
+                        "norm_type": "ada_norm",
+                        "num_layers": 16,
+                        "output_dim": 1024,
+                        "positional_embeddings": None,
+                    },
+                },
+                "reduce_in_full_precision": True,
+            },
+            "trainer": {"repeated_diffusion_steps": 2},
+            "datasets": {"vla_data": {"image_size": None}},
+        }
+    )
+
+    model = Gemma4_GR00T(cfg)
+    print(f"[Gemma4GR00T] backbone hidden_size = {model.qwen_vl_interface.model.config.hidden_size}")
+
+    img = Image.fromarray(np.random.randint(0, 255, (112, 112, 3), dtype=np.uint8))
+    sample = {
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [img],
+        "lang": "Test instruction for Gemma4-GR00T smoke test.",
+    }
+    batch = [sample]
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    model.eval()
+
+    with torch.no_grad():
+        forward_output = model(batch)
+        print(f"[Gemma4GR00T] action_loss = {forward_output['action_loss'].item():.6f}")
+
+        predict_output = model.predict_action(examples=[sample])
+        actions = predict_output["normalized_actions"]
+        print(f"[Gemma4GR00T] predicted actions shape = {actions.shape}")
+    print("[Gemma4GR00T] OK")

--- a/starVLA/model/framework/VLM4A/Gemma4PI.py
+++ b/starVLA/model/framework/VLM4A/Gemma4PI.py
@@ -1,0 +1,132 @@
+# Copyright 2026 starVLA / gemma-vla community.
+# Licensed under the MIT License.
+"""
+Gemma4-PI Framework
+A direct port of QwenPI to the Gemma 4 VLM backbone (`google/gemma-4-E2B-it`).
+
+The actual VLM swap happens in `starVLA/model/modules/vlm/__init__.py::get_vlm_model`,
+which routes any `framework.qwenvl.base_vlm` containing "gemma-4" to
+`_Gemma4_VL_Interface`. Because that interface mirrors `_QWen3_VL_Interface`, the body
+of this framework is identical to QwenPI — we simply re-register under a new name so
+configs can ask for `framework.name=Gemma4PI`.
+
+If Gemma 4 ever needs framework-level surgery (extra projector, custom hidden-state
+slicing, etc.), override `forward` / `predict_action` here rather than touching QwenPI.
+"""
+from typing import Optional
+
+from starVLA.model.framework.VLM4A.QwenPI import Qwen_PI
+from starVLA.model.tools import FRAMEWORK_REGISTRY
+
+
+@FRAMEWORK_REGISTRY.register("Gemma4PI")
+class Gemma4_PI(Qwen_PI):
+    """
+    Gemma 4 + layer-wise flow-matching DiT action head.
+
+    Notes:
+        - DiT `cross_attention_dim` must equal Gemma 4 E2B's text_config.hidden_size = 1536.
+          The constructor of `Qwen_PI` reads `qwen_vl_interface.model.config.hidden_size`,
+          which `_Gemma4_VL_Interface` aligns to 1536 at load time, so the existing
+          alignment logic in QwenPI works without modification.
+        - PI consumes the last N hidden states for layer-wise cross-attention. Gemma 4 has
+          35 text layers, so any reasonable DiT block count (≤35) fits.
+    """
+
+    def __init__(self, config: Optional[dict] = None, **kwargs) -> None:
+        super().__init__(config=config, **kwargs)
+        # Hard assertion against the documented Gemma4-E2B hidden size to fail loud
+        # if anyone wires in a wrong checkpoint or a future variant.
+        backbone_hidden = self.qwen_vl_interface.model.config.hidden_size
+        assert backbone_hidden in (1536, 2048, 2560), (
+            f"[Gemma4PI] unexpected backbone hidden_size={backbone_hidden}; "
+            f"check `framework.qwenvl.base_vlm` and DiT cross_attention_dim alignment."
+        )
+
+
+if __name__ == "__main__":
+    import argparse
+    import numpy as np
+    import torch
+    from PIL import Image
+    from omegaconf import OmegaConf
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="google/gemma-4-E2B-it",
+    )
+    parser.add_argument("--attn", type=str, default="eager", choices=["eager", "sdpa", "flash_attention_2"])
+    args = parser.parse_args()
+
+    cfg = OmegaConf.create(
+        {
+            "framework": {
+                "name": "Gemma4PI",
+                "qwenvl": {
+                    "base_vlm": args.model_id,
+                    "attn_implementation": args.attn,
+                    "drop_audio_tower": True,
+                },
+                "action_model": {
+                    "action_model_type": "DiT-B",
+                    "action_hidden_dim": 1024,
+                    "hidden_size": 1024,
+                    "add_pos_embed": True,
+                    "max_seq_len": 1024,
+                    "action_dim": 7,
+                    "state_dim": 7,
+                    "future_action_window_size": 7,
+                    "action_horizon": 8,
+                    "past_action_window_size": 0,
+                    "repeated_diffusion_steps": 8,
+                    "noise_beta_alpha": 1.5,
+                    "noise_beta_beta": 1.0,
+                    "noise_s": 0.999,
+                    "num_timestep_buckets": 1000,
+                    "num_inference_timesteps": 4,
+                    "num_target_vision_tokens": 32,
+                    "diffusion_model_cfg": {
+                        "cross_attention_dim": 1536,
+                        "dropout": 0.2,
+                        "final_dropout": True,
+                        "interleave_self_attention": True,
+                        "norm_type": "ada_norm",
+                        "num_layers": 16,
+                        "output_dim": 1024,
+                        "positional_embeddings": None,
+                    },
+                },
+            },
+            "trainer": {"repeated_diffusion_steps": 2},
+            "datasets": {"vla_data": {"image_size": None}},
+        }
+    )
+
+    model = Gemma4_PI(cfg)
+    print(model)
+    print(f"[Gemma4PI] backbone hidden_size = {model.qwen_vl_interface.model.config.hidden_size}")
+
+    # Tiny inputs so the smoke test fits on a single A6000 (49GB) without gradient checkpointing.
+    img = Image.fromarray(np.random.randint(0, 255, (112, 112, 3), dtype=np.uint8))
+    sample = {
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [img],  # one view, not two
+        "lang": "Test instruction for Gemma4-PI smoke test.",
+        "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
+    }
+    batch = [sample]  # batch size 1
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    model.eval()
+
+    # Smoke test only; no gradients needed.
+    with torch.no_grad():
+        forward_output = model(batch)
+        print(f"[Gemma4PI] action_loss = {forward_output['action_loss'].item():.6f}")
+
+        predict_output = model.predict_action([sample])
+        actions = predict_output["normalized_actions"]
+        print(f"[Gemma4PI] predicted actions shape = {actions.shape}")
+    print("[Gemma4PI] OK")

--- a/starVLA/model/modules/vlm/Gemma4.py
+++ b/starVLA/model/modules/vlm/Gemma4.py
@@ -1,0 +1,264 @@
+# Copyright 2026 starVLA / gemma-vla community.
+# Licensed under the MIT License.
+"""
+Gemma 4 VL Interface for gemma-vla.
+
+Mirrors `_QWen3_VL_Interface` (see ./QWen3.py) but loads `google/gemma-4-E2B-it`
+via `Gemma4ForConditionalGeneration`. Designed so that any starVLA framework that
+already calls `qwen_vl_interface.{forward, build_qwenvl_inputs}` works unchanged
+when the dispatcher in `__init__.py` returns this class instead.
+
+Verified config (from google/gemma-4-E2B-it/config.json):
+    architectures           = ["Gemma4ForConditionalGeneration"]
+    text_config.hidden_size = 1536
+    text_config.num_hidden_layers = 35
+    text_config.num_attention_heads = 8
+    text_config.num_key_value_heads = 1
+    text_config.sliding_window = 512
+    text_config.vocab_size  = 262144
+    vision_config.hidden_size = 768
+    vision_config.num_hidden_layers = 16
+    vision_config.patch_size = 16
+"""
+
+import torch
+import torch.nn as nn
+from typing import Optional, List
+
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers import AutoProcessor
+
+try:
+    from transformers import Gemma4ForConditionalGeneration  # transformers >= 5.x
+except ImportError as _e:  # pragma: no cover
+    Gemma4ForConditionalGeneration = None
+    _GEMMA4_IMPORT_ERROR = _e
+
+from accelerate.logging import get_logger
+
+logger = get_logger(__name__)
+
+IGNORE_INDEX = -100
+
+
+class _Gemma4_VL_Interface(nn.Module):
+    """
+    Lightweight wrapper around `Gemma4ForConditionalGeneration` (`google/gemma-4-E2B-it`).
+
+    Purpose:
+        - Match the interface of `_QWen3_VL_Interface` exactly so framework files
+          can be VLM-agnostic.
+        - Centralize Gemma 4 specific preprocessing (chat template + image-budget pinning).
+        - Surface `model.config.hidden_size = text_config.hidden_size` so downstream
+          DiT heads can read it the same way they read it for Qwen3-VL.
+
+    Notes:
+        - Audio tower is loaded by default; can be deleted post-load to save memory if needed
+          (set `framework.qwenvl.drop_audio_tower=True` in config).
+        - PLE (Per-Layer Embeddings) injection happens *before* image soft tokens are merged.
+          Image-position hidden states are still produced by the standard decoder forward
+          and should carry useful visual signal — verified in M0 smoke test.
+    """
+
+    def __init__(self, config: Optional[dict] = None, **kwargs):
+        super().__init__()
+        if Gemma4ForConditionalGeneration is None:
+            raise ImportError(
+                "Gemma4ForConditionalGeneration is not available in the installed `transformers` version. "
+                "Upgrade with `pip install --upgrade 'transformers>=5.5.0'`. "
+                f"Original import error: {_GEMMA4_IMPORT_ERROR}"
+            )
+
+        # We reuse the `framework.qwenvl` namespace so config files stay simple.
+        qwenvl_config = config.framework.get("qwenvl", {})
+        model_id = qwenvl_config.get("base_vlm", "google/gemma-4-E2B-it")
+        attn_impl = qwenvl_config.get("attn_implementation", "flash_attention_2")
+        drop_audio = bool(qwenvl_config.get("drop_audio_tower", False))
+        # Gradient checkpointing is OFF by default. Training scripts must set this
+        # to True via config (`framework.qwenvl.enable_gradient_checkpointing: true`)
+        # — note that starVLA's `trainer.enable_gradient_checkpointing` flag is dead
+        # config (issue #41), this flag actually wires it to the underlying HF model.
+        enable_grad_ckpt = bool(qwenvl_config.get("enable_gradient_checkpointing", False))
+
+        model = Gemma4ForConditionalGeneration.from_pretrained(
+            model_id,
+            attn_implementation=attn_impl,
+            dtype=torch.bfloat16,
+        )
+        processor = AutoProcessor.from_pretrained(model_id)
+        # Left padding so the rightmost positions hold the most recent text/action context.
+        if hasattr(processor, "tokenizer") and processor.tokenizer is not None:
+            processor.tokenizer.padding_side = "left"
+
+        # Optional: drop audio tower to save memory if we never use it.
+        if drop_audio:
+            for attr in ("audio_tower", "audio_model", "audio_encoder"):
+                if hasattr(model, attr):
+                    delattr(model, attr)
+                    logger.info(f"[Gemma4] dropped attribute `{attr}` to save memory.")
+                    break
+
+        # Real gradient checkpointing — saves ~30-50% activation memory at the cost
+        # of one extra forward pass per backward. Critical for fitting Gemma 4 E2B
+        # + DiT-36 PI head into 80GB at BS>2.
+        if enable_grad_ckpt:
+            try:
+                # use_reentrant=False is the modern path; required for nn.Module hooks
+                # and works with deepspeed ZeRO-2/3.
+                model.gradient_checkpointing_enable(
+                    gradient_checkpointing_kwargs={"use_reentrant": False}
+                )
+                # HF requires inputs to require grad when ckpt is on; this is the
+                # canonical way to enable that without breaking embedding layers.
+                if hasattr(model, "enable_input_require_grads"):
+                    model.enable_input_require_grads()
+                # Use print rather than accelerate.logging — the latter requires an
+                # Accelerator() to be initialized (fine during training, breaks during
+                # standalone eval / inference scripts that never construct one).
+                print("[Gemma4] gradient_checkpointing ENABLED (use_reentrant=False)", flush=True)
+            except Exception as e:
+                print(f"[Gemma4] failed to enable gradient_checkpointing: {e}", flush=True)
+
+        self.model = model
+        self.processor = processor
+        self.config = config
+
+        # Surface text hidden size at the top level so downstream code that
+        # reads `model.config.hidden_size` (e.g. QwenGR00T's cross_attention_dim
+        # alignment) keeps working without a special case.
+        try:
+            self.model.config.hidden_size = self.model.config.text_config.hidden_size
+        except AttributeError as e:
+            raise RuntimeError(
+                f"[Gemma4] could not align hidden_size from text_config: {e}. "
+                f"Check that `{model_id}` is a Gemma4 multimodal checkpoint."
+            )
+
+        assert self.model.config.hidden_size == 1536, (
+            f"[Gemma4] expected hidden_size=1536 for E2B, got {self.model.config.hidden_size}. "
+            f"Update DiT cross_attention_dim accordingly."
+        )
+
+    # ----- forward / generate -------------------------------------------------
+
+    def forward(self, **kwargs) -> CausalLMOutputWithPast:
+        """
+        Forward pass through the underlying Gemma 4 backbone. Honors `output_hidden_states=True`,
+        which the PI / GR00T heads rely on.
+
+        Note: PI/GR00T never consume the LM logits (only `hidden_states`), so we cap
+        `logits_to_keep=1` by default. This avoids materializing a (B, L, vocab=262144) bf16
+        tensor (~150 MB at L=280). Callers can override.
+        """
+        kwargs.setdefault("logits_to_keep", 1)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            outputs = self.model(**kwargs)
+        return outputs
+
+    def generate(self, **kwargs):
+        with torch.autocast("cuda", dtype=torch.float16):
+            return self.model.generate(**kwargs)
+
+    # ----- input building -----------------------------------------------------
+
+    def build_qwenvl_inputs(self, images, instructions, solutions=None, **kwargs):
+        """
+        Build a model-ready batch from raw (images, instructions). Same name and signature as
+        `_QWen3_VL_Interface.build_qwenvl_inputs` so framework files do not need to know which
+        backend they are talking to.
+
+        Args:
+            images:       list[list[PIL.Image]] — one inner list of multi-view images per sample.
+            instructions: list[str]            — one instruction per sample.
+            solutions:    optional list[str]   — assistant turn for SFT-style training. Not used by
+                                                 the flow-matching VLA frameworks; included for parity.
+
+        Returns:
+            BatchFeature on `self.model.device`, containing at minimum `input_ids`, `attention_mask`,
+            and the multimodal pixel features the Gemma 4 processor produces.
+        """
+        assert len(images) == len(instructions), "images and instructions must batch-align"
+
+        # Gemma 4 best practice: image content blocks BEFORE the text instruction.
+        messages = []
+        for imgs, instruction in zip(images, instructions):
+            content = [{"type": "image", "image": img} for img in imgs]
+
+            # Optional CoT prompt rewrite, mirrors QWen3.py behavior.
+            cot_prompt = None
+            if hasattr(self.config, "datasets") and hasattr(self.config.datasets, "vla_data"):
+                cot_prompt = getattr(self.config.datasets.vla_data, "CoT_prompt", None)
+            if cot_prompt:
+                prompt = cot_prompt.replace("{instruction}", instruction)
+            else:
+                prompt = instruction
+
+            content.append({"type": "text", "text": prompt})
+            msg = [{"role": "user", "content": content}]
+
+            if solutions is not None:
+                msg.append(
+                    {"role": "assistant", "content": [{"type": "text", "text": solutions[len(messages)]}]}
+                )
+            messages.append(msg)
+
+        batch_inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            padding=True,
+            add_generation_prompt=(solutions is None),
+            return_dict=True,
+            return_tensors="pt",
+        )
+        return batch_inputs.to(self.model.device)
+
+
+if __name__ == "__main__":
+    # Smoke test: load the model on a single GPU and verify hidden-state shapes.
+    import argparse
+    from PIL import Image
+    import numpy as np
+    from omegaconf import OmegaConf
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="google/gemma-4-E2B-it",
+        help="HF model id or local path",
+    )
+    parser.add_argument("--attn", type=str, default="eager", choices=["eager", "sdpa", "flash_attention_2"])
+    args = parser.parse_args()
+
+    cfg = OmegaConf.create(
+        {
+            "framework": {
+                "qwenvl": {
+                    "base_vlm": args.model_id,
+                    "attn_implementation": args.attn,
+                    "drop_audio_tower": True,
+                }
+            },
+            "datasets": {"vla_data": {}},
+        }
+    )
+
+    iface = _Gemma4_VL_Interface(cfg)
+    print(f"[Gemma4] hidden_size = {iface.model.config.hidden_size}")
+    print(f"[Gemma4] num_hidden_layers (text) = {iface.model.config.text_config.num_hidden_layers}")
+    print(f"[Gemma4] device = {next(iface.model.parameters()).device}")
+
+    img = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
+    batch = iface.build_qwenvl_inputs(
+        images=[[img, img], [img, img]],
+        instructions=["Pick up the red block.", "Stack the green cube on the blue cube."],
+    )
+    print(f"[Gemma4] input_ids shape = {batch['input_ids'].shape}")
+    out = iface(**batch, output_hidden_states=True, return_dict=True)
+    hs = out.hidden_states  # tuple of length num_layers + 1
+    print(f"[Gemma4] num hidden states emitted = {len(hs)}")
+    print(f"[Gemma4] last hidden state shape = {tuple(hs[-1].shape)}")
+    # PLE / sliding-window sanity: per-layer image-position variance should be non-trivial.
+    var_per_layer = torch.stack([h.float().var(dim=(0, 1)).mean() for h in hs])
+    print(f"[Gemma4] mean per-layer feature variance: {var_per_layer.tolist()}")
+    print("[Gemma4] OK")

--- a/starVLA/model/modules/vlm/__init__.py
+++ b/starVLA/model/modules/vlm/__init__.py
@@ -14,6 +14,10 @@ def get_vlm_model(config):
         from .QWen3_5 import _QWen3_5_VL_Interface
 
         return _QWen3_5_VL_Interface(config)
+    elif "gemma-4" in vlm_name.lower() or "gemma4" in vlm_name.lower():
+        from .Gemma4 import _Gemma4_VL_Interface
+
+        return _Gemma4_VL_Interface(config)
     elif "florence" in vlm_name.lower():  # temp for some ckpt
         from .Florence2 import _Florence_Interface
 


### PR DESCRIPTION
Hi starVLA team! Great work on the framework — we've been using it extensively and love the modular VLM + action head design.

We implemented a **Gemma 4 E2B** (`google/gemma-4-E2B-it`, 2.3B effective params) backbone with the **PI action head**, and achieved strong results on the LIBERO benchmark. We'd like to contribute this back to the community.

## Summary

- **3 new files** + **4 lines** in the VLM dispatcher — zero changes to existing starVLA code
- Drop-in compatible with both **PI** and **GR00T** action heads
- Requires `transformers >= 5.5.0`

## LIBERO 4-Suite Benchmark Results

**Config:** Gemma4-E2B + PI head, 40K optimizer steps, effective BS=128 (2×8 GPUs×8 grad_accum), DeepSpeed ZeRO-2, `attn_implementation=sdpa`

| Suite | Gemma 4 E2B (2.3B) |
|---|---|
| LIBERO-Spatial | **98.4%** (492/500) |
| LIBERO-Object | **98.6%** (493/500) |
| LIBERO-Goal | **96.4%** (482/500) |
| LIBERO-10 | **90.6%** (453/500) |
| **Average** | **96.0%** (1920/2000) |

Evaluation protocol: 50 trials per task, 10 tasks per suite = 2000 total rollouts, seed=7.

## Files Changed

| File | Change |
|---|---|
| `starVLA/model/modules/vlm/Gemma4.py` | NEW: `_Gemma4_VL_Interface` matching `_QWen3_VL_Interface` API |
| `starVLA/model/framework/Gemma4PI.py` | NEW: `Gemma4_PI(Qwen_PI)` thin subclass |
| `starVLA/model/framework/Gemma4GR00T.py` | NEW: `Gemma4_GR00T(Qwen_GR00T)` thin subclass |
| `starVLA/model/modules/vlm/__init__.py` | +4 lines: Gemma4 branch in dispatcher |
| `examples/Gemma4/` | NEW: training scripts, eval script, smoke test, README |

## Test Plan

- [x] Single-GPU smoke test (VLM interface + PI head + GR00T head)
- [x] Multi-GPU training on 8×H100 with DeepSpeed ZeRO-2
- [x] Full LIBERO 4-suite evaluation (50 trials/task × 10 tasks × 4 suites = 2000 rollouts)