### PR TITLE
fix lerobot v3 image index

### DIFF
--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -926,13 +926,33 @@ class LeRobotSingleDataset(Dataset):
                         video_key = str(col)[len("videos/") : -len("/from_timestamp")]
                         from_timestamps[video_key] = float(value)
 
-                    # TODO auto map key? just map to file_path and file_from_index
+                    # TODO auto map key 
+                    # Collect video file indices for each video key
+                    #已修改的lerobotv3.0的视频索引（提取视频和文件的索引）
+                    video_file_indices = {}
+                    for col in timestamp_cols:
+                        video_key = str(col)[len("videos/") : -len("/from_timestamp")]
+                        chunk_col = f"videos/{video_key}/chunk_index"
+                        file_col = f"videos/{video_key}/file_index"
+                        if chunk_col in episode and file_col in episode:
+                            video_file_indices[video_key] = {
+                                "chunk_index": int(episode[chunk_col]),
+                                "file_index": int(episode[file_col]),
+                            }
+                    print(video_file_indices)
                     episode_meta = {
                         "data/chunk_index": episode["data/chunk_index"],
                         "data/file_index": episode["data/file_index"],
                         "data/file_from_index": index,
                         "videos/from_timestamps": from_timestamps,
+                        "videos/file_indices": video_file_indices,
                     }
+                    # episode_meta = {
+                    #     "data/chunk_index": episode["data/chunk_index"],
+                    #     "data/file_index": episode["data/file_index"],
+                    #     "data/file_from_index": index,
+                    #     "videos/from_timestamps": from_timestamps,
+                    # }
                     self.trajectory_ids_to_metadata[trajectory_ids[-1]] = episode_meta
 
             # Should be able to directly read the saved index info here
@@ -1542,6 +1562,16 @@ class LeRobotSingleDataset(Dataset):
             )
         elif self._lerobot_version == "v3.0":
             episode_meta = self.trajectory_ids_to_metadata[trajectory_id]
+
+            video_file_indices = episode_meta.get("videos/file_indices", {})
+            # print(f"{video_file_indices=}")
+            #已修改的lerobotv3.0的视频索引
+            if original_key in video_file_indices:
+                video_chunk_index = video_file_indices[original_key]["chunk_index"]
+                video_file_index = video_file_indices[original_key]["file_index"]
+            else:
+                video_chunk_index = episode_meta["data/chunk_index"]
+                video_file_index = episode_meta["data/file_index"]
             video_filename = self.video_path_pattern.format(
                 video_key=original_key,
                 chunk_index=episode_meta["data/chunk_index"],

--- a/starVLA/dataloader/gr00t_lerobot/mixtures.py
+++ b/starVLA/dataloader/gr00t_lerobot/mixtures.py
@@ -359,4 +359,7 @@ DATASET_NAMED_MIXTURES = {
         ("LEROBOT_LIBERO_DATA/libero_10_no_noops_1.0.0_lerobot", 1.0, "libero_franka"),
         # ("OXE_LEROBOT_DATASET/bridge_orig_1.0.0_lerobot", 1.0, "oxe_bridge"),
     ],
+    "calvin_task_D_D_v3.0": [
+        ("calvin_task_D_D_v3.0", 1.0, "libero_franka"),
+    ],
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR does -->
修复 LeRobot v3 格式数据集的视频文件索引错误，解决 image 和 wrist_image 视频读取错位问题。


## Motivation
<!-- Why is this change needed? Please link the related Issue -->
在对比 CALVIN v2.0 和 v3.0 数据集训练效果时，发现使用 v3.0 数据训练模型效果远不如 v2.0。经过详细排查，发现是数据加载器中的 Bug 导致视频文件读取错误。

- 对于calvin数据，LeRobot v3 格式的数据 parquet 文件只有 1 个（`data/chunk-000/file-000.parquet`），因此所有 episode 的 `data/file_index` 都是 0
- 但视频文件被分割成多个（image 有 6 个文件，wrist_image 有 2 个文件）
- 原代码统一使用 `data/file_index`（总是 0）构建视频路径，导致：
  - image 视频读取错误
  - wrist_image 视频读取错误
 
## Changes
<!-- List the key changes -->
1. **`starVLA/dataloader/gr00t_lerobot/datasets.py` - `_get_trajectories` 方法**
   - 新增收集每个视频类型的独立 `chunk_index` 和 `file_index`
   - 存储到 `videos/file_indices` 字典中

2. **`starVLA/dataloader/gr00t_lerobot/datasets.py` - `get_video_path` 方法**
   - 从 `videos/file_indices` 获取视频特定的 file_index
   - 保持向后兼容：如果找不到则回退到 `data/file_index`

## Testing
<!-- How was this verified? Check at least one -->
<!-- - [ ] `make check` passes  TODO: enable later -->
- [x] Local training for N steps without errors
- [x] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

**配置**: Qwen2.5-VL-3B-Instruct (Qwenvl) + DiT-B Action Model  
**数据集**: CALVIN task D-D (LeRobot v3.0)  
**训练**: 20k steps  
**对比**: 修复前 (v2.0 dataloader) vs 修复后 (v3.0 dataloader)

| Configuration | Steps | Avg. Length | Task 1 | Task 2 | Task 3 | Task 4 | Task 5 | Overall |
|--------------|-------|-------------|--------|--------|--------|--------|--------|---------|
| v2.0 dataloader (baseline) | 20k | 3.152 | 90.4 | 74.1 | 59.7 | 49.0 | 42.0 | 63.04 |
| **v3.0 dataloader (fixed)** | 20k | 3.397 | 88.5 | 75.2 | **66.3** | **58.4** | **51.3** | **67.94** |

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)
## Screenshots / Logs (optional)
<!-- Training curves, evaluation result screenshots, relevant logs -->


## Technical Details

### 元数据结构
LeRobot v3 的 episode 元数据包含每个视频类型的独立索引：
以通过官方脚本转化的calvin lerobot v3数据为例。
```
videos/image/chunk_index: 0~5
videos/image/file_index: 0~5
videos/wrist_image/chunk_index: 0~1
videos/wrist_image/file_index: 0~1
```

### 修复代码逻辑
```python
# 1. 收集视频索引
video_file_indices = {}
for col in timestamp_cols:
    video_key = str(col)[len("videos/") : -len("/from_timestamp")]
    chunk_col = f"videos/{video_key}/chunk_index"
    file_col = f"videos/{video_key}/file_index"
    if chunk_col in episode and file_col in episode:
        video_file_indices[video_key] = {
            "chunk_index": int(episode[chunk_col]),
            "file_index": int(episode[file_col]),
        }

# 2. 构建视频路径时使用正确的索引
video_file_indices = episode_meta.get("videos/file_indices", {})
if original_key in video_file_indices:
    video_chunk_index = video_file_indices[original_key]["chunk_index"]
    video_file_index = video_file_indices[original_key]["file_index"]
else:
    # 向后兼容：回退到 data/file_index
    video_chunk_index = episode_meta["data/chunk_index"]
    video_file_index = episode_meta["data/file_index"]
```