### PR TITLE
[refactor] unify smoke tests: env-gated debugpy, libero default yaml,…

### DIFF
--- a/starVLA/dataloader/lerobot_datasets.py
+++ b/starVLA/dataloader/lerobot_datasets.py
@@ -99,27 +99,25 @@ def get_vla_dataset(
 
 
 if __name__ == "__main__":
-
-    # import debugpy
     import argparse
+    import os
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_behavior.yaml", help="Path to YAML config")
+    parser.add_argument("--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_libero.yaml", help="Path to YAML config")
     args, clipargs = parser.parse_known_args()
 
-    # debugpy.listen(("0.0.0.0", 10092))
-    # print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    # debugpy.wait_for_client()
-    args.config_yaml = "./examples/MultiRobot/train_files/starvla_cotrain_multiRobot.yaml"
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
+
     cfg = OmegaConf.load(args.config_yaml)
-    # cfg.datasets.vla_data.data_mix = "robotwin"
     vla_dataset_cfg = cfg.datasets.vla_data
-    # cfg.datasets.vla_data.include_state = True
-    vla_dataset_cfg.task_id = 1
     for task_id in ["all"]:
         vla_dataset_cfg.task_id = task_id
         print(f"Testing Task ID: {task_id}")
         dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-        # dataset
     from torch.utils.data import DataLoader
     train_dataloader = DataLoader(
         dataset,
@@ -135,8 +133,6 @@ if __name__ == "__main__":
     from tqdm import tqdm
     count = 0
     for batch in tqdm(train_dataloader, desc="Processing Batches"):
-        # print(batch)
-        # print(1)
         if count > 100:
             break
         count += 1

--- a/starVLA/dataloader/vlm_datasets.py
+++ b/starVLA/dataloader/vlm_datasets.py
@@ -600,15 +600,17 @@ def make_vlm_dataloader(cfg):
 from transformers import AutoTokenizer, AutoProcessor
 
 if __name__ == "__main__":
-    import debugpy
     import argparse
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config_yaml", type=str, default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml", help="Path to YAML config")
+    parser.add_argument("--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_libero.yaml", help="Path to YAML config")
     args, clipargs = parser.parse_known_args()
 
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    debugpy.wait_for_client()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
     
@@ -634,7 +636,6 @@ if __name__ == "__main__":
     data_args_ns.image_processor = image_processor
     data_module = make_supervised_data_module(tokenizer=tokenizer, data_args=data_args_ns)
 
-    #
     train_dataset = data_module["train_dataset"]
     data_collator = data_module["data_collator"]
     from torch.utils.data import DataLoader
@@ -646,13 +647,10 @@ if __name__ == "__main__":
     )
     batchs = iter(train_dataloader)
     batch_samples = next(batchs)
-    # skip the first 99 batches, get the 100th batch
-    from itertools import islice
 
-    # batch_samples = next(islice(batchs, 99, 100))
     count = 0
     while count < 100:
-        batch_samples = next(batchs)  # for debug
+        batch_samples = next(batchs)
         print(count)
         count += 1
     pass

--- a/starVLA/model/framework/VLM4A/ABot_M0.py
+++ b/starVLA/model/framework/VLM4A/ABot_M0.py
@@ -280,61 +280,35 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_cotrain_oxe.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    # debugpy.listen(("0.0.0.0", 10092))
-    # print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    # debugpy.wait_for_client()
-
     cfg = OmegaConf.load(args.config_yaml)
