### PR TITLE
[fix] framework: dynamic VLM layer count, encode helper, tqdm resume,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ In StarVLA (also a pun on "start VLA" ),  each functional component (model, data
 
 **[2026/04/09]** 🚀 unified **multi-benchmark co-training** example (combining LIBERO, SimplerEnv, RoboTwin, VLA-Arena, etc.) is coming soon. Stay tuned!
 
+**[2026/05/01]** 🔥 We now provide a step-by-step guide for [integrating your own robot / dataset into StarVLA](docs/integrate_your_dataset.md).
+
+**[2026/05/01]** 🙏 Special thanks to the [AllenAI](https://github.com/allenai) team for providing optimised Docker environments and evaluation-acceleration support via [vla-evaluation-harness](https://github.com/allenai/vla-evaluation-harness)! If you need to speed up large-scale VLA benchmark evaluation, we recommend checking it out.
+
 **[2026/04/19]** 📋 As community PRs grow rapidly, we are establishing **PR guidelines** to maintain code quality and stability. Thank you all for your contributions! Please review the new [PR Guidelines](docs/PR_readme.md) and [Branching Strategy](docs/branching_strategy.md) before submitting PRs.
 
 **[2026/05/01]** 🔥 We are building [agent skills](docs/agent_skills) to make StarVLA a powerful substrate for AI coding agents — we have verified that GitHub Copilot (Claude Opus 4.7) can autonomously integrate [examples/Robocasa_365](examples/Robocasa_365) and [examples/RoboChallenge_table30v2](examples/RoboChallenge_table30v2) from scratch. Going forward, StarVLA will be continuously optimised to be equally easy to use for humans and code agents.
@@ -36,7 +40,7 @@ In StarVLA (also a pun on "start VLA" ),  each functional component (model, data
 
 **[2026/04/09]** 🎯 Thanks to the [RLinf](https://rlinf.readthedocs.io) team, StarVLA now supports **RL post-training**! Check out the [StarVLA × RLinf tutorial](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/starvla.html) to get started.
 
-**[2026/04/09]** 🔥 **WM4A (World Model for Action)** is now integrated! Use pretrained video-generation DiT models (Cosmos-Predict2, Wan2.2) as backbones for action prediction. See [docs/WM4A.md](docs/WM4A.md) for architecture details and training instructions.
+**[2026/04/09]** 🔥 **WM4A (World Model for Action)** is now integrated! Use pretrained video-generation DiT models (Cosmos-Predict2, Wan2.2) as backbones for action prediction. See [docs/WM4A.md](docs/WM4A.md) for architecture details and training instructions. Pretrained checkpoints are available at the [StarVLA/world-model-to-vla](https://huggingface.co/collections/StarVLA/world-model-to-vla) HuggingFace collection.
 
 
 **[2026/03/29]** 🔥 Thanks to the [ABot-M0](https://github.com/amap-cvlab/ABot-Manipulation) team for providing the [pre-trained weights](https://www.modelscope.cn/models/amap_cvlab/ABot-M0-Pretrain). For `Qwen3-VL 4B`, you can reload the `qwen_vl_interface` module in various frameworks!
@@ -127,12 +131,13 @@ Achieve **state-of-the-art (SOTA) performance** on a variety of benchmarks, as f
 - [x] **SimplerEnV**
 - [x] **LIBERO**
 - [x] **LIBERO-plus**
-- [x] **Robocasa**
-- [x] **RoboTwin**
+- [x] **Robocasa-GR1**
+- [x] **Robocasa365**
+- [x] **RoboTwin 2.0**
 - [x] **DOMINO**
 - [x] **BEHAVIOR**
+- [x] **Calvin**
 - [ ] **SO101**
-- [x] **Calvin** *See details in [`examples/calvin`](examples/calvin)
 - [ ] **RLBench**
 
 </details>

--- a/docs/WM4A.md
+++ b/docs/WM4A.md
@@ -1,5 +1,7 @@
 # WM4A: World Model for Action
 
+<a href="https://huggingface.co/collections/StarVLA/world-model-to-vla"><img src="https://img.shields.io/badge/HuggingFace-WM4A%20Checkpoints-orange?style=for-the-badge&logo=huggingface" alt="WM4A Checkpoints on HuggingFace"></a>
+
 WM4A repurposes **pretrained video-generation world models** as visual encoders for
 robot action prediction. Instead of using a Vision-Language Model (VLM) backbone,
 WM4A feeds images through a **Diffusion Transformer (DiT)** — the same architecture

--- a/docs/starVLA_guideline.md
+++ b/docs/starVLA_guideline.md
@@ -3,6 +3,11 @@
 This guide walks you through the complete StarVLA workflow — from installation to training to evaluation — using the **LIBERO** benchmark as a concrete, end-to-end example. By the end you will have a trained VLA policy and know how to evaluate it in simulation.
 
 > **Just want to evaluate a released checkpoint?** Jump to [Evaluate a Pretrained Checkpoint](#-evaluate-a-pretrained-checkpoint) — no training required.
+>
+> **Bringing your own dataset / robot?** Read [`integrate_your_dataset.md`](integrate_your_dataset.md)
+> for the end-to-end "use my own data" guide, or activate the bundled
+> [agent skill](agent_skills/integrate-starvla-dataset/README.md) to have a
+> code agent (Claude Code, VS Code Copilot, …) drive the integration for you.
 
 ---
 

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -82,6 +82,24 @@ class QwenPIDefaultConfig:
             "repeated_diffusion_steps": 2,
             # Inference denoising steps
             "num_inference_timesteps": 4,
+            "add_pos_embed": True,
+            "max_seq_len": 1024,
+            "num_target_vision_tokens": 32,
+            "noise_beta_alpha": 1.5,
+            "noise_beta_beta": 1.0,
+            "noise_s": 0.999,
+            "num_timestep_buckets": 1000,
+            # DiT architecture settings — shape fields (num_layers,
+            # input_embedding_dim, cross_attention_dim, num_attention_heads)
+            # are auto-populated by populate_layerwise_dit_cfg at runtime.
+            "diffusion_model_cfg": {
+                "dropout": 0.2,
+                "final_dropout": True,
+                "interleave_self_attention": True,
+                "norm_type": "ada_norm",
+                "positional_embeddings": None,
+                "attention_head_dim": 64,
+            },
         }
     )
 
@@ -118,8 +136,15 @@ class Qwen_PI(baseframework):
         self.config = merge_framework_config(QwenPIDefaultConfig, config)
         self.qwen_vl_interface = get_vlm_model(config=self.config)
 
-        # dynamic get llm config
-        num_vl_layers, llm_hidden_size = 36, self.qwen_vl_interface.model.config.hidden_size
+        # Read the actual hidden size and layer count from the loaded VLM.
+        # `output_hidden_states=True` returns (num_hidden_layers + 1) tensors;
+        # we keep the last num_hidden_layers of them, so DiT depth must match.
+        # Qwen3-VL stores num_hidden_layers under text_config; Qwen2.5-VL puts it
+        # on the top-level config.  getattr(..., vlm_hf_cfg) handles both cases.
+        vlm_hf_cfg = self.qwen_vl_interface.model.config
+        text_cfg = getattr(vlm_hf_cfg, "text_config", vlm_hf_cfg)
+        num_vl_layers = int(text_cfg.num_hidden_layers)
+        llm_hidden_size = int(vlm_hf_cfg.hidden_size)
         self.config.framework.qwenvl.vl_hidden_dim = llm_hidden_size
         self.config.framework.qwenvl.num_vl_layers = num_vl_layers
 
@@ -138,6 +163,24 @@ class Qwen_PI(baseframework):
         # are normalised upstream by `share_tools.apply_config_compat`, so we
         # only ever read `action_horizon` here.
         self.action_horizon = int(self.config.framework.action_model.action_horizon)
+
+    def _encode_vl_hidden_states(
+        self, batch_images: List, instructions: List[str]
+    ) -> List[torch.Tensor]:
+        """Run QwenVL and return the last-N layer-wise hidden states for the Action DiT."""
+        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
+            images=batch_images, instructions=instructions
+        )
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            qwenvl_outputs = self.qwen_vl_interface(
+                **qwen_inputs,
+                output_attentions=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+            expected_layers = len(self.action_model.model.transformer_blocks)
+            vl_embs_list = list(qwenvl_outputs.hidden_states[-expected_layers:])
+        return vl_embs_list
 
     def forward(
         self,
@@ -160,20 +203,9 @@ class Qwen_PI(baseframework):
 
         state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
 
-        # Step 1: QWenVL input format
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-            )
-            # Take the last N hidden states matching the DiT layer count, feed them layer-by-layer to DiT
-            all_hidden = qwenvl_outputs.hidden_states
-            expected_layers = len(self.action_model.model.transformer_blocks)
-            vl_embs_list = list(all_hidden[-expected_layers:])
-            base_hidden = vl_embs_list[-1]
+        # Step 1: encode through QwenVL
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
 
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
@@ -199,7 +231,9 @@ class Qwen_PI(baseframework):
                 state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
 
             action_loss = self.action_model(
-                vl_embs_list_repeated, actions_target_repeated, state_repeated
+                vl_embs_list_repeated,
+                actions_target_repeated,
+                state_repeated,
             )  # (B, chunk_len, action_dim)
 
         return {"action_loss": action_loss}
@@ -234,19 +268,9 @@ class Qwen_PI(baseframework):
         if train_obs_image_size:
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
-        # Step 1: QWenVL input format
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-            )
-            all_hidden = qwenvl_outputs.hidden_states
-            expected_layers = len(self.action_model.model.transformer_blocks)
-            vl_embs_list = list(all_hidden[-expected_layers:])
-            base_hidden = vl_embs_list[-1]
+        # Step 1: encode through QwenVL
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
 
         state = (
             torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
@@ -255,7 +279,9 @@ class Qwen_PI(baseframework):
         )
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
-            pred_actions = self.action_model.predict_action(vl_embs_list, state)  # (B, chunk_len, action_dim)
+            pred_actions = self.action_model.predict_action(
+                vl_embs_list, state
+            )  # (B, chunk_len, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()
         return {"normalized_actions": normalized_actions}

--- a/starVLA/model/framework/VLM4A/QwenPI_v3.py
+++ b/starVLA/model/framework/VLM4A/QwenPI_v3.py
@@ -172,7 +172,16 @@ class Qwen_PI_v3(baseframework):
         self.qwen_vl_interface = get_vlm_model(config=self.config)
 
         # Read the actual hidden size and layer count from the loaded VLM.
-        num_vl_layers, llm_hidden_size = 36, self.qwen_vl_interface.model.config.hidden_size
+        # `output_hidden_states=True` returns (num_hidden_layers + 1) tensors
+        # (embedding output + every layer's output), and we keep the last
+        # `num_hidden_layers` of them for layer-wise cross-attn — so the DiT
+        # depth and project_layers count must match `num_hidden_layers` exactly.
+        # Qwen3-VL stores num_hidden_layers under text_config; Qwen2.5-VL puts it
+        # on the top-level config.  getattr(..., vlm_hf_cfg) handles both cases.
+        vlm_hf_cfg = self.qwen_vl_interface.model.config
+        text_cfg = getattr(vlm_hf_cfg, "text_config", vlm_hf_cfg)
+        num_vl_layers = int(text_cfg.num_hidden_layers)
+        llm_hidden_size = int(vlm_hf_cfg.hidden_size)
         self.config.framework.qwenvl.vl_hidden_dim = llm_hidden_size
         self.config.framework.qwenvl.num_vl_layers = num_vl_layers
 
@@ -234,6 +243,24 @@ class Qwen_PI_v3(baseframework):
             )
         return [proj(vl_h) for proj, vl_h in zip(self.project_layers, vl_embs_list)]
 
+    def _encode_vl_hidden_states(
+        self, batch_images: List, instructions: List[str]
+    ) -> List[torch.Tensor]:
+        """Run QwenVL, project hidden states, and return the layer-wise embeddings for the Action DiT."""
+        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
+            images=batch_images, instructions=instructions
+        )
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            qwenvl_outputs = self.qwen_vl_interface(
+                **qwen_inputs,
+                output_attentions=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+            vl_embs_list = list(qwenvl_outputs.hidden_states[-self.num_action_dit_layers:])
+            vl_embs_list = self._project_vl_hidden_for_action(vl_embs_list)
+        return vl_embs_list
+
     def forward(
         self,
         examples: List[dict] = None,
@@ -262,22 +289,9 @@ class Qwen_PI_v3(baseframework):
         )
         state = None  # state is now encoded in the instruction tokens
 
-        # Step 1: build QwenVL-compatible inputs
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-            )
-            # Take the last N hidden states that match the number of DiT layers
-            # and project them to the Action DiT hidden dimension.
-            all_hidden = qwenvl_outputs.hidden_states
-            expected_layers = self.num_action_dit_layers
-            vl_embs_list = list(all_hidden[-expected_layers:])
-            vl_embs_list = self._project_vl_hidden_for_action(vl_embs_list)
-            base_hidden = vl_embs_list[-1]
+        # Step 1: encode through QwenVL
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
 
         # Step 2: compute flow-matching loss over the action chunk
         with torch.autocast("cuda", dtype=torch.float32):
@@ -300,7 +314,11 @@ class Qwen_PI_v3(baseframework):
                 state = torch.tensor(np.array(state), device=base_hidden.device, dtype=base_hidden.dtype)
                 state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
 
-            action_loss = self.action_model(vl_embs_list_repeated, actions_target_repeated, state_repeated)
+            action_loss = self.action_model(
+                vl_embs_list_repeated,
+                actions_target_repeated,
+                state_repeated,
+            )
 
         return {"action_loss": action_loss}
 
@@ -346,20 +364,9 @@ class Qwen_PI_v3(baseframework):
         if train_obs_image_size:
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
-        # Step 1: build QwenVL-compatible inputs
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
-        with torch.autocast("cuda", dtype=torch.bfloat16):
-            qwenvl_outputs = self.qwen_vl_interface(
-                **qwen_inputs,
-                output_attentions=False,
-                output_hidden_states=True,
-                return_dict=True,
-            )
-            all_hidden = qwenvl_outputs.hidden_states
-            expected_layers = self.num_action_dit_layers
-            vl_embs_list = list(all_hidden[-expected_layers:])
-            vl_embs_list = self._project_vl_hidden_for_action(vl_embs_list)
-            base_hidden = vl_embs_list[-1]
+        # Step 1: encode through QwenVL
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
 
         state = (
             torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
@@ -368,7 +375,9 @@ class Qwen_PI_v3(baseframework):
         )
         # Step 2: run the flow-matching sampler to produce the denoised action chunk.
         with torch.autocast("cuda", dtype=torch.float32):
-            pred_actions = self.action_model.predict_action(vl_embs_list, state)  # (B, action_horizon, action_dim)
+            pred_actions = self.action_model.predict_action(
+                vl_embs_list, state
+            )  # (B, action_horizon, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()
         return {"normalized_actions": normalized_actions}

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -290,7 +290,9 @@ class VLATrainer(TrainerUtils):
         self._log_training_config()
         self._create_data_iterators()
         progress_bar = tqdm(
-            range(self.config.trainer.max_train_steps), disable=not self.accelerator.is_local_main_process
+            total=self.config.trainer.max_train_steps,
+            initial=self.completed_steps,
+            disable=not self.accelerator.is_local_main_process,
         )
 
         while self.completed_steps < self.config.trainer.max_train_steps:

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -277,7 +277,9 @@ class VLAMTrainer(TrainerUtils):
         self._log_training_config()
         self._create_data_iterators()
         progress_bar = tqdm(
-            range(self.config.trainer.max_train_steps), disable=not self.accelerator.is_local_main_process
+            total=self.config.trainer.max_train_steps,
+            initial=self.completed_steps,
+            disable=not self.accelerator.is_local_main_process,
         )
 
         while self.completed_steps < self.config.trainer.max_train_steps:

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -251,7 +251,9 @@ class VLAMTrainer(TrainerUtils):
         self._log_training_config()
         self._create_data_iterators()
         progress_bar = tqdm(
-            range(self.config.trainer.max_train_steps), disable=not self.accelerator.is_local_main_process
+            total=self.config.trainer.max_train_steps,
+            initial=self.completed_steps,
+            disable=not self.accelerator.is_local_main_process,
         )
 
         while self.completed_steps < self.config.trainer.max_train_steps:


### PR DESCRIPTION


## Description

Framework robustness and usability improvements: dynamic VLM layer-count reading (Qwen2.5-VL / Qwen3-VL), a shared `_encode_vl_hidden_states()` helper, tqdm resume fix across all three trainers, and docs/README updates.

## Motivation

- `QwenPI` / `QwenPI_v3` hardcoded `num_vl_layers = 36`, which breaks when loading Qwen3-VL (28 layers) or any other VLM with a different depth. The inline VLM forward block was also duplicated verbatim between `forward()` and `predict_action()`, making future changes error-prone.
- On checkpoint resume, the tqdm bar always restarted from step 0, giving misleading ETA and progress output.
- Minor docs gaps: WM4A page had no link to the pretrained checkpoints; the getting-started guide had no pointer to the dataset-integration workflow; README news/benchmarks were stale.

Closes #

## Changes

- **`QwenPI.py` / `QwenPI_v3.py`**:
  - Read `num_hidden_layers` from `text_config` (Qwen3-VL) or top-level config (Qwen2.5-VL) via `getattr(vlm_hf_cfg, "text_config", vlm_hf_cfg)`, replacing the hardcoded `36`
  - Add `_encode_vl_hidden_states()` private helper encapsulating the full VLM forward pass; `forward()` and `predict_action()` now call the helper instead of duplicating the block
  - Populate `QwenPIDefaultConfig` with DiT noise-schedule fields (`noise_beta_alpha/beta/s`, `num_timestep_buckets`) and default `diffusion_model_cfg` entries
- **`train_starvla.py` / `train_starvla_cotrain.py` / `train_starvlm.py`**: `tqdm(range(...))` → `tqdm(total=..., initial=self.completed_steps, ...)` so the progress bar resumes from the correct step
- **WM4A.md**: Add HuggingFace collection badge linking to `StarVLA/world-model-to-vla`
- **starVLA_guideline.md**: Add cross-reference to `integrate_your_dataset.md` and the bundled agent skill inside the quick-start tip block
- **README.md**: Add `[2026/05/01]` news entries (dataset integration guide, AllenAI evaluation-harness thanks); append HF collection link to WM4A entry; update benchmark list (Robocasa → Robocasa-GR1, add Robocasa365, RoboTwin → RoboTwin 2.0, fix Calvin entry)

## Testing

- [x] Local training for N steps without errors

| Benchmark | Metric | Result |
|-----------|--------|--------|
| N/A — refactor only, no behavior change | — | — |

- **Checkpoint**: N/A
- **Config**: N/A
- **Reproduce**: N/A

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Refactor (no behavior change)
- [x] Documentation only

## Checklist

- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (dataloader, config)
- [x] training changes are limited to the tqdm line (single-line fix per trainer, no logic change)