### PR TITLE
[fix] resolve potential negative sampling in sample_time

### DIFF
--- a/starVLA/model/modules/action_model/AML_ActionHeader.py
+++ b/starVLA/model/modules/action_model/AML_ActionHeader.py
@@ -252,7 +252,7 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
-        return (self.config.noise_s - sample) / self.config.noise_s
+        return self.config.noise_s * (1 - sample)
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)

--- a/starVLA/model/modules/action_model/GR00T_ActionHeader.py
+++ b/starVLA/model/modules/action_model/GR00T_ActionHeader.py
@@ -245,7 +245,7 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype).clamp(max=self.config.noise_s)
-        return (self.config.noise_s - sample) / self.config.noise_s
+        return self.config.noise_s * (1 - sample)
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -264,7 +264,7 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
-        return (self.config.noise_s - sample) / self.config.noise_s
+        return self.config.noise_s * (1 - sample)
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)


### PR DESCRIPTION


## Description

Refactored the `sample_time` calculation to prevent negative time step sampling.


## Motivation

Experimental observations indicate that the original `sample_time` function can produce negative time steps. Specifically, when the `sample` value is close to 1 (exceeding `noise_s`), the current formula `(self.config.noise_s - sample) / self.config.noise_s` yields negative results (e.g., -0.001001). 

Closes #239

## Changes

Changed `(self.config.noise_s - sample) / self.config.noise_s` to `self.config.noise_s * (1 - sample)` in the following files:

- AML_ActionHeader.py
- GR00T_ActionHeader.py
- LayerwiseFM_ActionHeader.py

## Testing

- [x] Local training for N steps without errors

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)



