### PR TITLE
[fix] Restore the fix for loading VLA-Arena datasets

### DIFF
--- a/starVLA/dataloader/gr00t_lerobot/data_config.py
+++ b/starVLA/dataloader/gr00t_lerobot/data_config.py
@@ -983,6 +983,89 @@ class AgilexData50Config:
 
         return ComposedModalityTransform(transforms=transforms)
 
+###########################################################################################
+
+class VLAArenaFrankaDataConfig:
+    """
+    Data config for VLA-Arena environments (robosuite, mounted Panda).
+
+    Action space  : 7-DOF delta EEF  (Δx, Δy, Δz, Δroll, Δpitch, Δyaw, gripper)
+    Observation   : primary agentview image (256×256 rendered, resized to 224×224)
+    State         : EEF pos (3) + EEF axis-angle (3) + gripper qpos (1) = 7
+    """
+
+    video_keys = [
+        "video.primary_image",   # agentview camera
+    ]
+    state_keys = [
+        "state.x",
+        "state.y",
+        "state.z",
+        "state.roll",
+        "state.pitch",
+        "state.yaw",
+        "state.gripper",
+    ]
+    action_keys = [
+        "action.x",
+        "action.y",
+        "action.z",
+        "action.roll",
+        "action.pitch",
+        "action.yaw",
+        "action.gripper",
+    ]
+
+    language_keys = ["annotation.human.action.task_description"]
+
+    observation_indices = [0]
+    action_indices = list(range(8))
+    state_indices = list(range(-16, 0))
+
+    def modality_config(self):
+        video_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.video_keys,
+        )
+        state_modality = ModalityConfig(
+            delta_indices=self.state_indices,
+            modality_keys=self.state_keys,
+        )
+        action_modality = ModalityConfig(
+            delta_indices=self.action_indices,
+            modality_keys=self.action_keys,
+        )
+        language_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.language_keys,
+        )
+        return {
+            "video": video_modality,
+            "state": state_modality,
+            "action": action_modality,
+            "language": language_modality,
+        }
+
+    def transform(self):
+        transforms = [
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={
+                    "action.x": "min_max",
+                    "action.y": "min_max",
+                    "action.z": "min_max",
+                    "action.roll": "min_max",
+                    "action.pitch": "min_max",
+                    "action.yaw": "min_max",
+                },
+            ),
+        ]
+        return ComposedModalityTransform(transforms=transforms)
+
+
+###########################################################################################
+
 ROBOT_TYPE_CONFIG_MAP = {
     "libero_franka": Libero4in1DataConfig(),
     "oxe_droid": OxeDroidDataConfig(),
@@ -994,7 +1077,8 @@ ROBOT_TYPE_CONFIG_MAP = {
     "robotwin": AgilexDataConfig(),
     "robotwin50": AgilexData50Config(),
     "fourier_gr1_arms_waist": FourierGr1ArmsWaistDataConfig(),
-    
+    "vla_arena_franka": VLAArenaFrankaDataConfig(),
+
     "custom_robot_config": SingleFrankaRobotiqDeltaEefDataConfig(),
 }
 

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -25,6 +25,7 @@ See `scripts/load_dataset.py` for examples on how to use these datasets.
 """
 import os
 import hashlib
+import io
 import json, torch
 import copy
 from collections import defaultdict
@@ -783,9 +784,13 @@ class LeRobotSingleDataset(Dataset):
                 channels = le_video_meta["shape"][le_video_meta["names"].index("channel")]
                 fps = le_video_meta["video_info"]["video.fps"]
             except (ValueError, KeyError):
-                # channels = le_video_meta["shape"][le_video_meta["names"].index("channels")]
-                channels = le_video_meta["info"]["video.channels"]
-                fps = le_video_meta["info"]["video.fps"]
+                try:
+                    channels = le_video_meta["info"]["video.channels"]
+                    fps = le_video_meta["info"]["video.fps"]
+                except (ValueError, KeyError):
+                    # Fallback for image-only datasets (e.g. VLA-Arena) that lack video_info
+                    channels = 3
+                    fps = le_info.get("fps", 30)
             simplified_modality_meta["video"][new_key] = {
                 "resolution": [width, height],
                 "channels": channels,
@@ -1608,6 +1613,43 @@ class LeRobotSingleDataset(Dataset):
         assert key.startswith("video."), f"Video key must start with 'video.', got {key}"
         # Get the sub-key
         key = key.replace("video.", "")
+
+        # Image-only LeRobot datasets (e.g. VLA-Arena) may store frames directly
+        # in parquet columns and have total_videos == 0 (no mp4 files). In this
+        # case, load frames from the original image column and pad by step indices.
+        original_key = self.lerobot_modality_meta.video[key].original_key
+        if original_key is None:
+            original_key = key
+        if self.curr_traj_data is not None and original_key in self.curr_traj_data.columns:
+            image_entries = self.curr_traj_data[original_key].tolist()
+
+            def _decode_image_entry(entry):
+                if isinstance(entry, np.ndarray):
+                    return entry
+                if isinstance(entry, Image.Image):
+                    return np.array(entry)
+                if isinstance(entry, dict):
+                    img_bytes = entry.get("bytes", None)
+                    img_path = entry.get("path", None)
+
+                    if img_bytes is not None:
+                        return np.array(Image.open(io.BytesIO(img_bytes)).convert("RGB"))
+
+                    if img_path is not None:
+                        path_obj = Path(img_path)
+                        if not path_obj.is_absolute():
+                            path_obj = self.dataset_path / path_obj
+                        return np.array(Image.open(path_obj).convert("RGB"))
+
+                raise TypeError(f"Unsupported image entry type: {type(entry)}")
+
+            frames = []
+            for idx in step_indices:
+                safe_idx = int(min(max(idx, 0), len(image_entries) - 1))
+                frames.append(_decode_image_entry(image_entries[safe_idx]))
+
+            return np.stack(frames)
+
         video_path = self.get_video_path(trajectory_id, key)
         # Get the action/state timestamps for each frame in the video
         assert self.curr_traj_data is not None, f"No data found for {trajectory_id=}"
@@ -2311,8 +2353,23 @@ class LeRobotMixtureDataset(Dataset):
 
         for attempt in range(max_retries):
             try:
-                while True: # @DUG
+                sample_tries = 0
+                max_sample_tries = 200
+                while True:
+                    sample_tries += 1
+                    if sample_tries > max_sample_tries:
+                        raise RuntimeError(
+                            f"Unable to sample a valid item after {max_sample_tries} attempts. "
+                            f"dataset={self.datasets[0].dataset_name if len(self.datasets)>0 else 'unknown'}"
+                        )
+
                     dataset, trajectory_id, step = self.sample_step(index)
+                    # If dataset has no physical videos (e.g., image frames in parquet
+                    # for VLA-Arena), do not gate sampling on mp4 existence.
+                    total_videos = int(dataset.lerobot_info_meta.get("total_videos", 0))
+                    if total_videos == 0:
+                        break
+
                     key = dataset.modality_keys["video"][0].replace("video.", "")
                     video_path = dataset.get_video_path(trajectory_id, key)
                     if os.path.exists(video_path):

--- a/starVLA/dataloader/gr00t_lerobot/mixtures.py
+++ b/starVLA/dataloader/gr00t_lerobot/mixtures.py
@@ -359,7 +359,14 @@ DATASET_NAMED_MIXTURES = {
         ("LEROBOT_LIBERO_DATA/libero_10_no_noops_1.0.0_lerobot", 1.0, "libero_franka"),
         # ("OXE_LEROBOT_DATASET/bridge_orig_1.0.0_lerobot", 1.0, "oxe_bridge"),
     ],
-    "calvin_task_D_D_v3.0": [
-        ("calvin_task_D_D_v3.0", 1.0, "libero_franka"),
+
+    "vla_arena_L0_S": [
+        ("VLA_Arena_L0_S_lerobot_openpi", 1.0, "vla_arena_franka"),
+    ],
+    "vla_arena_L0_M": [
+        ("VLA_Arena_L0_M_lerobot_openpi", 1.0, "vla_arena_franka"),
+    ],
+    "vla_arena_L0_L": [
+        ("VLA_Arena_L0_L_lerobot_openpi", 1.0, "vla_arena_franka"),
     ],
 }

--- a/starVLA/dataloader/gr00t_lerobot/mixtures.py
+++ b/starVLA/dataloader/gr00t_lerobot/mixtures.py
@@ -359,6 +359,10 @@ DATASET_NAMED_MIXTURES = {
         ("LEROBOT_LIBERO_DATA/libero_10_no_noops_1.0.0_lerobot", 1.0, "libero_franka"),
         # ("OXE_LEROBOT_DATASET/bridge_orig_1.0.0_lerobot", 1.0, "oxe_bridge"),
     ],
+    
+    "calvin_task_D_D_v3.0": [
+        ("calvin_task_D_D_v3.0", 1.0, "libero_franka"),
+    ],
 
     "vla_arena_L0_S": [
         ("VLA_Arena_L0_S_lerobot_openpi", 1.0, "vla_arena_franka"),


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR does -->
Restore the fix for loading VLA-Arena datasets in `starVLA/dataloader/gr00t_lerobot`.

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [ ] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [ ] No modifications to shared files, or justified above
- [x] If adding framework/benchmark: checkpoint uploaded to personal HF (public)
