### PR TITLE
[docs] add agent skills (integrate-starvla-dataset, submit-starvla-pr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ In StarVLA (also a pun on "start VLA" ),  each functional component (model, data
 
 **[2026/04/19]** 📋 As community PRs grow rapidly, we are establishing **PR guidelines** to maintain code quality and stability. Thank you all for your contributions! Please review the new [PR Guidelines](docs/PR_readme.md) and [Branching Strategy](docs/branching_strategy.md) before submitting PRs.
 
+**[2026/05/01]** 🔥 We are building [agent skills](docs/agent_skills) to make StarVLA a powerful substrate for AI coding agents — we have verified that GitHub Copilot (Claude Opus 4.7) can autonomously integrate [examples/Robocasa_365](examples/Robocasa_365) and [examples/RoboChallenge_table30v2](examples/RoboChallenge_table30v2) from scratch. Going forward, StarVLA will be continuously optimised to be equally easy to use for humans and code agents.
+
 **[2026/04/18]** 🔥 StarVLA now supports [DOMINO](examples/DOMINO), a dynamic manipulation benchmark for moving objects and time-varying scenes. Original DOMINO repository is [here](https://github.com/H-EmbodVis/DOMINO).
 
 **[2026/04/09]** 🎯 Thanks to the [RLinf](https://rlinf.readthedocs.io) team, StarVLA now supports **RL post-training**! Check out the [StarVLA × RLinf tutorial](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/starvla.html) to get started.

--- a/docs/agent_skills/integrate-starvla-dataset/assets/templates/data_config.py
+++ b/docs/agent_skills/integrate-starvla-dataset/assets/templates/data_config.py
@@ -1,0 +1,87 @@
+"""<<TODO_BENCH>> — data_config / embodiments / mixtures.
+
+Auto-discovered by ``starVLA.dataloader.gr00t_lerobot.registry.discover_and_merge``.
+Drop this file at::
+
+    examples/<<TODO_BENCH>>/train_files/data_registry/data_config.py
+
+It MUST export the three module-level dicts at the bottom — search for
+``ROBOT_TYPE_CONFIG_MAP``, ``ROBOT_TYPE_TO_EMBODIMENT_TAG``,
+``DATASET_NAMED_MIXTURES``. The names are what the registry looks for.
+"""
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import (
+    StateActionToTensor,
+    StateActionTransform,
+)
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+
+
+# ---------------------------------------------------------------------------
+# Per-robot data layout — replace <<TODO_*>> placeholders.
+# Keep camera / state / action key names IDENTICAL to what your converter
+# wrote into the LeRobot dataset.
+# ---------------------------------------------------------------------------
+class _MyRobotDataConfig:
+    video_keys = [
+        "video.<<TODO_CAM_1>>",
+        "video.<<TODO_CAM_2>>",
+    ]
+    state_keys = [
+        "state.<<TODO_STATE_GROUP_1>>",        # e.g. "state.joint_positions"
+        "state.<<TODO_STATE_GROUP_2>>",        # e.g. "state.gripper_width"
+    ]
+    action_keys = [
+        "action.<<TODO_ACTION_GROUP_1>>",      # e.g. "action.ee_positions"
+        "action.<<TODO_ACTION_GROUP_2>>",      # e.g. "action.gripper_width"
+    ]
+    language_keys = ["annotation.human.task_description"]
+
+    observation_indices = [0]                  # current frame only
+    action_indices = list(range(8))            # predict t .. t+7  (== action_horizon)
+
+    def modality_config(self):
+        return {
+            "video":    ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
+            "state":    ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.state_keys),
+            "action":   ModalityConfig(delta_indices=self.action_indices,      modality_keys=self.action_keys),
+            "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
+        }
+
+    def transform(self):
+        return ComposedModalityTransform(transforms=[
+            StateActionToTensor(apply_to=self.state_keys),
+            StateActionTransform(
+                apply_to=self.state_keys,
+                normalization_modes={k: "min_max" for k in self.state_keys},
+            ),
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={k: "min_max" for k in self.action_keys},
+            ),
+        ])
+
+
+# ---------------------------------------------------------------------------
+# REQUIRED top-level exports — names matter, do not rename.
+# ---------------------------------------------------------------------------
+ROBOT_TYPE_CONFIG_MAP = {
+    "<<TODO_robot_type_string>>": _MyRobotDataConfig(),
+}
+
+ROBOT_TYPE_TO_EMBODIMENT_TAG = {
+    # NEW_EMBODIMENT is the safe default. Use FRANKA / UR5 / etc only if your
+    # action space matches an existing tag's embedding head.
+    "<<TODO_robot_type_string>>": EmbodimentTag.NEW_EMBODIMENT,
+}
+
+DATASET_NAMED_MIXTURES = {
+    # mixture_name : list of (dataset_subdir, weight, robot_type_string)
+    # dataset_subdir is RELATIVE to yaml.datasets.vla_data.data_root_dir
+    "<<TODO_mixture_name>>": [
+        ("<<TODO_dataset_subdir_1>>", 1.0, "<<TODO_robot_type_string>>"),
+        # ("<<TODO_dataset_subdir_2>>", 1.0, "<<TODO_robot_type_string>>"),
+    ],
+}

--- a/docs/agent_skills/integrate-starvla-dataset/assets/templates/modality.json
+++ b/docs/agent_skills/integrate-starvla-dataset/assets/templates/modality.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "<<TODO_BENCH>> — gr00t modality schema. Drop at meta/modality.json of every LeRobot dataset.",
+  "_critical": "annotation.human.task_description.original_key MUST be 'task_index'. Anything else silently breaks language conditioning.",
+
+  "video": {
+    "<<TODO_CAM_1>>": {"original_key": "observation.images.<<TODO_CAM_1>>"},
+    "<<TODO_CAM_2>>": {"original_key": "observation.images.<<TODO_CAM_2>>"}
+  },
+
+  "state": {
+    "<<TODO_STATE_GROUP_1>>": {"start": 0, "end": 6, "original_key": "observation.state"},
+    "<<TODO_STATE_GROUP_2>>": {"start": 6, "end": 7, "original_key": "observation.state"}
+  },
+
+  "action": {
+    "<<TODO_ACTION_GROUP_1>>": {"start": 0, "end": 7, "original_key": "action"},
+    "<<TODO_ACTION_GROUP_2>>": {"start": 7, "end": 8, "original_key": "action"}
+  },
+
+  "annotation": {
+    "human": {
+      "task_description": {
+        "original_key": "task_index"
+      }
+    }
+  }
+}

--- a/docs/agent_skills/integrate-starvla-dataset/assets/templates/model2bench_interface.py
+++ b/docs/agent_skills/integrate-starvla-dataset/assets/templates/model2bench_interface.py
@@ -1,0 +1,109 @@
+"""<<TODO_BENCH>> — Policy bridge between trained checkpoint and the env / server.
+
+Copy to: examples/<<TODO_BENCH>>/eval_files/model2<<TODO_BENCH>>_interface.py
+
+The contract evaluators expect:
+
+    policy = <Bench>Policy(checkpoint_path)
+    actions = policy.run_policy(obs, prompt)   # (n_action_steps, action_dim) un-normalized
+
+Always exercise this in 3 steps (Skill Phase 7):
+    1. local_self_test.py     — dummy obs, no env
+    2. closed-loop on a recorded episode / mock server
+    3. closed-loop on real env
+
+Cribbing references:
+    examples/Robocasa_365/eval_files/model2robocasa365_interface.py        (in-process sim)
+    examples/RoboChallenge_table30v2/eval_files/model2robochallenge_interface.py  (HTTP server)
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from PIL import Image
+
+from starVLA.model.framework.base_framework import build_framework
+
+
+@dataclass
+class RobotSpec:
+    image_keys: Sequence[str]            # cameras the model expects, in order
+    state_dim: int
+    action_dim: int
+    norm_unnorm_key: str                 # key in dataset_statistics.json for state+action stats
+
+
+# Replace with your robot(s). Mirror data_registry/data_config.py.
+ROBOT_SPECS: dict[str, RobotSpec] = {
+    "<<TODO_robot_type_string>>": RobotSpec(
+        image_keys=["<<TODO_CAM_1>>", "<<TODO_CAM_2>>"],
+        state_dim=<<TODO_STATE_DIM>>,
+        action_dim=<<TODO_ACTION_DIM>>,
+        norm_unnorm_key="<<TODO_robot_type_string>>",
+    ),
+}
+
+
+def _load_norm_stats(checkpoint_path: str) -> dict:
+    """Find dataset_statistics.json saved next to the checkpoint at training time."""
+    ckpt = Path(checkpoint_path)
+    # Trainer writes it at <run_root_dir>/<run_id>/dataset_statistics.json
+    candidate = ckpt.parents[1] / "dataset_statistics.json"
+    if not candidate.is_file():
+        raise FileNotFoundError(f"dataset_statistics.json not found at {candidate} — "
+                                f"keep it paired with the checkpoint")
+    return json.loads(candidate.read_text())
+
+
+def _normalize(x: np.ndarray, stats: dict, keys: Sequence[str]) -> np.ndarray:
+    """min_max → [-1, 1]. Mirror of starVLA's training-time normalization."""
+    lo = np.array([stats[k]["min"] for k in keys], dtype=np.float32)
+    hi = np.array([stats[k]["max"] for k in keys], dtype=np.float32)
+    rng = np.maximum(hi - lo, 1e-8)
+    return 2.0 * (x - lo) / rng - 1.0
+
+
+def _unnormalize(y: np.ndarray, stats: dict, keys: Sequence[str], mask: np.ndarray | None = None) -> np.ndarray:
+    lo = np.array([stats[k]["min"] for k in keys], dtype=np.float32)
+    hi = np.array([stats[k]["max"] for k in keys], dtype=np.float32)
+    out = (y + 1.0) / 2.0 * (hi - lo) + lo
+    if mask is not None:
+        out = np.where(mask, out, y)   # leave un-normalizable dims (e.g. quaternions) raw
+    return out
+
+
+class <<TODO_BENCH_PASCAL>>Policy:
+    def __init__(self, checkpoint_path: str, robot_tag: str = "<<TODO_robot_type_string>>"):
+        if robot_tag not in ROBOT_SPECS:
+            raise KeyError(f"robot_tag={robot_tag} not in {list(ROBOT_SPECS)}")
+        self.spec = ROBOT_SPECS[robot_tag]
+        self.stats = _load_norm_stats(checkpoint_path)
+        self.model = build_framework(checkpoint_path=checkpoint_path)
+        self.model.eval()
+
+    @property
+    def n_action_steps(self) -> int:
+        return self.model.cfg.framework.action_model.action_horizon
+
+    def run_policy(self, obs: dict, prompt: str) -> np.ndarray:
+        # 1. images: (H, W, 3) uint8 per camera, in self.spec.image_keys order
+        images = [Image.fromarray(obs["images"][k]).convert("RGB") for k in self.spec.image_keys]
+
+        # 2. normalize state
+        raw_state = np.asarray(obs["state"], dtype=np.float32).reshape(-1)
+        norm_state = _normalize(raw_state, self.stats[self.spec.norm_unnorm_key]["state"],
+                                keys=list(self.stats[self.spec.norm_unnorm_key]["state"].keys()))
+        norm_state = norm_state[None, :]   # (1, S)
+
+        # 3. forward
+        sample = {"image": images, "lang": prompt, "state": norm_state}
+        out = self.model.predict_action([sample])
+        norm_action = out["normalized_actions"][0].cpu().numpy()  # (T, A)
+
+        # 4. un-normalize
+        action_keys = list(self.stats[self.spec.norm_unnorm_key]["action"].keys())
+        return _unnormalize(norm_action, self.stats[self.spec.norm_unnorm_key]["action"], action_keys)

--- a/docs/agent_skills/integrate-starvla-dataset/assets/templates/run_train.sh
+++ b/docs/agent_skills/integrate-starvla-dataset/assets/templates/run_train.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# <<TODO_BENCH>> — launch script (smoke-test profile by default).
+# Copy to: examples/<<TODO_BENCH>>/train_files/run_<<TODO_BENCH>>_train.sh
+set -euo pipefail
+cd "$(dirname "$0")/../../.."   # always run from repo root
+
+###########################################################################################
+# === Edit these for your environment ===
+Framework_name=<<TODO_FRAMEWORK>>          # QwenOFT | QwenFAST | QwenPI | QwenPI_v3 | QwenGR00T
+freeze_module_list=''                      # e.g. 'qwen_vl' to freeze the VLM backbone
+config_yaml=./examples/<<TODO_BENCH>>/train_files/starvla_<<TODO_FRAMEWORK>>_<<TODO_BENCH>>.yaml
+data_root_dir=playground/Datasets/<<TODO_DATASET_PARENT_DIR>>
+data_mix=<<TODO_MIXTURE_NAME>>
+run_root_dir=./results/Checkpoints
+run_id=starvla_<<TODO_FRAMEWORK>>_<<TODO_BENCH>>_smoke
+num_processes=2                            # number of GPUs
+###########################################################################################
+
+mkdir -p "${run_root_dir}/${run_id}"
+cp "$0" "${run_root_dir}/${run_id}/$(basename "$0")"   # snapshot the launcher
+cp "${config_yaml}" "${run_root_dir}/${run_id}/$(basename "${config_yaml}")"
+
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes ${num_processes} \
+  starVLA/training/train_starvla.py \
+    --config_yaml "${config_yaml}" \
+    --framework.name "${Framework_name}" \
+    --datasets.vla_data.data_root_dir "${data_root_dir}" \
+    --datasets.vla_data.data_mix "${data_mix}" \
+    --run_root_dir "${run_root_dir}" \
+    --run_id "${run_id}" \
+    ${freeze_module_list:+--trainer.freeze_modules "${freeze_module_list}"}

--- a/docs/agent_skills/integrate-starvla-dataset/assets/templates/training_config.yaml
+++ b/docs/agent_skills/integrate-starvla-dataset/assets/templates/training_config.yaml
@@ -1,0 +1,63 @@
+# <<TODO_BENCH>> training config — copy to:
+#   examples/<<TODO_BENCH>>/train_files/starvla_<<TODO_FRAMEWORK>>_<<TODO_BENCH>>.yaml
+#
+# CLI overrides this file:  --trainer.learning_rate.base 1e-4
+run_id: starvla_<<TODO_FRAMEWORK>>_<<TODO_BENCH>>_smoke
+run_root_dir: results/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_<<TODO_BENCH>>
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: <<TODO_FRAMEWORK>>          # QwenOFT | QwenFAST | QwenPI | QwenPI_v3 | QwenGR00T
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+  action_model:
+    action_dim: <<TODO_ACTION_DIM>>     # match data_config.py action_keys total width
+    state_dim:  <<TODO_STATE_DIM>>      # match data_config.py state_keys  total width
+    action_horizon: 8                   # must equal len(action_indices) in data_config
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: playground/Datasets/<<TODO_DATASET_PARENT_DIR>>   # parent of <task>_lerobot/
+    data_mix: <<TODO_MIXTURE_NAME>>     # name from DATASET_NAMED_MIXTURES
+    action_type: <<TODO_ACTION_TYPE>>   # delta_ee | delta_qpos | abs_ee | abs_qpos
+    sequential_step_sampling: false
+    per_device_batch_size: 2            # raise once it fits in VRAM
+    obs_image_size: [224, 224]
+    load_all_data_for_training: true
+    video_backend: torchvision_av       # try `decord` for speed
+
+trainer:
+  # SMOKE TEST FIRST — bump after Phase 5 gate passes.
+  max_train_steps: 100
+  num_warmup_steps: 10
+  save_interval: 100
+  eval_interval: 1000
+  learning_rate:
+    base: 2.5e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 1.0e-06
+  freeze_modules: ''                    # 'qwen_vl' to freeze the VLM backbone
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1        # raise to 4 once you go past smoke
+  gradient_checkpointing: true          # leave true unless you have huge VRAM
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08


### PR DESCRIPTION
## Summary

Introduce **agent skills** under `docs/agent_skills/` — structured, machine-
readable guides that let AI coding agents (e.g. GitHub Copilot, Claude) drive
common StarVLA workflows end-to-end with minimal human steering.

## What's included

### `docs/agent_skills/integrate-starvla-dataset/`
A skill that walks an agent through integrating a new robot / dataset:
- `SKILL.md` – the procedural prompt the agent follows.
- `README.md` – human-facing overview.
- `assets/templates/` – fill-in templates the agent copies and adapts:
  - `data_config.py`, `modality.json`
  - `model2bench_interface.py`
  - `training_config.yaml`, `run_train.sh`

### `docs/agent_skills/submit-starvla-pr/`
A skill that teaches an agent how to submit a clean PR to StarVLA:
- `SKILL.md`, `README.md` – branching policy, scope discipline, commit-message
  style, PR description format aligned with [docs/PR_readme.md](docs/PR_readme.md)
  and [docs/branching_strategy.md](docs/branching_strategy.md).

### `README.md`
Add one news entry under `## News` pointing to the new skills folder.

## Why

StarVLA already has the lowest-coupling architecture in the community; we want
to extend that ergonomic advantage to **AI coding agents**, not just humans. As
a sanity check, GitHub Copilot (Claude Opus 4.7) was able to autonomously
integrate both `examples/Robocasa_365` and `examples/RoboChallenge_table30v2`
from scratch using these skills — the news entry mentions this verification.

## Notes for reviewers

- Docs / templates only. No code under `starVLA/`, `examples/`, `deployment/`,
  or `scripts/` is touched.
- Skills are formatted to be loadable by Copilot's skill system and by
  Claude's tool-use protocol; they remain readable as plain Markdown for
  humans.