### PR TITLE
[fix] RoboCasa instruction broadcast for parallel envs

### DIFF
--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -62,6 +62,20 @@ class PolicyWarper:
         self.image_history.append(image)
         self.num_image_history = min(self.num_image_history + 1, self.horizon)
 
+    @staticmethod
+    def _select_instruction(instructions, batch_index: int):
+        if not isinstance(instructions, list):
+            return instructions
+        if len(instructions) == 0:
+            raise ValueError("instructions must not be an empty list")
+        if batch_index < len(instructions):
+            return instructions[batch_index]
+        if len(instructions) == 1:
+            return instructions[0]
+        raise IndexError(
+            f"instructions has length {len(instructions)}, but batch index {batch_index} was requested"
+        )
+
     def reset(self, task_description: str or tuple) -> None:
 
         self.task_description = task_description
@@ -111,11 +125,11 @@ class PolicyWarper:
         # prepare vla input
         examples = []
         batch_size = len(images)
-        instructions = [self.task_description] if isinstance(self.task_description, str) else self.task_description
+        instructions = self.task_description
         for b in range(batch_size):
             example = {
                 "image": images[b],  # A list of multi-view images for a single sample
-                "lang": instructions[b] if isinstance(instructions, list) else instructions,
+                "lang": self._select_instruction(instructions, b),
                 "state": input_state[b],  # N_history, 58 #Hack BUG
             }
             examples.append(example)


### PR DESCRIPTION
## Description
Fix RoboCasa tabletop evaluation when one task instruction is shared across multiple parallel envs.

## Motivation
With n_envs greater than 1, observations can be batched while the task description is still a single shared instruction. The old code wrapped that instruction as a one-item list and then indexed it by batch id, which caused list index out of range.

Closes #233

## Changes
- Keep per-sample instruction lists working.
- Broadcast a single instruction to every sample in the batch.
- Raise a clearer error for mismatched multi-item instruction lists.

## Testing
- [x] python -m py_compile examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
- [x] git diff --check
- [x] Local instruction selection check for string, single-item list, per-sample list, and mismatch cases

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated to the RoboCasa evaluation interface