### PR TITLE
[fix] QwenGR00T smoke test dimensions

### DIFF
--- a/starVLA/model/framework/VLM4A/QwenGR00T.py
+++ b/starVLA/model/framework/VLM4A/QwenGR00T.py
@@ -297,12 +297,19 @@ if __name__ == "__main__":
     model: Qwen_GR00T = Qwen_GR00T(cfg)
     print(model)
 
+    action_dim = int(model.action_model.action_dim)
+    state_dim = int(model.action_model.config.get("state_dim", 0) or 0)
+    action_steps = 2 * int(model.action_horizon)
+
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "action": np.random.uniform(-1, 1, size=(action_steps, action_dim)).astype(np.float16),
         "image": [image],
         "lang": "This is a fake instruction for testing.",
     }
+    if state_dim > 0:
+        sample["state"] = np.random.uniform(-1, 1, size=(1, state_dim)).astype(np.float16)
+
     sample2 = sample.copy()
     sample2["lang"] = "Another fake instruction for testing."
 


### PR DESCRIPTION
## Description
Fix the QwenGR00T smoke-test sample so it uses the action/state dimensions from the loaded config.

## Motivation
Some configs, such as RoboTwin, DOMINO, and Franka dual-arm, use non-7D actions. The smoke test in QwenGR00T.py still created a 7D fake action, so the script could fail before it actually checked the model path.

Closes #297

## Changes
- Read action_dim, state_dim, and action_horizon from the initialized model.
- Add fake state input when state_dim is enabled.

## Testing
- [x] python -m py_compile starVLA/model/framework/VLM4A/QwenGR00T.py
- [x] git diff --check
- [x] Local 14D QwenGR00T smoke test with py313 + local Qwen2.5-VL-3B-Instruct-Action weights

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated to the smoke-test entrypoint