### PR TITLE
fix(dataloader): remove unreachable code in sample_step

### DIFF
--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -2270,26 +2270,6 @@ class LeRobotMixtureDataset(Dataset):
         # Sample step
         base_index = rng.choice(dataset.trajectory_lengths[trajectory_index])
         return dataset, trajectory_id, base_index
-        if len(dataset.all_steps) == 0:
-            raise ValueError(f"Dataset {dataset.dataset_name} has no steps.")
-
-        if not self._sequential_step_sampling:
-            single_step_index = rng.choice(len(dataset.all_steps))
-        else:
-            step_pos = self._step_pos[dataset_index]
-            if step_pos >= len(dataset.all_steps):
-                order = np.arange(len(dataset.all_steps))
-                if self.mode == "train":
-                    seed = safe_hash((self.epoch, dataset_index, self.seed, step_pos))
-                    rng = np.random.default_rng(seed)
-                    rng.shuffle(order)
-                self._step_order[dataset_index] = order
-                step_pos = 0
-
-            single_step_index = self._step_order[dataset_index][step_pos]
-            self._step_pos[dataset_index] = step_pos + 1
-        trajectory_id, base_index = dataset.all_steps[single_step_index]
-        return dataset, trajectory_id, base_index
 
     
 


### PR DESCRIPTION
  ## Summary

  This PR removes unreachable code in `starVLA/dataloader/gr00t_lerobot/datasets.py::sample_step`.

 ## Problem

  `sample_step()` currently returns early after trajectory-based sampling:

  ```python
  base_index = rng.choice(dataset.trajectory_lengths[trajectory_index])
  return dataset, trajectory_id, base_index
 ```
  As a result, the following block is never executed:

  - if len(dataset.all_steps) == 0: ...
  - _sequential_step_sampling logic
  - the second return dataset, trajectory_id, base_index

  This makes the function misleading to read and suggests that the old all_steps-based path is still active, while it is actually dead code.


 ## Change

  - Keep the current active trajectory-based sampling behavior unchanged
  - Remove the unreachable code after the early return

 ## Validation

  - Not run locally
  - This change is a dead-code cleanup and is intended to keep current behavior unchanged

 ## Notes

  This PR is intended as dead-code cleanup only and should not change runtime behavior.

  If the old all_steps-based sampling path is still intended to be supported, that should be restored through an
  explicit control-flow refactor in a separate PR.