-    # try get model
-    cfg.framework.action_model.action_hidden_dim = 2048
-
-    # cfg.framework.qwenvl.base_vlm = f"{CHECKPOINT_BASEDIR}/Florence-2-large"
 
     model: ABot_M0 = ABot_M0(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        "state": np.random.uniform(-1, 1, size=(1, 14)).astype(np.float16),  # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16),
+        "image": [image],
+        "lang": "This is a fake instruction for testing.",
+        "state": np.random.uniform(-1, 1, size=(1, 14)).astype(np.float16),
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
-    predict_output = model.predict_action(examples=[sample])  # , state=[batch[0]["state"]]
+    predict_output = model.predict_action(examples=[sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # from torch.utils.data import DataLoader
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # cfg.datasets.vla_data.include_state = "False"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     break
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
-    # action = model.predict_action(examples=batch)
     print("Finished")

--- a/starVLA/model/framework/VLM4A/LangForce.py
+++ b/starVLA/model/framework/VLM4A/LangForce.py
@@ -662,24 +662,22 @@ class LangForce(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--config_yaml", type=str, default="./examples/Robotwin/train_files/starvla_cotrain_robotwin.yaml"
+        "--config_yaml", type=str, default="./starVLA/config/training/starvla_cotrain_libero.yaml"
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
-    # args.config_yaml = "examples/MultiRobot/train_files/starvla_cotrain_multiRobot.yaml"
     cfg = OmegaConf.load(args.config_yaml)
 
     model: LangForce = LangForce(cfg)
@@ -689,13 +687,10 @@ if __name__ == "__main__":
     sample = {
         "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
         "image": [image],
-        "lang": "Put all the toys in the child's room ... inside the toy box.",
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
-        "image": [image],
-        "lang": "Put all the toys in the child's room ... inside the toy box.",
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
     batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -707,14 +702,4 @@ if __name__ == "__main__":
     pred = model.predict_action([sample])
     print("Pred shape:", pred["normalized_actions"].shape)
 
-    # # optional dataloader test (requires data)
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # from torch.utils.data import DataLoader
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # cfg.datasets.vla_data.include_state = "False"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     model(batch)
-    #     break
     print("Finished")

--- a/starVLA/model/framework/VLM4A/M1.py
+++ b/starVLA/model/framework/VLM4A/M1.py
@@ -401,6 +401,7 @@ class InternVLA_M1(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -408,74 +409,40 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_cotrain_oxe.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
     cfg = OmegaConf.load(args.config_yaml)
 
-    # try get model
     model = InternVLA_M1(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # two views
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image, image],
         "lang": "This is a fake instruction for testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
     predict_output = model.predict_action(examples=[batch[0]])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # model_path = "./results/Checkpoints/1_need/0906_bestvla_retrain_sota2/checkpoints/steps_50000_pytorch_model.pt"
-    # state_dict = torch.load(model_path, map_location="cpu")
-
-    # model.load_state_dict(state_dict, strict=True)
-
-    # # try forward model
-    # # can be fake sample， but here get from dataloader for simpler
-    # from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
-
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-
-    # from torch.utils.data import DataLoader
-
-    # train_dataloader = DataLoader(
-    #     dataset,
-    #     batch_size=2,
-    #     num_workers=1,  # For Debug
-    #     collate_fn=collate_fn,
-    # )
-
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     break
-
-    # # try get model
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
     print("Finished")

--- a/starVLA/model/framework/VLM4A/QwenAdapter.py
+++ b/starVLA/model/framework/VLM4A/QwenAdapter.py
@@ -549,6 +549,7 @@ class Qwen_Adapter(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -556,79 +557,40 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_train_adapter.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
     cfg = OmegaConf.load(args.config_yaml)
-    # try get model
-    cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct"
 
     model: Qwen_Adapter = Qwen_Adapter(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # two views
-        "lang": "This is a fake for testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image, image],
+        "lang": "This is a fake instruction for testing.",
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
     predict_output = model.predict_action(examples=[batch[0]])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
-
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-
-    # from torch.utils.data import DataLoader
-
-    # train_dataloader = DataLoader(
-    #     dataset,
-    #     batch_size=2,
-    #     num_workers=1,  # For Debug
-    #     collate_fn=collate_fn,
-    # )
-    # #
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     break
-
-    # # try get model
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
-
-    # action = model.predict_action(batch_images=[batch[0]["image"]], instructions=[batch[0]["lang"]])
-
-    # # fake state
-    # for ba in batch:
-    #     ba["state"] = ba["action"][0][None]
-
-    # model(batch)
-    # action = model.predict_action(batch_images=[batch[0]["image"]], instructions=[batch[0]["lang"]], state=[batch[0]["state"]])
     print("Finished")

--- a/starVLA/model/framework/VLM4A/QwenDual.py
+++ b/starVLA/model/framework/VLM4A/QwenDual.py
@@ -277,6 +277,7 @@ class Qwen_Dual(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -284,77 +285,40 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_cotrain_oxe.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
     cfg = OmegaConf.load(args.config_yaml)
-    # try get model
-    # cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen3-VL-4B-Instruct"
-    # # cfg.framework.action_model.connect_layer_index = 16
-    # cfg.framework.action_model.state_dim = 44
-    # cfg.datasets.vla_data.include_state = True
-
-    cfg.framework.action_model.action_hidden_dim = 2048
-    # cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Florence-2-large"
-    cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct"
 
     model: Qwen_Dual = Qwen_Dual(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        # "wrist_views": [image, image],
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 44)).astype(np.float16), # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image],
+        "lang": "This is a fake instruction for testing.",
     }
-
     sample2 = sample.copy()
-    sample2["lang"] = "Move the red cup from the table to the kitchen counter next to the sink."
-    batch = [sample, sample2]  # batch size 2
+    sample2["lang"] = "Another fake instruction for testing."
+
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
-    predict_output = model.predict_action([sample])  # , state=[batch[0]["state"]]
+    predict_output = model.predict_action([sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # vla_dataset_cfg.task_id = 40
-    # vla_dataset_cfg.video_backend = "torchvision_av"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # from torch.utils.data import DataLoader
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # count = 0
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     count += 1
-    #     if count > 1:
-    #         break
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
-    # action = model.predict_action(examples=[sample])
     print("Finished")

--- a/starVLA/model/framework/VLM4A/QwenFast.py
+++ b/starVLA/model/framework/VLM4A/QwenFast.py
@@ -271,6 +271,7 @@ class Qwenvl_Fast(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -278,69 +279,41 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_cotrain_oxe.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
-    args.config_yaml = "./examples/Robotwin/train_files/starvla_cotrain_robotwin.yaml"
     cfg = OmegaConf.load(args.config_yaml)
-    # cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen3-VL-4B-Instruct-Action"
 
-    # try get model
     model = Qwenvl_Fast(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # two views
+        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16),
+        "image": [image, image],
         "lang": "This is a fake instruction for testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 14)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # two views
-        "lang": "The fake instruction for testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
-    }
-
-    batch = [sample, sample2]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action. for new model, it didn't learn to predict action token, so you would meet empty action
+    # Untrained models haven't learned the action tokens, so predictions may be empty.
     predict_output = model.predict_action([sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # test with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # vla_dataset_cfg.video_backend = "torchvision_av"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # from torch.utils.data import DataLoader
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     break
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
-    # action = model.predict_action(batch[0])
     print("Finished")

--- a/starVLA/model/framework/VLM4A/QwenGR00T.py
+++ b/starVLA/model/framework/VLM4A/QwenGR00T.py
@@ -270,6 +270,7 @@ class Qwen_GR00T(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -277,72 +278,40 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/Robotwin/train_files/starvla_cotrain_robotwin.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
-    # args.config_yaml = "examples/MultiRobot/train_files/starvla_cotrain_multiRobot.yaml"
     cfg = OmegaConf.load(args.config_yaml)
-    # try get model
-    # cfg.framework.action_model.action_hidden_dim = 2048
-
-    # cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Florence-2-large"
 
     model: Qwen_GR00T = Qwen_GR00T(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image],
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample2]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
-    predict_output = model.predict_action(examples=[sample])  # , state=[batch[0]["state"]]
+    predict_output = model.predict_action(examples=[sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # from torch.utils.data import DataLoader
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # cfg.datasets.vla_data.include_state = "False"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    #     model = model.to(device)
-    #     model(batch)
-    # action = model.predict_action(examples=batch)
     print("Finished")

--- a/starVLA/model/framework/VLM4A/QwenOFT.py
+++ b/starVLA/model/framework/VLM4A/QwenOFT.py
@@ -313,6 +313,7 @@ class Qwenvl_OFT(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -320,72 +321,41 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    # try:
-    #     import debugpy
-    #     debugpy.listen(("0.0.0.0", 10092))
-    #     print("Rank 0 waiting for debugger attach on port 10092...")
-    #     debugpy.wait_for_client()
-    # except (ImportError, RuntimeError):
-    #     pass
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
-    cfg.framework.action_model.action_hidden_dim = 2560
 
-    cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen3-VL-4B-Instruct"
-
-    # try get model
     model = Qwenvl_OFT(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # two views
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image],
         "lang": "This is a fake instruction for testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # two views
-        "lang": "For testing.",
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
-    }
-
-    batch = [sample, sample2]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
     predict_output = model.predict_action(examples=[batch[0]])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
-
-    # # try forward model with dataloader (requires data)
-    from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    vla_dataset_cfg = cfg.datasets.vla_data
-    dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    from torch.utils.data import DataLoader
-    train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    for batch in tqdm(train_dataloader, desc="Processing Batches"):
-        batch
-        break
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = model.to(device)
-    model(batch)
-    action = model.predict_action(batch)
-
-    print(f"Unnormalized Action: {action['normalized_actions']}")
 
     print("Finished")
 

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -252,6 +252,7 @@ class Qwen_PI(baseframework):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
     from omegaconf import OmegaConf
 
@@ -259,81 +260,41 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./starVLA/config/training/starvla_cotrain_oxe.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
-    try:
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
-    except (ImportError, RuntimeError):
-        pass
 
     cfg = OmegaConf.load(args.config_yaml)
-    # try get model
-    cfg.framework.qwenvl.base_vlm = "./playground/Pretrained_models/Qwen3-VL-4B-Instruct"
 
     model = Qwen_PI(cfg)
-    # ckpt="/mnt/petrelfs/yejinhui/Projects/llavavla/results/Checkpoints/1011_qwenpi/checkpoints/need_steps_10000_pytorch_model.pt"
-    # model = Qwen_PI.from_pretrained(ckpt)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # two views
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image, image],
         "lang": "This is a fake instruction for testing.",
-        "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),  # chunk, state_dim
+        "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
     }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
     predict_output = model.predict_action([sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
-
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-
-    # from torch.utils.data import DataLoader
-
-    # train_dataloader = DataLoader(
-    #     dataset,
-    #     batch_size=2,
-    #     num_workers=1,  # For Debug
-    #     collate_fn=collate_fn,
-    # )
-    # #
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     batch
-    #     break
-
-    # # try get model
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # model = model.to(device)
-    # model(batch)
-
-    # action = model.predict_action(batch_images=[batch[0]["image"]], instructions=[batch[0]["lang"]])
-
-    # # fake state
-    # for ba in batch:
-    #     ba["state"] = ba["action"][0][None]
-
-    # model(batch)
-    # action = model.predict_action(batch_images=[batch[0]["image"]], instructions=[batch[0]["lang"]], state=[batch[0]["state"]])
     print("Finished")

--- a/starVLA/model/framework/WM4A/CosmoPredict2GR00T.py
+++ b/starVLA/model/framework/WM4A/CosmoPredict2GR00T.py
@@ -232,14 +232,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
 
     cfg = OmegaConf.load(args.config_yaml)
 
-    # Override for CosmoPredict2-GR00T testing
     cfg.framework.name = "CosmoPredict2GR00T"
     cfg.framework.world_model = {
         "base_wm": "./playground/Pretrained_models/nvidia/Cosmos-Predict2-2B-Video2World",
@@ -249,49 +248,24 @@ if __name__ == "__main__":
     model: CosmoPredict2_GR00T = CosmoPredict2_GR00T(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image, image],
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample2]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
-    predict_output = model.predict_action(examples=[sample])  # , state=[batch[0]["state"]]
+    predict_output = model.predict_action(examples=[sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # from torch.utils.data import DataLoader
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # cfg.datasets.vla_data.include_state = "False"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    #     model = model.to(device)
-    #     model(batch)
-    # action = model.predict_action(examples=batch)
     print("Finished")

--- a/starVLA/model/framework/WM4A/CosmoPredict2OFT.py
+++ b/starVLA/model/framework/WM4A/CosmoPredict2OFT.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
@@ -204,13 +204,10 @@ if __name__ == "__main__":
     sample = {
         "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
         "image": [image, image],
-        "lang": "Pick up the red block and place it on the table.",
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
-        "image": [image],
-        "lang": "Pick up the red block and place it on the table.",
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
     batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/starVLA/model/framework/WM4A/CosmoPredict2PI.py
+++ b/starVLA/model/framework/WM4A/CosmoPredict2PI.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
@@ -267,15 +267,11 @@ if __name__ == "__main__":
     sample = {
         "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
         "image": [image, image],
-        "lang": "Pick up the red block and place it on the table.",
+        "lang": "This is a fake instruction for testing.",
         "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
-        "image": [image],
-        "lang": "Pick up the red block and place it on the table.",
-        "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
     batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/starVLA/model/framework/WM4A/WanGR00T.py
+++ b/starVLA/model/framework/WM4A/WanGR00T.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
@@ -254,49 +254,24 @@ if __name__ == "__main__":
     model: Wan_GR00T = Wan_GR00T(cfg)
     print(model)
 
-    # fake sample
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
-    # Create a sample
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image, image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
+        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "image": [image, image],
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),  # action_chunk, action_dim
-        "image": [image],  # three views
-        "lang": (
-            "Put all the toys in the child's room - the three board games (two on the bed and one on the table), the two jigsaw puzzles on the table, and the tennis ball on the table - inside the toy box on the table in the child's room."
-        ),
-        # "state" : np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16), # chunk, state_dim
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
-    batch = [sample, sample2]  # batch size 2
+    batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
     forward_output = model(batch)
     action_loss = forward_output["action_loss"]
     print(f"Action Loss: {action_loss.item()}")
 
-    # test predict action
-    predict_output = model.predict_action(examples=[sample])  # , state=[batch[0]["state"]]
+    predict_output = model.predict_action(examples=[sample])
     normalized_actions = predict_output["normalized_actions"]
     print(f"Unnormalized Action: {normalized_actions}")
 
-    # # Advance: try forward model with dataloader
-    # # can be fake sample， but here get from dataloader for simpler
-    # vla_dataset_cfg = cfg.datasets.vla_data
-    # from torch.utils.data import DataLoader
-    # from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
-    # cfg.datasets.vla_data.include_state = "False"
-    # dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-    # train_dataloader = DataLoader(dataset, batch_size=2, num_workers=1, collate_fn=collate_fn)
-    # for batch in tqdm(train_dataloader, desc="Processing Batches"):
-    #     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    #     model = model.to(device)
-    #     model(batch)
-    # action = model.predict_action(examples=batch)
     print("Finished")

--- a/starVLA/model/framework/WM4A/WanOFT.py
+++ b/starVLA/model/framework/WM4A/WanOFT.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
@@ -206,13 +206,10 @@ if __name__ == "__main__":
     sample = {
         "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
         "image": [image, image],
-        "lang": "Pick up the red block and place it on the table.",
+        "lang": "This is a fake instruction for testing.",
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
-        "image": [image],
-        "lang": "Pick up the red block and place it on the table.",
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
     batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/starVLA/model/framework/WM4A/WanPI.py
+++ b/starVLA/model/framework/WM4A/WanPI.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_yaml",
         type=str,
-        default="./examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        default="./starVLA/config/training/starvla_cotrain_libero.yaml",
         help="Path to YAML config",
     )
     args, clipargs = parser.parse_known_args()
@@ -275,15 +275,11 @@ if __name__ == "__main__":
     sample = {
         "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
         "image": [image, image],
-        "lang": "Pick up the red block and place it on the table.",
+        "lang": "This is a fake instruction for testing.",
         "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
     }
-    sample2 = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
-        "image": [image],
-        "lang": "Pick up the red block and place it on the table.",
-        "state": np.random.uniform(-1, 1, size=(1, 7)).astype(np.float16),
-    }
+    sample2 = sample.copy()
+    sample2["lang"] = "Another fake instruction for testing."
 
     batch = [sample, sample2]
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/starVLA/model/modules/action_model/fast_ActionHeader.py
+++ b/starVLA/model/modules/action_model/fast_ActionHeader.py
@@ -134,22 +134,19 @@ def start_debugpy_once():
 
 if __name__ == "__main__":
 
-    start_debugpy_once()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        start_debugpy_once()
 
     fast_tokenizer_name = "physical-intelligence/fast"
     fast_tokenizer = Fast_Action_Tokenizer(fast_tokenizer_name=fast_tokenizer_name)
     raw_actions = [np.random.randn(16, 7), np.random.randn(16, 7)]
 
-    # Load the tokenizer from the Hugging Face hub
     tokenizer = AutoProcessor.from_pretrained(fast_tokenizer_name, trust_remote_code=True)
 
-    # basic test
-    # Tokenize & decode action chunks (we use dummy data here)
-    action_data = np.random.rand(2, 16, 7)  # one batch of action chunks
-    tokens = tokenizer(action_data)  # tokens = list[int]
+    action_data = np.random.rand(2, 16, 7)
+    tokens = tokenizer(action_data)
     decoded_actions = tokenizer.decode(tokens)
 
-    # self func test
     vlm_tokens = fast_tokenizer.encoder_action2vlmtoken(raw_actions)
     print(vlm_tokens)
     pred_actions = fast_tokenizer.decoder_action(np.array([12, 3, 45, 87]))

--- a/starVLA/model/modules/vlm/Florence2.py
+++ b/starVLA/model/modules/vlm/Florence2.py
@@ -163,8 +163,8 @@ class _Florence_Interface(nn.Module):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
-    import debugpy
     from omegaconf import OmegaConf
 
     parser = argparse.ArgumentParser()
@@ -176,12 +176,13 @@ if __name__ == "__main__":
     )
     args, clipargs = parser.parse_known_args()
 
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    debugpy.wait_for_client()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
-    # model_id = "microsoft/Florence-2-large"
     model_id = "playground/Pretrained_models/Florence-2-large"
     cfg.framework.qwenvl.base_vlm = model_id
     qwen_vl = _Florence_Interface(cfg)

--- a/starVLA/model/modules/vlm/QWen2_5.py
+++ b/starVLA/model/modules/vlm/QWen2_5.py
@@ -301,8 +301,8 @@ class _QWen_VL_Interface(nn.Module):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
-    import debugpy
     from omegaconf import OmegaConf
 
     parser = argparse.ArgumentParser()
@@ -314,9 +314,11 @@ if __name__ == "__main__":
     )
     args, clipargs = parser.parse_known_args()
 
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    debugpy.wait_for_client()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
 

--- a/starVLA/model/modules/vlm/QWen3.py
+++ b/starVLA/model/modules/vlm/QWen3.py
@@ -174,8 +174,8 @@ class _QWen3_VL_Interface(nn.Module):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
-    import debugpy
     from omegaconf import OmegaConf
 
     parser = argparse.ArgumentParser()
@@ -187,9 +187,11 @@ if __name__ == "__main__":
     )
     args, clipargs = parser.parse_known_args()
 
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    debugpy.wait_for_client()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
 

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -182,8 +182,8 @@ class _QWen3_5_VL_Interface(nn.Module):
 
 if __name__ == "__main__":
     import argparse
+    import os
 
-    import debugpy
     from omegaconf import OmegaConf
 
     parser = argparse.ArgumentParser()
@@ -195,9 +195,11 @@ if __name__ == "__main__":
     )
     args, clipargs = parser.parse_known_args()
 
-    debugpy.listen(("0.0.0.0", 10092))
-    print("🔍 Rank 0 waiting for debugger attach on port 10092...")
-    debugpy.wait_for_client()
+    if os.getenv("DEBUGPY_ENABLE", "0") == "1":
+        import debugpy
+        debugpy.listen(("0.0.0.0", 10092))
+        print("Rank 0 waiting for debugger attach on port 10092...")
+        debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
 


### PR DESCRIPTION
## Description

Clean up and unify the smoke-test `__main__` blocks across all framework (VLM4A/WM4A), dataloader, and module files so every smoke test follows the same shape.

## Motivation

- `debugpy.listen` auto-started whenever `debugpy` was installed, blocking scripts at import time with no way to opt out
- Hardcoded `args.config_yaml = "..."` silently discarded the user's `--config_yaml` CLI value (QwenFast, lerobot_datasets)
- Hardcoded `cfg.framework.qwenvl.base_vlm` / `action_hidden_dim` overrode whatever the YAML said
- `lerobot_datasets.py`'s default `--config_yaml` pointed to a non-existent `starvla_cotrain_behavior.yaml`
- Large blocks of commented-out dataloader demos + many meaningless labels (`# fake sample`, `# Create a sample`, `# try get model`, `# test predict action`, trailing `# two views` / `# batch size 2` / `# action_chunk, action_dim`, …)
- `batch = [sample, sample]` vs `batch = [sample, sample2]` mixed; some `sample2` blocks were verbatim duplicates of `sample`

## Changes

- `debugpy` now gated behind `DEBUGPY_ENABLE=1` env var in every smoke test (was `try/except` auto-start, commented-out, or missing depending on file)
- Delete all hardcoded `args.config_yaml = ...` and `cfg.framework.*` overrides in VLM4A — YAML is the single source of truth; users pass `--framework.qwenvl.base_vlm <path>` etc. on the CLI when needed
- Unify default `--config_yaml` to `./starVLA/config/training/starvla_cotrain_libero.yaml` across all framework + dataloader smoke tests (also fixes the broken `behavior.yaml` default)
- Strip meaningless comments and all commented-out dataloader demo blocks
- Unify every smoke test to the same shape:
  ```python
  sample = {...}
  sample2 = sample.copy()
  sample2["lang"] = "Another fake instruction for testing."
  batch = [sample, sample2]
  ```
- WM4A's cfg.framework.name / world_model / qwenvl construction blocks preserved as-is — no matching YAMLs are shipped yet; will revisit once examples/<wm4a>/ YAMLs land
- Remove QwenOFT's orphan dataloader tail block so it matches the other VLM4A smoke tests

## Testing

only smoke test part are modified

## Type of Change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [x] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [x] If adding framework/benchmark: checkpoint uploaded to personal HF (public)
