### PR TITLE
feat(eval): add LIBERO, LIBERO-plus and Robotwin parallel eval with labtasker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+core.*
+
 debug/
 ckpts/
 third_party/

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/.env.example
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/.env.example
@@ -1,0 +1,23 @@
+# ============================================================
+# Environment config for LIBERO-plus parallel eval worker (run.py)
+# Usage: python run.py --env /path/to/this/.env
+# ============================================================
+
+# Python interpreter with starVLA + labtasker installed
+STARVLA_PYTHON=/path/to/starvla/env/bin/python
+
+# Python interpreter with LIBERO-plus sim installed
+LIBERO_PLUS_PYTHON=/path/to/libero_plus/env/bin/python
+
+# Root directory of the LIBERO-plus repo (sylvestf/LIBERO-plus)
+LIBERO_PLUS_HOME=/path/to/LIBERO-plus
+
+# ------------------------------------------------------------
+# Optional (defaults shown)
+# ------------------------------------------------------------
+
+# Episodes per task
+LIBERO_NUM_TRIALS=50
+
+# Seconds to wait for the policy server to become ready
+SERVER_TIMEOUT=300

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/README.md
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/README.md
@@ -1,0 +1,186 @@
+# LIBERO-plus 并行评测：Labtasker 使用说明
+
+本目录提供基于 [Labtasker](https://github.com/luocfprime/labtasker) 的 LIBERO-plus 并行评测脚本，支持多 GPU 弹性并行、失败自动重试、结果汇总。
+
+---
+
+## Labtasker 简介
+
+[Labtasker](https://github.com/luocfprime/labtasker) 是一个轻量级任务队列系统，专为 ML 实验设计。核心思路是把 `for` 循环替换为任务队列：
+
+- **submit**：把实验参数组合批量推入队列
+- **worker**：从队列拉取任务并执行，多个 worker 并行互不干扰
+- **retry**：任务失败自动重试，成功后将结果写入 summary
+
+### 安装
+
+```bash
+pip install 'labtasker[plugins]'
+```
+
+### 启动 Labtasker Server
+
+Labtasker 需要一个后端服务来管理任务队列。在远端机器上启动（建议放入 tmux）：
+
+```bash
+labtasker-server serve &
+```
+
+### 初始化队列
+
+首次使用时，在项目根目录初始化配置并创建队列：
+
+```bash
+labtasker init          # 交互式填写 server 地址、队列名等，生成 .labtasker/config.toml
+labtasker queue create-from-config
+```
+
+此后同一机器上的所有 submit / worker 命令自动读取 `.labtasker/config.toml`，无需重复配置。
+
+---
+
+## 架构说明
+
+每个任务（checkpoint × task suite）完全自洽：worker 为该任务启动 policy server，eval 结束后关闭，再处理下一个任务。
+
+```
+Queue                                  Worker (GPU 0)
+┌──────────────────────────────┐       ┌──────────────────────────────────────────┐
+│  ckpt=A × libero_spatial     │──────►│  start server(ckpt=A)                   │
+│  ckpt=A × libero_goal        │       │  run eval_libero.py(libero_spatial)      │
+│  ckpt=B × libero_spatial     │       │  stop server                            │
+│  ckpt=B × libero_goal        │       │  start server(ckpt=A)                   │
+│  ...                         │       │  run eval_libero.py(libero_goal)         │
+└──────────────────────────────┘       │  stop server                            │
+                                       │  ...                                    │
+                                       └──────────────────────────────────────────┘
+```
+
+## 文件说明
+
+| 文件 | 作用 |
+|---|---|
+| `submit.py` | 向任务队列提交 (checkpoint × task_suite) 评测任务 |
+| `run.py` | Worker 脚本：循环拉取任务 → 启动 server → 运行评测 → 关闭 server → 上报结果 |
+| `.env.example` | 环境变量模板，复制为 `.env` 后填入实际路径 |
+| `collect_results.ipynb` | 结果汇总 notebook，含 per-suite 和 per-category（扰动类型）两个维度 |
+
+任务粒度：**每个任务 = 一个 checkpoint × 一个 task suite**（默认 4 个 suite = 4 个任务/checkpoint）。
+
+---
+
+## 前提条件
+
+LIBERO-plus 使用独立的 conda 环境（`libero_plus`），与运行 policy server 的 starVLA 环境分离。请确保 labtasker 在两个环境中都已安装：
+
+```bash
+# starVLA 环境（运行 run.py / policy server）
+${STARVLA_PYTHON} -m pip install 'labtasker[plugins]'
+
+# LIBERO-plus 环境（运行 eval_libero.py）
+${LIBERO_PLUS_PYTHON} -m pip install labtasker
+```
+
+---
+
+## 快速开始
+
+### 第一步：配置环境变量
+
+复制模板并填入实际路径：
+
+```bash
+cp .env.example .env
+# 编辑 .env，填入 STARVLA_PYTHON、LIBERO_PLUS_PYTHON、LIBERO_PLUS_HOME
+```
+
+`.env` 内容说明：
+
+```bash
+# 必填
+STARVLA_PYTHON=      # 运行 policy server 的 Python（starVLA conda env）
+LIBERO_PLUS_PYTHON=  # 运行 eval_libero.py 的 Python（libero_plus conda env）
+LIBERO_PLUS_HOME=    # LIBERO-plus repo 根目录（sylvestf/LIBERO-plus）
+
+# 可选（括号内为默认值）
+LIBERO_NUM_TRIALS=50   # 每个任务的 episode 数（50）
+SERVER_TIMEOUT=300     # 等待 policy server 就绪的超时秒数（300）
+```
+
+### 第二步：提交任务
+
+编辑 `submit.py` 顶部的 USER CONFIG，填写 `CKPT_LIST`（或 `CKPT_DIR`）和要评测的 `TASK_SUITES`：
+
+```python
+CKPT_LIST = [
+    "/path/to/steps_30000_pytorch_model.pt",
+]
+TASK_SUITES = ["libero_spatial", "libero_object", "libero_goal", "libero_10"]
+```
+
+提交：
+
+```bash
+${STARVLA_PYTHON} examples/LIBERO-plus/eval_files/parallel_eval_labtasker/submit.py
+```
+
+### 第三步：启动 Worker
+
+每个 GPU 启动一个 worker，worker 自动从队列中拉取任务：
+
+```bash
+# GPU 0
+CUDA_VISIBLE_DEVICES=0 \
+    ${STARVLA_PYTHON} examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/LIBERO-plus/eval_files/parallel_eval_labtasker/.env &
+
+# GPU 1
+CUDA_VISIBLE_DEVICES=1 \
+    ${STARVLA_PYTHON} examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/LIBERO-plus/eval_files/parallel_eval_labtasker/.env &
+
+wait
+```
+
+多个 worker 可以并行处理不同任务，labtasker 自动分配，不会重复。Worker 队列为空时自动退出。
+
+---
+
+## 查看进度
+
+```bash
+labtasker task count
+labtasker task ls
+labtasker task ls -s running
+labtasker task ls -s failed  --no-pager
+labtasker task ls -s success
+```
+
+## 汇总结果
+
+打开 `collect_results.ipynb` 查看：
+- 每个 (checkpoint × task_suite) 的成功率
+- 按 checkpoint 的跨 suite 加权汇总
+- 按扰动类别（Camera / Robot / Language / Light / Background / Noise / Layout）的成功率分析
+
+## 失败重试
+
+```bash
+# 查看失败任务
+labtasker task ls -s failed --no-pager
+
+# 批量重置为 pending（重新排队）
+labtasker task update -s failed -u "retries=0" --reset-pending --quiet
+```
+
+## 日志位置
+
+```
+<ckpt_dir>/
+  logs/
+    <task_suite>/
+      <ckpt_stem>_server.log   # policy server 日志
+      <ckpt_stem>.log          # eval_libero.py 完整输出
+  videos/<task_suite>/<ckpt_stem>/
+    rollout_*.mp4
+```

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/collect_results.ipynb
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/collect_results.ipynb
@@ -1,0 +1,602 @@
+{
+ "cells": [
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T07:14:44.623514Z",
+     "start_time": "2026-04-29T07:14:43.536940Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "!pip install \"labtasker[plugins]\" pandas",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://artifactory-cloud.chehejia.com/artifactory/api/pypi/liauto-pypi-l5/simple\r\n",
+      "Requirement already satisfied: pandas in /opt/miniconda3/lib/python3.13/site-packages (3.0.2)\r\n",
+      "Requirement already satisfied: labtasker[plugins] in /opt/miniconda3/lib/python3.13/site-packages (1.0.0)\r\n",
+      "Requirement already satisfied: pymongo<5.0.0,>=4.0.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.17.0)\r\n",
+      "Requirement already satisfied: fastapi<0.137.0,>=0.115.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.136.1)\r\n",
+      "Requirement already satisfied: uvicorn<0.45.0,>=0.15.0 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.44.0)\r\n",
+      "Requirement already satisfied: click<9.0.0,>=8.2.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (8.3.1)\r\n",
+      "Requirement already satisfied: passlib<2.0.0,>=1.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.7.4)\r\n",
+      "Requirement already satisfied: pydantic-settings<3.0.0,>=2.8.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (2.14.0)\r\n",
+      "Requirement already satisfied: httpx<0.29.0,>=0.28.0 in /opt/miniconda3/lib/python3.13/site-packages (from httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (0.28.1)\r\n",
+      "Requirement already satisfied: typer<0.25.0,>=0.16.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.24.2)\r\n",
+      "Requirement already satisfied: loguru<0.8.0,>=0.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.7.3)\r\n",
+      "Requirement already satisfied: ruamel-yaml<0.20.0,>=0.18.10 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.18.10)\r\n",
+      "Requirement already satisfied: pyyaml<7.0.0,>=6.0.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (6.0.3)\r\n",
+      "Requirement already satisfied: tomlkit<0.15.0,>=0.13.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.14.0)\r\n",
+      "Requirement already satisfied: importlib-metadata<10.0.0,>=8.5.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (9.0.0)\r\n",
+      "Requirement already satisfied: packaging<27.0,>=24.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (24.2)\r\n",
+      "Requirement already satisfied: sse-starlette<4.0.0,>=2.1.3 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (3.4.1)\r\n",
+      "Requirement already satisfied: httpx-sse<0.5.0,>=0.4.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.4.3)\r\n",
+      "Requirement already satisfied: stamina<27.0.0,>=25.1.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (26.1.0)\r\n",
+      "Requirement already satisfied: noneprompt<0.2.0,>=0.1.9 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.11)\r\n",
+      "Requirement already satisfied: mongomock<4.4.0,>=4.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.3.0)\r\n",
+      "Requirement already satisfied: jsonpickle<5.0.0,>=4.0.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.1.1)\r\n",
+      "Requirement already satisfied: mslex<2.0.0,>=1.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.3.0)\r\n",
+      "Requirement already satisfied: pexpect<5.0.0,>=4.9.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.9.0)\r\n",
+      "Requirement already satisfied: pip>=25 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (25.1)\r\n",
+      "Requirement already satisfied: dateparser<2.0.0,>=1.2.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.4.0)\r\n",
+      "Requirement already satisfied: labtasker-plugin-task-count in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.1)\r\n",
+      "Requirement already satisfied: labtasker-plugin-task-recency in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.1)\r\n",
+      "Requirement already satisfied: python-dateutil>=2.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2.9.0.post0)\r\n",
+      "Requirement already satisfied: pytz>=2024.2 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2026.1.post1)\r\n",
+      "Requirement already satisfied: regex>=2024.9.11 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2026.4.4)\r\n",
+      "Requirement already satisfied: tzlocal>=0.2 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (5.3.1)\r\n",
+      "Requirement already satisfied: starlette>=0.46.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (1.0.0)\r\n",
+      "Requirement already satisfied: pydantic>=2.9.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (2.11.7)\r\n",
+      "Requirement already satisfied: typing-extensions>=4.8.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (4.12.2)\r\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.4.2)\r\n",
+      "Requirement already satisfied: annotated-doc>=0.0.2 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.0.4)\r\n",
+      "Requirement already satisfied: anyio in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (4.13.0)\r\n",
+      "Requirement already satisfied: certifi in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (2025.10.5)\r\n",
+      "Requirement already satisfied: httpcore==1.* in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (1.0.9)\r\n",
+      "Requirement already satisfied: idna in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (3.7)\r\n",
+      "Requirement already satisfied: h11>=0.16 in /opt/miniconda3/lib/python3.13/site-packages (from httpcore==1.*->httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (0.16.0)\r\n",
+      "Requirement already satisfied: socksio==1.* in /opt/miniconda3/lib/python3.13/site-packages (from httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (1.0.0)\r\n",
+      "Requirement already satisfied: zipp>=3.20 in /opt/miniconda3/lib/python3.13/site-packages (from importlib-metadata<10.0.0,>=8.5.0->labtasker[plugins]) (3.23.1)\r\n",
+      "Requirement already satisfied: sentinels in /opt/miniconda3/lib/python3.13/site-packages (from mongomock<4.4.0,>=4.3.0->labtasker[plugins]) (1.1.1)\r\n",
+      "Requirement already satisfied: prompt-toolkit<4.0.0,>=3.0.19 in /opt/miniconda3/lib/python3.13/site-packages (from noneprompt<0.2.0,>=0.1.9->labtasker[plugins]) (3.0.52)\r\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /opt/miniconda3/lib/python3.13/site-packages (from pexpect<5.0.0,>=4.9.0->labtasker[plugins]) (0.7.0)\r\n",
+      "Requirement already satisfied: wcwidth in /opt/miniconda3/lib/python3.13/site-packages (from prompt-toolkit<4.0.0,>=3.0.19->noneprompt<0.2.0,>=0.1.9->labtasker[plugins]) (0.6.0)\r\n",
+      "Requirement already satisfied: python-dotenv>=0.21.0 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic-settings<3.0.0,>=2.8.0->labtasker[plugins]) (1.2.2)\r\n",
+      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in /opt/miniconda3/lib/python3.13/site-packages (from pymongo<5.0.0,>=4.0.0->labtasker[plugins]) (2.8.0)\r\n",
+      "Requirement already satisfied: tenacity in /opt/miniconda3/lib/python3.13/site-packages (from stamina<27.0.0,>=25.1.0->labtasker[plugins]) (9.1.4)\r\n",
+      "Requirement already satisfied: shellingham>=1.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from typer<0.25.0,>=0.16.0->labtasker[plugins]) (1.5.4)\r\n",
+      "Requirement already satisfied: rich>=12.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from typer<0.25.0,>=0.16.0->labtasker[plugins]) (13.9.4)\r\n",
+      "Requirement already satisfied: httptools>=0.6.3 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.7.1)\r\n",
+      "Requirement already satisfied: uvloop>=0.15.1 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.22.1)\r\n",
+      "Requirement already satisfied: watchfiles>=0.20 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (1.1.1)\r\n",
+      "Requirement already satisfied: websockets>=10.4 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (16.0)\r\n",
+      "Requirement already satisfied: numpy>=1.26.0 in /opt/miniconda3/lib/python3.13/site-packages (from pandas) (2.4.4)\r\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic>=2.9.0->fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.6.0)\r\n",
+      "Requirement already satisfied: pydantic-core==2.33.2 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic>=2.9.0->fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (2.33.2)\r\n",
+      "Requirement already satisfied: six>=1.5 in /opt/miniconda3/lib/python3.13/site-packages (from python-dateutil>=2.7.0->dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (1.17.0)\r\n",
+      "Requirement already satisfied: markdown-it-py>=2.2.0 in /opt/miniconda3/lib/python3.13/site-packages (from rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (2.2.0)\r\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /opt/miniconda3/lib/python3.13/site-packages (from rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (2.19.1)\r\n",
+      "Requirement already satisfied: mdurl~=0.1 in /opt/miniconda3/lib/python3.13/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (0.1.0)\r\n",
+      "\u001B[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001B[0m\u001B[33m\r\n",
+      "\u001B[0m"
+     ]
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:17:39.680325Z",
+     "start_time": "2026-05-02T12:17:32.917885Z"
+    }
+   },
+   "source": [
+    "import os\n",
+    "os.chdir(\"/path/to/starVLA\")\n",
+    "print(os.getcwd())\n",
+    "from labtasker import ls_tasks"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/path/to/starVLA\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:17:41.723816Z",
+     "start_time": "2026-05-02T12:17:39.685211Z"
+    }
+   },
+   "source": "!labtasker task count -f 'metadata.benchmark == \"LIBERO-plus\"'",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🟡 Pending: \u001B[1;36m43\u001B[0m\r\n",
+      "🔵 Running: \u001B[1;36m4\u001B[0m\r\n",
+      "🟢 Success: \u001B[1;36m13\u001B[0m\r\n",
+      "🔴 Failed: \u001B[1;36m0\u001B[0m\r\n",
+      "⚪ Cancelled: \u001B[1;36m0\u001B[0m\r\n"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:17:42.698427Z",
+     "start_time": "2026-05-02T12:17:41.725298Z"
+    }
+   },
+   "source": [
+    "# Filter by benchmark to avoid mixing with LIBERO tasks\n",
+    "# Add more conditions as needed:\n",
+    "# e.g. extra_filter = 'metadata.benchmark == \"LIBERO-plus\" and metadata.ckpt_stem == \"steps_30000_pytorch_model\"'\n",
+    "extra_filter = 'metadata.benchmark == \"LIBERO-plus\"'\n",
+    "\n",
+    "tasks = ls_tasks(\n",
+    "    status=\"success\",\n",
+    "    extra_filter=extra_filter if extra_filter else None,\n",
+    "    limit=1000,\n",
+    ").content\n",
+    "print(f\"{len(tasks)} successful tasks\")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13 successful tasks\n"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:17:42.797928Z",
+     "start_time": "2026-05-02T12:17:42.699433Z"
+    }
+   },
+   "source": [
+    "tasks[0]"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Task(unknown_fields={}, task_id='3f3362f7-c2f2-4b9d-9c65-30c5daead983', queue_id='b5b7ed91-b5ef-46bc-a244-33216576b5d9', status='success', task_name='steps_30000_pytorch_model_libero_object_0_210', created_at=datetime.datetime(2026, 4, 29, 10, 9, 56, 762000), start_time=datetime.datetime(2026, 4, 29, 11, 19, 27, 353000), last_heartbeat=datetime.datetime(2026, 4, 30, 6, 26, 32, 813000), last_modified=datetime.datetime(2026, 4, 30, 6, 26, 33, 818000), heartbeat_timeout=30.0, task_timeout=None, max_retries=3, retries=0, priority=10, metadata={'benchmark': 'LIBERO-plus', 'ckpt_stem': 'steps_30000_pytorch_model', 'task_suite': 'libero_object'}, args={'ckpt': '/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt', 'task_suite': 'libero_object', 'start_idx': 0, 'end_idx': 210}, cmd=['examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py', '--env', 'examples/LIBERO-plus/eval_files/parallel_eval_labtasker/.env'], summary={'success_rate': 0.9218095238095239, 'total_successes': 9679, 'total_episodes': 10500, 'task_suite': 'libero_object', 'start_idx': 0, 'end_idx': 210, 'category_results': {'Background Textures': {'total_count': 10500, 'success_count': 9679}, 'Robot Initial States': {'total_count': 0, 'success_count': 0}, 'Camera Viewpoints': {'total_count': 0, 'success_count': 0}, 'Language Instructions': {'total_count': 0, 'success_count': 0}, 'Sensor Noise': {'total_count': 0, 'success_count': 0}, 'Objects Layout': {'total_count': 0, 'success_count': 0}, 'Light Conditions': {'total_count': 0, 'success_count': 0}}}, worker_id=None)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:19.974100Z",
+     "start_time": "2026-05-02T12:18:14.262335Z"
+    }
+   },
+   "source": "import pandas as pd\n\n# Each task is one slice [start_idx, end_idx); aggregate slices → per-(ckpt, suite) totals\nrows = []\nfor t in tasks:\n    rows.append({\n        \"ckpt_stem\":       t.metadata.get(\"ckpt_stem\", \"\"),\n        \"task_suite\":      t.summary[\"task_suite\"],\n        \"start_idx\":       t.args.get(\"start_idx\"),\n        \"end_idx\":         t.args.get(\"end_idx\"),\n        \"total_episodes\":  t.summary[\"total_episodes\"],\n        \"total_successes\": t.summary[\"total_successes\"],\n    })\n\nraw_df = pd.DataFrame(rows)\n\n# Sum slices → per-(ckpt_stem, task_suite)\nsuite_df = (\n    raw_df\n    .groupby([\"ckpt_stem\", \"task_suite\"])[[\"total_episodes\", \"total_successes\"]]\n    .sum()\n)\nsuite_df[\"success_rate\"] = suite_df[\"total_successes\"] / suite_df[\"total_episodes\"]\nsuite_df[\"n_slices\"] = raw_df.groupby([\"ckpt_stem\", \"task_suite\"]).size()\nsuite_df = suite_df.sort_index()\nsuite_df",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                          total_episodes  total_successes  \\\n",
+       "ckpt_stem                 task_suite                                        \n",
+       "steps_30000_pytorch_model libero_object            73450            48456   \n",
+       "                          libero_spatial           60100            40580   \n",
+       "\n",
+       "                                          success_rate  n_slices  \n",
+       "ckpt_stem                 task_suite                              \n",
+       "steps_30000_pytorch_model libero_object       0.659714         7  \n",
+       "                          libero_spatial      0.675208         6  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>total_episodes</th>\n",
+       "      <th>total_successes</th>\n",
+       "      <th>success_rate</th>\n",
+       "      <th>n_slices</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ckpt_stem</th>\n",
+       "      <th>task_suite</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">steps_30000_pytorch_model</th>\n",
+       "      <th>libero_object</th>\n",
+       "      <td>73450</td>\n",
+       "      <td>48456</td>\n",
+       "      <td>0.659714</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>libero_spatial</th>\n",
+       "      <td>60100</td>\n",
+       "      <td>40580</td>\n",
+       "      <td>0.675208</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "source": "# Total tasks per suite in LIBERO-plus (from benchmark; update if suite changes)\nSUITE_SIZES = {\n    \"libero_10\":      2519,\n    \"libero_goal\":    2591,\n    \"libero_object\":  2518,\n    \"libero_spatial\": 2402,\n}\n\n# Join with suite_df to show \"X successes / Y episodes across Z tasks\"\nsize_series = pd.Series(SUITE_SIZES, name=\"total_tasks\").rename_axis(\"task_suite\")\n\n# suite_df has multi-index (ckpt_stem, task_suite); join on task_suite level\nsuite_full = suite_df.join(size_series, on=\"task_suite\")\nsuite_full[\"tasks_per_episode\"] = suite_full[\"total_episodes\"] / suite_full[\"total_tasks\"]  # ≈ num_trials_per_task\nsuite_full = suite_full[[\"total_tasks\", \"total_episodes\", \"total_successes\", \"success_rate\", \"n_slices\", \"tasks_per_episode\"]]\nsuite_full",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:20.213721Z",
+     "start_time": "2026-05-02T12:18:20.106738Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                          total_tasks  total_episodes  \\\n",
+       "ckpt_stem                 task_suite                                    \n",
+       "steps_30000_pytorch_model libero_object          2518           73450   \n",
+       "                          libero_spatial         2402           60100   \n",
+       "\n",
+       "                                          total_successes  success_rate  \\\n",
+       "ckpt_stem                 task_suite                                      \n",
+       "steps_30000_pytorch_model libero_object             48456      0.659714   \n",
+       "                          libero_spatial            40580      0.675208   \n",
+       "\n",
+       "                                          n_slices  tasks_per_episode  \n",
+       "ckpt_stem                 task_suite                                   \n",
+       "steps_30000_pytorch_model libero_object          7          29.169976  \n",
+       "                          libero_spatial         6          25.020816  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>total_tasks</th>\n",
+       "      <th>total_episodes</th>\n",
+       "      <th>total_successes</th>\n",
+       "      <th>success_rate</th>\n",
+       "      <th>n_slices</th>\n",
+       "      <th>tasks_per_episode</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ckpt_stem</th>\n",
+       "      <th>task_suite</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">steps_30000_pytorch_model</th>\n",
+       "      <th>libero_object</th>\n",
+       "      <td>2518</td>\n",
+       "      <td>73450</td>\n",
+       "      <td>48456</td>\n",
+       "      <td>0.659714</td>\n",
+       "      <td>7</td>\n",
+       "      <td>29.169976</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>libero_spatial</th>\n",
+       "      <td>2402</td>\n",
+       "      <td>60100</td>\n",
+       "      <td>40580</td>\n",
+       "      <td>0.675208</td>\n",
+       "      <td>6</td>\n",
+       "      <td>25.020816</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:22.037779Z",
+     "start_time": "2026-05-02T12:18:21.954415Z"
+    }
+   },
+   "source": "# Per-checkpoint aggregate across all suites (slices already merged in suite_df)\nsummary_rows = []\nfor ckpt_stem, grp in suite_df.groupby(\"ckpt_stem\"):\n    total_ep   = grp[\"total_episodes\"].sum()\n    total_succ = grp[\"total_successes\"].sum()\n    summary_rows.append({\n        \"ckpt_stem\":       ckpt_stem,\n        \"n_suites\":        len(grp),\n        \"total_episodes\":  int(total_ep),\n        \"total_successes\": int(total_succ),\n        \"success_rate\":    total_succ / total_ep if total_ep > 0 else 0.0,\n    })\n\nsummary_df = pd.DataFrame(summary_rows).set_index(\"ckpt_stem\")\nsummary_df.sort_values(\"success_rate\", ascending=False)",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                           n_suites  total_episodes  total_successes  \\\n",
+       "ckpt_stem                                                              \n",
+       "steps_30000_pytorch_model         2          133550            89036   \n",
+       "\n",
+       "                           success_rate  \n",
+       "ckpt_stem                                \n",
+       "steps_30000_pytorch_model      0.666687  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>n_suites</th>\n",
+       "      <th>total_episodes</th>\n",
+       "      <th>total_successes</th>\n",
+       "      <th>success_rate</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ckpt_stem</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>steps_30000_pytorch_model</th>\n",
+       "      <td>2</td>\n",
+       "      <td>133550</td>\n",
+       "      <td>89036</td>\n",
+       "      <td>0.666687</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:22.257949Z",
+     "start_time": "2026-05-02T12:18:22.185135Z"
+    }
+   },
+   "source": [
+    "# Per-category breakdown (LIBERO-plus disturbance categories)\n",
+    "# category_results: {category: {total_count, success_count}}\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "cat_agg: dict[str, dict] = defaultdict(lambda: {\"total_count\": 0, \"success_count\": 0})\n",
+    "for t in tasks:\n",
+    "    for cat, counts in t.summary.get(\"category_results\", {}).items():\n",
+    "        cat_agg[cat][\"total_count\"]   += counts[\"total_count\"]\n",
+    "        cat_agg[cat][\"success_count\"] += counts[\"success_count\"]\n",
+    "\n",
+    "cat_rows = [\n",
+    "    {\n",
+    "        \"category\":     cat,\n",
+    "        \"total\":        v[\"total_count\"],\n",
+    "        \"successes\":    v[\"success_count\"],\n",
+    "        \"success_rate\": v[\"success_count\"] / v[\"total_count\"] if v[\"total_count\"] > 0 else 0.0,\n",
+    "    }\n",
+    "    for cat, v in cat_agg.items()\n",
+    "]\n",
+    "cat_df = pd.DataFrame(cat_rows).set_index(\"category\").sort_values(\"success_rate\", ascending=True)\n",
+    "cat_df"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                       total  successes  success_rate\n",
+       "category                                             \n",
+       "Objects Layout             0          0      0.000000\n",
+       "Sensor Noise               0          0      0.000000\n",
+       "Camera Viewpoints      38600      14019      0.363187\n",
+       "Robot Initial States   37400      22149      0.592219\n",
+       "Language Instructions  21800      18926      0.868165\n",
+       "Light Conditions       10450       9877      0.945167\n",
+       "Background Textures    25300      24065      0.951186"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>total</th>\n",
+       "      <th>successes</th>\n",
+       "      <th>success_rate</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>category</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Objects Layout</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Sensor Noise</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Camera Viewpoints</th>\n",
+       "      <td>38600</td>\n",
+       "      <td>14019</td>\n",
+       "      <td>0.363187</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Robot Initial States</th>\n",
+       "      <td>37400</td>\n",
+       "      <td>22149</td>\n",
+       "      <td>0.592219</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Language Instructions</th>\n",
+       "      <td>21800</td>\n",
+       "      <td>18926</td>\n",
+       "      <td>0.868165</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Light Conditions</th>\n",
+       "      <td>10450</td>\n",
+       "      <td>9877</td>\n",
+       "      <td>0.945167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Background Textures</th>\n",
+       "      <td>25300</td>\n",
+       "      <td>24065</td>\n",
+       "      <td>0.951186</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 8
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/eval_libero.py
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/eval_libero.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 import pathlib
+import sys
 import time
 
 import imageio
@@ -13,14 +14,14 @@ import tyro
 from libero.libero import benchmark, get_libero_path
 from libero.libero.envs import OffScreenRenderEnv
 
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+from examples.LIBERO.eval_files.model2libero_interface import ModelClient
+
 try:
     import labtasker
     _has_labtasker = True
 except ImportError:
     _has_labtasker = False
-
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
-from examples.LIBERO.eval_files.model2libero_interface import ModelClient
 
 LIBERO_DUMMY_ACTION = [0.0] * 6 + [-1.0]
 LIBERO_ENV_RESOLUTION = 256  # resolution used to render training data
@@ -51,8 +52,6 @@ class Args:
     #################################################################################################################
     # Utils
     #################################################################################################################
-    video_out_path: str = "experiments/libero/logs"  # Path to save videos
-
     seed: int = 7  # Random Seed (for reproducibility)
 
     pretrained_path: str = ""
@@ -60,6 +59,10 @@ class Args:
     post_process_action: bool = True
 
     job_name: str = "test"
+
+    start_idx: int = -1
+    end_idx: int = -1
+    output_dir: str = "./output"
 
 
 def eval_libero(args: Args) -> None:
@@ -74,9 +77,14 @@ def eval_libero(args: Args) -> None:
     num_tasks_in_suite = task_suite.n_tasks
     logging.info(f"Task suite: {args.task_suite_name}")
 
-    # args.video_out_path = f"{date_base}+{args.job_name}"
+    if args.start_idx == -1:
+        args.start_idx = 0
+        args.end_idx = num_tasks_in_suite
 
-    pathlib.Path(args.video_out_path).mkdir(parents=True, exist_ok=True)
+    video_out_path = os.path.join(args.output_dir, args.task_suite_name)
+    log_path = args.output_dir
+
+    pathlib.Path(video_out_path).mkdir(parents=True, exist_ok=True)
 
     if args.task_suite_name == "libero_spatial":
         max_steps = 220  # longest training demo has 193 steps
@@ -98,9 +106,23 @@ def eval_libero(args: Args) -> None:
         image_size=args.resize_size,
     )
 
+    disturb_res = {}
+    LIBERO_HOME = os.environ.get("LIBERO_HOME", "path_to_LIBERO-plus_home")
+    with open(os.path.join(LIBERO_HOME, "libero/libero/benchmark/task_classification.json")) as f:
+        TASK_MAPPING = json.load(f)[args.task_suite_name]
+    ID2CATEGORY = {}
+    for item in TASK_MAPPING:
+        category = item["category"]
+        item_name = item["name"]
+        ID2CATEGORY[item["id"]] = (category, item_name)
+        if category not in disturb_res:
+            disturb_res[category] = {"total_count": 0, "success_count": 0}
+
     # Start evaluation
+
     total_episodes, total_successes = 0, 0
-    for task_id in tqdm.tqdm(range(num_tasks_in_suite)):
+    for task_id in tqdm.tqdm(range(args.start_idx, args.end_idx)):
+
         # Get task
         task = task_suite.get_task(task_id)
 
@@ -113,6 +135,7 @@ def eval_libero(args: Args) -> None:
         # Start episodes
         task_episodes, task_successes = 0, 0
         for episode_idx in tqdm.tqdm(range(args.num_trials_per_task)):
+
             logging.info(f"\nTask: {task_description}")
 
             # Reset environment
@@ -133,6 +156,7 @@ def eval_libero(args: Args) -> None:
             # full_actions = np.load("./debug/action.npy")
 
             while t < max_steps + args.num_steps_wait:
+
                 # try:
                 # IMPORTANT: Do nothing for the first few timesteps because the simulator drops objects
                 # and we need to wait for them to fall
@@ -171,6 +195,7 @@ def eval_libero(args: Args) -> None:
 
                 start_time = time.time()
 
+                # response = client_model.step(example=example_dict)
                 response = client_model.step(example=example_dict, step=step)
 
                 end_time = time.time()
@@ -205,20 +230,25 @@ def eval_libero(args: Args) -> None:
                 if done:
                     task_successes += 1
                     total_successes += 1
+                    disturb_res[ID2CATEGORY[task_id + 1][0]]["success_count"] += 1
                     break
                 t += 1
                 step += 1
 
             task_episodes += 1
             total_episodes += 1
+            disturb_res[ID2CATEGORY[task_id + 1][0]]["total_count"] += 1
 
             # Save a replay video of the episode
             suffix = "success" if done else "failure"
             task_segment = task_description.replace(" ", "_")
+
             imageio.mimwrite(
-                pathlib.Path(args.video_out_path) / f"rollout_{task_segment}_episode{episode_idx}_{suffix}.mp4",
+                pathlib.Path(video_out_path)
+                / f"rollout_{ID2CATEGORY[task_id+1][1]}_episode{episode_idx}_{suffix}.mp4",
                 [np.asarray(x) for x in replay_images],
-                fps=10,
+                fps=25,
+                format="FFMPEG",
             )
 
             full_actions = np.stack(full_actions)
@@ -233,12 +263,11 @@ def eval_libero(args: Args) -> None:
         # Log final results
         logging.info(f"Current task success rate: {float(task_successes) / float(task_episodes)}")
         logging.info(f"Current total success rate: {float(total_successes) / float(total_episodes)}")
-
+    with open(os.path.join(log_path, f"{args.start_idx}_to_{args.end_idx}.json"), "w", encoding="utf-8") as f:
+        json.dump(disturb_res, f)
     logging.info(f"Total success rate: {float(total_successes) / float(total_episodes)}")
     logging.info(f"Total episodes: {total_episodes}")
 
-    # If Labtasker is installed and used, report results to Labtasker upon completion
-    # If Labtasker is not being used, labtasker.finish will automatically be a no-op
     if _has_labtasker:
         labtasker.finish(
             status="success",
@@ -247,7 +276,9 @@ def eval_libero(args: Args) -> None:
                 "total_successes": total_successes,
                 "total_episodes": total_episodes,
                 "task_suite": args.task_suite_name,
-                "pretrained_path": args.pretrained_path,
+                "start_idx": args.start_idx,
+                "end_idx": args.end_idx,
+                "category_results": disturb_res,
             },
         )
 
@@ -257,7 +288,7 @@ def _get_libero_env(task, resolution, seed):
     task_description = task.language
     task_bddl_file = pathlib.Path(get_libero_path("bddl_files")) / task.problem_folder / task.bddl_file
     env_args = {
-        "bddl_file_name": task_bddl_file,
+        "bddl_file_name": str(task_bddl_file),
         "camera_heights": resolution,
         "camera_widths": resolution,
     }

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/requirements.extra.txt
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/requirements.extra.txt
@@ -1,0 +1,3 @@
+labtasker[plugins]
+pandas
+python-dotenv

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Worker script for LIBERO-plus parallel evaluation.
+
+Launch one worker per GPU:
+
+    CUDA_VISIBLE_DEVICES=0 ${STARVLA_PYTHON} \\
+        examples/LIBERO-plus/eval_files/parallel_eval_labtasker/run.py --env .env
+
+Each task = one (ckpt × task_suite × [start_idx, end_idx)) slice.
+Multiple workers process different slices of the same suite in parallel.
+
+Required env vars:
+    STARVLA_PYTHON       Python interpreter with starVLA installed (runs the policy server)
+    LIBERO_PLUS_PYTHON   Python interpreter with LIBERO-plus installed
+    LIBERO_PLUS_HOME     Root directory of the LIBERO-plus repo
+
+Optional env vars:
+    LIBERO_NUM_TRIALS    Episodes per task (default: 50)
+    SERVER_TIMEOUT       Seconds to wait for the policy server (default: 300)
+    CUDA_VISIBLE_DEVICES GPU(s) to use; worker uses the first device listed (default: 0)
+
+Optional flags:
+    --env <path>     Load a .env file before reading env vars
+                     Copy .env.example to .env, fill in your paths, then pass --env .env
+"""
+
+import argparse
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+
+try:
+    import labtasker
+    from labtasker import Required
+except ImportError:
+    print("[ERROR] Labtasker not installed. Install it with `pip install 'labtasker[plugins]'`")
+    exit(1)
+
+HERE = pathlib.Path(__file__).resolve().parent
+PROJECT_ROOT = HERE.parents[3]  # starVLA/
+EVAL_SCRIPT = HERE / "eval_libero.py"
+
+
+def _load_env_file(path: str) -> None:
+    for line in pathlib.Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip())
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        sys.exit(f"[ERROR] {name} is not set. Export it before launching this worker.")
+    return val
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(port: int, timeout: int) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(1.0)
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(2)
+    return False
+
+
+def _run(proc: subprocess.Popen, log_path: pathlib.Path) -> int:
+    with open(log_path, "w") as lf:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            lf.write(line)
+    proc.wait()
+    return proc.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--env", default=None)
+    args, _ = parser.parse_known_args()
+    if args.env:
+        _load_env_file(args.env)
+
+    starvla_py = _require_env("STARVLA_PYTHON")
+    libero_plus_py = _require_env("LIBERO_PLUS_PYTHON")
+    libero_plus_home = _require_env("LIBERO_PLUS_HOME")
+
+    gpu = os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
+    num_trials = os.environ.get("LIBERO_NUM_TRIALS", "50")
+    server_timeout = int(os.environ.get("SERVER_TIMEOUT", "300"))
+
+    @labtasker.loop(extra_filter='metadata.benchmark == "LIBERO-plus"')
+    def run_task(
+            ckpt: str = Required(),
+            task_suite: str = Required(),
+            start_idx: int = Required(),
+            end_idx: int = Required(),
+    ) -> None:
+        base_env = {
+            **os.environ,
+            "CUDA_VISIBLE_DEVICES": gpu,
+            "LIBERO_HOME": libero_plus_home,
+            "LIBERO_CONFIG_PATH": str(pathlib.Path(libero_plus_home) / "libero"),
+            "PYTHONPATH": os.pathsep.join(filter(None, [
+                str(PROJECT_ROOT),
+                libero_plus_home,
+                os.environ.get("PYTHONPATH", ""),
+            ])),
+        }
+
+        ckpt_path = pathlib.Path(ckpt)
+        ckpt_stem = ckpt_path.stem
+        ckpt_dir = ckpt_path.parent
+        port = _find_free_port()
+        slice_tag = f"{start_idx}_{end_idx}"
+
+        output_dir = ckpt_dir / "videos" / task_suite / ckpt_stem / slice_tag
+        log_dir = ckpt_dir / "logs" / task_suite
+        output_dir.mkdir(parents=True, exist_ok=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        server_log = log_dir / f"{ckpt_stem}_server_{slice_tag}.log"
+        server_proc = subprocess.Popen(
+            [
+                starvla_py,
+                str(PROJECT_ROOT / "deployment" / "model_server" / "server_policy.py"),
+                "--ckpt_path", ckpt,
+                "--port", str(port),
+                "--use_bf16",
+            ],
+            env=base_env,
+            stdout=open(server_log, "w"),
+            stderr=subprocess.STDOUT,
+        )
+        print(f"[INFO] Policy server pid={server_proc.pid}  port={port}  ckpt={ckpt_stem}")
+        print(f"[INFO] Waiting for policy server (timeout={server_timeout}s)...")
+
+        if not _wait_for_port(port, server_timeout):
+            server_proc.terminate()
+            server_proc.wait()
+            sys.exit(f"[ERROR] Policy server not ready in {server_timeout}s. See {server_log}")
+        print("[INFO] Policy server ready")
+
+        rc = -1
+        try:
+            eval_log = log_dir / f"{ckpt_stem}_{slice_tag}.log"
+            print(f"[INFO] suite={task_suite}  [{start_idx}, {end_idx})  gpu={gpu}  port={port}")
+            eval_proc = subprocess.Popen(
+                [
+                    libero_plus_py,
+                    str(EVAL_SCRIPT),
+                    "--args.pretrained-path", ckpt,
+                    "--args.host", "127.0.0.1",
+                    "--args.port", str(port),
+                    "--args.task-suite-name", task_suite,
+                    "--args.num-trials-per-task", num_trials,
+                    "--args.output-dir", str(output_dir),
+                    "--args.start-idx", str(start_idx),
+                    "--args.end-idx", str(end_idx),
+                ],
+                env=base_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            rc = _run(eval_proc, eval_log)
+            print(f"[INFO] eval exited with code {rc}")
+        finally:
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                server_proc.wait()
+            print("[INFO] Policy server stopped")
+
+        if rc != 0:
+            sys.exit(rc)
+        # labtasker.finish() is called inside eval_libero.py
+
+    run_task()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/submit.py
+++ b/examples/LIBERO-plus/eval_files/parallel_eval_labtasker/submit.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Submit LIBERO-plus evaluation tasks to Labtasker.
+
+Each task = one (ckpt × task_suite × [start_idx, end_idx)) slice.
+Multiple workers can process different slices of the same suite in parallel.
+"""
+
+import itertools
+import pathlib
+
+try:
+    import labtasker
+except ImportError:
+    print("[ERROR] Labtasker not installed. Install it with `pip install 'labtasker[plugins]'`")
+    exit(1)
+
+###############################################################################
+# ============ USER CONFIG ============
+###############################################################################
+
+CKPT_DIR  = ""
+CKPT_LIST = [
+    "/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt",
+]
+
+# Total number of tasks in each suite (determines the index range [0, size))
+SUITE_SIZES = {
+    "libero_goal":    2591,
+    "libero_object":  2518,
+    "libero_spatial": 2402,
+    "libero_10": 2519,
+}
+
+# How many labtasker tasks to split each suite into.
+# More slices = finer load balancing; workers consume from the queue regardless of count.
+NUM_SLICES = {
+    "libero_goal":    12,
+    "libero_object":  12,
+    "libero_spatial": 12,
+    "libero_10": 24,
+}
+
+MAX_RETRIES = 3
+PRIORITY    = 10
+
+###############################################################################
+# ============ END USER CONFIG ============
+###############################################################################
+
+
+def _slices(size: int, n: int):
+    """Yield (start, end) pairs that evenly partition [0, size) into n chunks."""
+    base, remainder = divmod(size, n)
+    start = 0
+    for i in range(n):
+        end = start + base + (1 if i < remainder else 0)
+        yield start, end
+        start = end
+
+
+def main() -> None:
+    ckpts = CKPT_LIST if CKPT_LIST else sorted(
+        str(p) for p in pathlib.Path(CKPT_DIR).glob("*.pt")
+    )
+    if not ckpts:
+        raise ValueError("No checkpoints found. Set CKPT_LIST or CKPT_DIR.")
+
+    submitted = 0
+    for ckpt, suite in itertools.product(ckpts, SUITE_SIZES):
+        stem = pathlib.Path(ckpt).stem
+        size = SUITE_SIZES[suite]
+        n = NUM_SLICES[suite]
+        for start, end in _slices(size, n):
+            result = labtasker.submit_task(
+                task_name=f"{stem}_{suite}_{start}_{end}",
+                args={"ckpt": ckpt, "task_suite": suite, "start_idx": start, "end_idx": end},
+                metadata={"benchmark": "LIBERO-plus", "ckpt_stem": stem, "task_suite": suite},
+                max_retries=MAX_RETRIES,
+                priority=PRIORITY,
+            )
+            print(f"  submitted  {stem} x {suite} [{start}, {end})  =>  {result.task_id}")
+            submitted += 1
+    print(f"\nDone. {submitted} tasks submitted.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/.env.example
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/.env.example
@@ -1,0 +1,23 @@
+# ============================================================
+# Environment config for LIBERO parallel eval worker (run.py)
+# Usage: python run.py --env /path/to/this/.env
+# ============================================================
+
+# Python interpreter with starVLA + labtasker installed
+STARVLA_PYTHON=/path/to/starvla/env/bin/python
+
+# Python interpreter with LIBERO sim installed
+LIBERO_PYTHON=/path/to/libero/env/bin/python
+
+# Root directory of the LIBERO repo
+LIBERO_HOME=/path/to/LIBERO
+
+# ------------------------------------------------------------
+# Optional (defaults shown)
+# ------------------------------------------------------------
+
+# Episodes per task
+LIBERO_NUM_TRIALS=50
+
+# Seconds to wait for the policy server to become ready
+SERVER_TIMEOUT=300

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/README.md
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/README.md
@@ -1,0 +1,180 @@
+# LIBERO 并行评测：Labtasker 使用说明
+
+本目录提供基于 [Labtasker](https://github.com/luocfprime/labtasker) 的 LIBERO 并行评测脚本，支持多 GPU 弹性并行、失败自动重试、结果汇总。
+
+---
+
+## Labtasker 简介
+
+[Labtasker](https://github.com/luocfprime/labtasker) 是一个轻量级任务队列系统，专为 ML 实验设计。核心思路是把 `for` 循环替换为任务队列：
+
+- **submit**：把实验参数组合批量推入队列
+- **worker**：从队列拉取任务并执行，多个 worker 并行互不干扰
+- **retry**：任务失败自动重试，成功后将结果写入 summary
+
+### 安装
+
+```bash
+pip install 'labtasker[plugins]'
+```
+
+### 启动 Labtasker Server
+
+Labtasker 需要一个后端服务来管理任务队列。在远端机器上启动（建议放入 tmux）：
+
+```bash
+# 指定数据目录（队列数据持久化在此）
+labtasker-server serve &
+```
+
+### 初始化队列
+
+首次使用时，在项目根目录初始化配置并创建队列：
+
+```bash
+labtasker init          # 交互式填写 server 地址、队列名等，生成 .labtasker/config.toml
+labtasker queue create-from-config
+```
+
+此后同一机器上的所有 submit / worker 命令自动读取 `.labtasker/config.toml`，无需重复配置。
+
+---
+
+## 架构说明
+
+每个任务（checkpoint × task suite）完全自洽：worker 为该任务启动 policy server，eval 结束后关闭，再处理下一个任务。
+
+```
+Queue                                  Worker (GPU 0)
+┌──────────────────────────────┐       ┌─────────────────────────────────────┐
+│  ckpt=A × libero_spatial     │──────►│  start server(ckpt=A)               │
+│  ckpt=A × libero_goal        │       │  run eval_libero.py(libero_spatial)  │
+│  ckpt=B × libero_spatial     │       │  stop server                        │
+│  ckpt=B × libero_goal        │       │  start server(ckpt=A)               │
+│  ...                         │       │  run eval_libero.py(libero_goal)     │
+└──────────────────────────────┘       │  stop server                        │
+                                       │  ...                                │
+                                       └─────────────────────────────────────┘
+```
+
+## 文件说明
+
+| 文件 | 作用 |
+|---|---|
+| `submit.py` | 向任务队列提交 (checkpoint × task_suite) 评测任务 |
+| `run.py` | Worker 脚本：循环拉取任务 → 启动 server → 运行评测 → 关闭 server → 上报结果 |
+| `.env.example` | 环境变量模板，复制为 `.env` 后填入实际路径 |
+
+任务粒度：**每个任务 = 一个 checkpoint × 一个 task suite**。
+
+---
+
+## 前提条件
+
+请先按照 `examples/LIBERO/README.md` 完成依赖安装，并确保 labtasker 在两个环境中都已安装：
+
+```bash
+# starVLA 环境（运行 run.py / policy server）
+${STARVLA_PYTHON} -m pip install 'labtasker[plugins]'
+
+# LIBERO 环境（运行 eval_libero.py）
+${LIBERO_PYTHON} -m pip install labtasker
+```
+
+---
+
+## 快速开始
+
+### 第一步：配置环境变量
+
+复制模板并填入实际路径：
+
+```bash
+cp .env.example .env
+# 编辑 .env，填入 STARVLA_PYTHON、LIBERO_PYTHON、LIBERO_HOME
+```
+
+`.env` 内容说明：
+
+```bash
+# 必填
+STARVLA_PYTHON=  # 运行 policy server 的 Python（starVLA conda env）
+LIBERO_PYTHON=   # 运行 eval_libero.py 的 Python（libero conda env）
+LIBERO_HOME=     # LIBERO repo 根目录
+
+# 可选（括号内为默认值）
+LIBERO_NUM_TRIALS=50   # 每个任务的 episode 数（50）
+SERVER_TIMEOUT=300     # 等待 policy server 就绪的超时秒数（300）
+```
+
+### 第二步：提交任务
+
+编辑 `submit.py` 顶部的 USER CONFIG，填写 `CKPT_LIST`（或 `CKPT_DIR`）和要评测的 `TASK_SUITES`：
+
+```python
+CKPT_LIST = [
+    "/path/to/steps_30000_pytorch_model.pt",
+    "/path/to/steps_50000_pytorch_model.pt",
+]
+TASK_SUITES = ["libero_spatial", "libero_object", "libero_goal", "libero_10"]
+```
+
+提交：
+
+```bash
+${STARVLA_PYTHON} examples/LIBERO/eval_files/parallel_eval_labtasker/submit.py
+```
+
+### 第三步：启动 Worker
+
+每个 GPU 启动一个 worker，worker 自动从队列中拉取任务：
+
+```bash
+# GPU 0
+CUDA_VISIBLE_DEVICES=0 \
+    ${STARVLA_PYTHON} examples/LIBERO/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/LIBERO/eval_files/parallel_eval_labtasker/.env &
+
+# GPU 1
+CUDA_VISIBLE_DEVICES=1 \
+    ${STARVLA_PYTHON} examples/LIBERO/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/LIBERO/eval_files/parallel_eval_labtasker/.env &
+
+wait
+```
+
+多个 worker 可以处理不同 checkpoint 的任务，也可以并行处理同一 checkpoint 的不同 suite，labtasker 自动分配，不会重复。Worker 队列为空时自动退出。
+
+---
+
+## 查看进度
+
+```bash
+labtasker task count
+labtasker task ls
+labtasker task ls -s running
+labtasker task ls -s failed  --no-pager
+labtasker task ls -s success
+```
+
+## 失败重试
+
+```bash
+# 查看失败任务
+labtasker task ls -s failed --no-pager
+
+# 批量重置为 pending（重新排队）
+labtasker task update -s failed -u "retries=0" --reset-pending --quiet
+```
+
+## 日志位置
+
+```
+<ckpt_dir>/
+  logs/
+    <task_suite>/
+      <ckpt_stem>_server.log   # policy server 日志
+      <ckpt_stem>.log          # eval_libero.py 完整输出
+  videos/<task_suite>/<ckpt_stem>/
+    rollout_*.mp4
+```

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/collect_results.ipynb
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/collect_results.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-28T10:18:14.300564Z",
+     "start_time": "2026-04-28T10:18:13.377179Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "!pip install labtasker[plugins] pandas",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://artifactory-cloud.chehejia.com/artifactory/api/pypi/liauto-pypi-l5/simple\r\n",
+      "Requirement already satisfied: pandas in /opt/miniconda3/lib/python3.13/site-packages (3.0.2)\r\n",
+      "Requirement already satisfied: labtasker[plugins] in /opt/miniconda3/lib/python3.13/site-packages (1.0.0)\r\n",
+      "Requirement already satisfied: pymongo<5.0.0,>=4.0.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.17.0)\r\n",
+      "Requirement already satisfied: fastapi<0.137.0,>=0.115.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.136.1)\r\n",
+      "Requirement already satisfied: uvicorn<0.45.0,>=0.15.0 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.44.0)\r\n",
+      "Requirement already satisfied: click<9.0.0,>=8.2.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (8.3.1)\r\n",
+      "Requirement already satisfied: passlib<2.0.0,>=1.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.7.4)\r\n",
+      "Requirement already satisfied: pydantic-settings<3.0.0,>=2.8.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (2.14.0)\r\n",
+      "Requirement already satisfied: httpx<0.29.0,>=0.28.0 in /opt/miniconda3/lib/python3.13/site-packages (from httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (0.28.1)\r\n",
+      "Requirement already satisfied: typer<0.25.0,>=0.16.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.24.2)\r\n",
+      "Requirement already satisfied: loguru<0.8.0,>=0.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.7.3)\r\n",
+      "Requirement already satisfied: ruamel-yaml<0.20.0,>=0.18.10 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.18.10)\r\n",
+      "Requirement already satisfied: pyyaml<7.0.0,>=6.0.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (6.0.3)\r\n",
+      "Requirement already satisfied: tomlkit<0.15.0,>=0.13.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.14.0)\r\n",
+      "Requirement already satisfied: importlib-metadata<10.0.0,>=8.5.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (9.0.0)\r\n",
+      "Requirement already satisfied: packaging<27.0,>=24.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (24.2)\r\n",
+      "Requirement already satisfied: sse-starlette<4.0.0,>=2.1.3 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (3.4.1)\r\n",
+      "Requirement already satisfied: httpx-sse<0.5.0,>=0.4.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.4.3)\r\n",
+      "Requirement already satisfied: stamina<27.0.0,>=25.1.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (26.1.0)\r\n",
+      "Requirement already satisfied: noneprompt<0.2.0,>=0.1.9 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.11)\r\n",
+      "Requirement already satisfied: mongomock<4.4.0,>=4.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.3.0)\r\n",
+      "Requirement already satisfied: jsonpickle<5.0.0,>=4.0.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.1.1)\r\n",
+      "Requirement already satisfied: mslex<2.0.0,>=1.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.3.0)\r\n",
+      "Requirement already satisfied: pexpect<5.0.0,>=4.9.0 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (4.9.0)\r\n",
+      "Requirement already satisfied: pip>=25 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (25.1)\r\n",
+      "Requirement already satisfied: dateparser<2.0.0,>=1.2.2 in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (1.4.0)\r\n",
+      "Requirement already satisfied: labtasker-plugin-task-count in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.1)\r\n",
+      "Requirement already satisfied: labtasker-plugin-task-recency in /opt/miniconda3/lib/python3.13/site-packages (from labtasker[plugins]) (0.1.1)\r\n",
+      "Requirement already satisfied: python-dateutil>=2.7.0 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2.9.0.post0)\r\n",
+      "Requirement already satisfied: pytz>=2024.2 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2026.1.post1)\r\n",
+      "Requirement already satisfied: regex>=2024.9.11 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (2026.4.4)\r\n",
+      "Requirement already satisfied: tzlocal>=0.2 in /opt/miniconda3/lib/python3.13/site-packages (from dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (5.3.1)\r\n",
+      "Requirement already satisfied: starlette>=0.46.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (1.0.0)\r\n",
+      "Requirement already satisfied: pydantic>=2.9.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (2.11.7)\r\n",
+      "Requirement already satisfied: typing-extensions>=4.8.0 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (4.12.2)\r\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.4.2)\r\n",
+      "Requirement already satisfied: annotated-doc>=0.0.2 in /opt/miniconda3/lib/python3.13/site-packages (from fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.0.4)\r\n",
+      "Requirement already satisfied: anyio in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (4.13.0)\r\n",
+      "Requirement already satisfied: certifi in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (2025.10.5)\r\n",
+      "Requirement already satisfied: httpcore==1.* in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (1.0.9)\r\n",
+      "Requirement already satisfied: idna in /opt/miniconda3/lib/python3.13/site-packages (from httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (3.7)\r\n",
+      "Requirement already satisfied: h11>=0.16 in /opt/miniconda3/lib/python3.13/site-packages (from httpcore==1.*->httpx<0.29.0,>=0.28.0->httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (0.16.0)\r\n",
+      "Requirement already satisfied: socksio==1.* in /opt/miniconda3/lib/python3.13/site-packages (from httpx[socks]<0.29.0,>=0.28.0->labtasker[plugins]) (1.0.0)\r\n",
+      "Requirement already satisfied: zipp>=3.20 in /opt/miniconda3/lib/python3.13/site-packages (from importlib-metadata<10.0.0,>=8.5.0->labtasker[plugins]) (3.23.1)\r\n",
+      "Requirement already satisfied: sentinels in /opt/miniconda3/lib/python3.13/site-packages (from mongomock<4.4.0,>=4.3.0->labtasker[plugins]) (1.1.1)\r\n",
+      "Requirement already satisfied: prompt-toolkit<4.0.0,>=3.0.19 in /opt/miniconda3/lib/python3.13/site-packages (from noneprompt<0.2.0,>=0.1.9->labtasker[plugins]) (3.0.52)\r\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /opt/miniconda3/lib/python3.13/site-packages (from pexpect<5.0.0,>=4.9.0->labtasker[plugins]) (0.7.0)\r\n",
+      "Requirement already satisfied: wcwidth in /opt/miniconda3/lib/python3.13/site-packages (from prompt-toolkit<4.0.0,>=3.0.19->noneprompt<0.2.0,>=0.1.9->labtasker[plugins]) (0.6.0)\r\n",
+      "Requirement already satisfied: python-dotenv>=0.21.0 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic-settings<3.0.0,>=2.8.0->labtasker[plugins]) (1.2.2)\r\n",
+      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in /opt/miniconda3/lib/python3.13/site-packages (from pymongo<5.0.0,>=4.0.0->labtasker[plugins]) (2.8.0)\r\n",
+      "Requirement already satisfied: tenacity in /opt/miniconda3/lib/python3.13/site-packages (from stamina<27.0.0,>=25.1.0->labtasker[plugins]) (9.1.4)\r\n",
+      "Requirement already satisfied: shellingham>=1.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from typer<0.25.0,>=0.16.0->labtasker[plugins]) (1.5.4)\r\n",
+      "Requirement already satisfied: rich>=12.3.0 in /opt/miniconda3/lib/python3.13/site-packages (from typer<0.25.0,>=0.16.0->labtasker[plugins]) (13.9.4)\r\n",
+      "Requirement already satisfied: httptools>=0.6.3 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.7.1)\r\n",
+      "Requirement already satisfied: uvloop>=0.15.1 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (0.22.1)\r\n",
+      "Requirement already satisfied: watchfiles>=0.20 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (1.1.1)\r\n",
+      "Requirement already satisfied: websockets>=10.4 in /opt/miniconda3/lib/python3.13/site-packages (from uvicorn[standard]<0.45.0,>=0.15.0->labtasker[plugins]) (16.0)\r\n",
+      "Requirement already satisfied: numpy>=1.26.0 in /opt/miniconda3/lib/python3.13/site-packages (from pandas) (2.4.4)\r\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic>=2.9.0->fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (0.6.0)\r\n",
+      "Requirement already satisfied: pydantic-core==2.33.2 in /opt/miniconda3/lib/python3.13/site-packages (from pydantic>=2.9.0->fastapi<0.137.0,>=0.115.0->labtasker[plugins]) (2.33.2)\r\n",
+      "Requirement already satisfied: six>=1.5 in /opt/miniconda3/lib/python3.13/site-packages (from python-dateutil>=2.7.0->dateparser<2.0.0,>=1.2.2->labtasker[plugins]) (1.17.0)\r\n",
+      "Requirement already satisfied: markdown-it-py>=2.2.0 in /opt/miniconda3/lib/python3.13/site-packages (from rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (2.2.0)\r\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /opt/miniconda3/lib/python3.13/site-packages (from rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (2.19.1)\r\n",
+      "Requirement already satisfied: mdurl~=0.1 in /opt/miniconda3/lib/python3.13/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer<0.25.0,>=0.16.0->labtasker[plugins]) (0.1.0)\r\n",
+      "\u001B[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001B[0m\u001B[33m\r\n",
+      "\u001B[0m"
+     ]
+    }
+   ],
+   "execution_count": 12
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:11.202882Z",
+     "start_time": "2026-04-29T02:06:04.731288Z"
+    }
+   },
+   "source": [
+    "import os\n",
+    "os.chdir(\"/path/to/starVLA\")\n",
+    "print(os.getcwd())\n",
+    "from labtasker import ls_tasks"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/path/to/starVLA\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:12.695753Z",
+     "start_time": "2026-04-29T02:06:11.211429Z"
+    }
+   },
+   "source": "!labtasker task count -f \"metadata.benchmark == 'LIBERO'\"",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🟡 Pending: \u001B[1;36m0\u001B[0m\r\n",
+      "🔵 Running: \u001B[1;36m0\u001B[0m\r\n",
+      "🟢 Success: \u001B[1;36m4\u001B[0m\r\n",
+      "🔴 Failed: \u001B[1;36m0\u001B[0m\r\n",
+      "⚪ Cancelled: \u001B[1;36m0\u001B[0m\r\n"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:13.561523Z",
+     "start_time": "2026-04-29T02:06:12.697203Z"
+    }
+   },
+   "source": "# Filter by benchmark to avoid mixing with RoboTwin tasks\n# Add more conditions as needed:\n# e.g. extra_filter = 'metadata.benchmark == \"LIBERO\" and metadata.ckpt_stem == \"steps_30000_pytorch_model\"'\n# e.g. extra_filter = 'metadata.benchmark == \"LIBERO\" and args.task_suite == \"libero_spatial\"'\nextra_filter = 'metadata.benchmark == \"LIBERO\"'\n\ntasks = ls_tasks(\n    status=\"success\",\n    extra_filter=extra_filter if extra_filter else None,\n    limit=1000,\n).content\nprint(f\"{len(tasks)} successful tasks\")",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 successful tasks\n"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:13.643452Z",
+     "start_time": "2026-04-29T02:06:13.564494Z"
+    }
+   },
+   "source": [
+    "tasks[0]"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Task(unknown_fields={}, task_id='c771ee81-e0fd-4e76-9109-a9f692eb3a34', queue_id='b5b7ed91-b5ef-46bc-a244-33216576b5d9', status='success', task_name='steps_30000_pytorch_model_libero_spatial', created_at=datetime.datetime(2026, 4, 28, 16, 59, 53, 315000), start_time=datetime.datetime(2026, 4, 28, 21, 53, 21, 399000), last_heartbeat=datetime.datetime(2026, 4, 28, 22, 42, 51, 317000), last_modified=datetime.datetime(2026, 4, 28, 22, 42, 58, 68000), heartbeat_timeout=30.0, task_timeout=None, max_retries=3, retries=0, priority=10, metadata={'benchmark': 'LIBERO', 'ckpt_stem': 'steps_30000_pytorch_model', 'task_suite': 'libero_spatial'}, args={'ckpt': '/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt', 'task_suite': 'libero_spatial'}, cmd=['examples/LIBERO/eval_files/parallel_eval_labtasker/run.py', '--env', 'examples/LIBERO/eval_files/parallel_eval_labtasker/.env'], summary={'success_rate': 0.98, 'total_successes': 490, 'total_episodes': 500, 'task_suite': 'libero_spatial', 'pretrained_path': '/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt'}, worker_id=None)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:13.730175Z",
+     "start_time": "2026-04-29T02:06:13.645441Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "tasks[0].summary",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success_rate': 0.98,\n",
+       " 'total_successes': 490,\n",
+       " 'total_episodes': 500,\n",
+       " 'task_suite': 'libero_spatial',\n",
+       " 'pretrained_path': '/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-29T02:06:19.883469Z",
+     "start_time": "2026-04-29T02:06:13.736418Z"
+    }
+   },
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "rows = []\n",
+    "for t in tasks:\n",
+    "    rows.append({\n",
+    "        \"ckpt_stem\": t.metadata.get(\"ckpt_stem\", \"\"),\n",
+    "        \"task_suite\": t.summary[\"task_suite\"],\n",
+    "        \"total_episodes\": t.summary[\"total_episodes\"],\n",
+    "        \"total_successes\": t.summary[\"total_successes\"],\n",
+    "        \"success_rate\": t.summary[\"success_rate\"],\n",
+    "    })\n",
+    "\n",
+    "df = pd.DataFrame(rows)\n",
+    "df = df.set_index([\"ckpt_stem\", \"task_suite\"]).sort_index()\n",
+    "df"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                          total_episodes  total_successes  \\\n",
+       "ckpt_stem                 task_suite                                        \n",
+       "steps_30000_pytorch_model libero_10                  500              447   \n",
+       "                          libero_goal                500              482   \n",
+       "                          libero_object              500              489   \n",
+       "                          libero_spatial             500              490   \n",
+       "\n",
+       "                                          success_rate  \n",
+       "ckpt_stem                 task_suite                    \n",
+       "steps_30000_pytorch_model libero_10              0.894  \n",
+       "                          libero_goal            0.964  \n",
+       "                          libero_object          0.978  \n",
+       "                          libero_spatial         0.980  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>total_episodes</th>\n",
+       "      <th>total_successes</th>\n",
+       "      <th>success_rate</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ckpt_stem</th>\n",
+       "      <th>task_suite</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">steps_30000_pytorch_model</th>\n",
+       "      <th>libero_10</th>\n",
+       "      <td>500</td>\n",
+       "      <td>447</td>\n",
+       "      <td>0.894</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>libero_goal</th>\n",
+       "      <td>500</td>\n",
+       "      <td>482</td>\n",
+       "      <td>0.964</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>libero_object</th>\n",
+       "      <td>500</td>\n",
+       "      <td>489</td>\n",
+       "      <td>0.978</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>libero_spatial</th>\n",
+       "      <td>500</td>\n",
+       "      <td>490</td>\n",
+       "      <td>0.980</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/requirements.extra.txt
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/requirements.extra.txt
@@ -1,0 +1,3 @@
+labtasker[plugins]
+pandas
+python-dotenv

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/run.py
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/run.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Worker script for LIBERO parallel evaluation.
+
+Launch one worker per GPU:
+
+    CUDA_VISIBLE_DEVICES=0 ${STARVLA_PYTHON} \\
+        examples/LIBERO/eval_files/parallel_eval_labtasker/run.py --env .env
+
+Each task is fully self-contained: the worker starts a policy server for the
+task's checkpoint, runs the eval suite, then shuts the server down before
+moving to the next task.
+
+Required env vars:
+    STARVLA_PYTHON   Python interpreter with starVLA installed (runs the policy server)
+    LIBERO_PYTHON    Python interpreter with LIBERO installed (runs eval_libero.py)
+    LIBERO_HOME      Root directory of the LIBERO repo
+
+Optional env vars:
+    LIBERO_NUM_TRIALS    Episodes per task (default: 50)
+    SERVER_TIMEOUT       Seconds to wait for the policy server to become ready (default: 300)
+    CUDA_VISIBLE_DEVICES GPU(s) to use; worker uses the first device listed (default: 0)
+
+Optional flags:
+    --env <path>     Load a .env file before reading env vars (key=value, # comments ok)
+                     Copy .env.example to .env, fill in your paths, then pass --env .env
+"""
+
+import argparse
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+
+from dotenv import load_dotenv
+
+try:
+    import labtasker
+    from labtasker import Required
+except ImportError:
+    print("[ERROR] Labtasker not installed. Install it with `pip install 'labtasker[plugins]'`")
+    exit(1)
+
+HERE = pathlib.Path(__file__).resolve().parent
+PROJECT_ROOT = HERE.parents[3]  # starVLA/
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        sys.exit(f"[ERROR] {name} is not set. Export it before launching this worker.")
+    return val
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(port: int, timeout: int) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(1.0)
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(2)
+    return False
+
+
+def _run(proc: subprocess.Popen, log_path: pathlib.Path) -> int:
+    """Tee proc stdout+stderr to our stdout and to log_path; return exit code."""
+    with open(log_path, "w") as lf:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            lf.write(line)
+    proc.wait()
+    return proc.returncode
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--env", default=None)
+    args, _ = parser.parse_known_args()
+    if args.env:
+        load_dotenv(args.env, override=False)
+
+    starvla_py = _require_env("STARVLA_PYTHON")
+    libero_py = _require_env("LIBERO_PYTHON")
+    libero_home = _require_env("LIBERO_HOME")
+
+    gpu = os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
+    num_trials = os.environ.get("LIBERO_NUM_TRIALS", "50")
+    server_timeout = int(os.environ.get("SERVER_TIMEOUT", "300"))
+
+    @labtasker.loop(extra_filter='metadata.benchmark == "LIBERO"')
+    def run_task(
+            ckpt: str = Required(),
+            task_suite: str = Required(),
+    ) -> None:
+        base_env = {
+            **os.environ,
+            "CUDA_VISIBLE_DEVICES": gpu,
+            "LIBERO_CONFIG_PATH": str(pathlib.Path(libero_home) / "libero"),
+            "PYTHONPATH": os.pathsep.join(filter(None, [
+                str(PROJECT_ROOT),
+                libero_home,
+                os.environ.get("PYTHONPATH", ""),
+            ])),
+        }
+
+        ckpt_path = pathlib.Path(ckpt)
+        ckpt_stem = ckpt_path.stem
+        ckpt_dir = ckpt_path.parent
+        port = _find_free_port()
+
+        video_out = ckpt_dir / "videos" / task_suite / ckpt_stem
+        log_dir = ckpt_dir / "logs" / task_suite
+        video_out.mkdir(parents=True, exist_ok=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Start policy server for this task's checkpoint
+        server_log = log_dir / f"{ckpt_stem}_server.log"
+        server_proc = subprocess.Popen(
+            [
+                starvla_py,
+                str(PROJECT_ROOT / "deployment" / "model_server" / "server_policy.py"),
+                "--ckpt_path", ckpt,
+                "--port", str(port),
+                "--use_bf16",
+            ],
+            env=base_env,
+            stdout=open(server_log, "w"),
+            stderr=subprocess.STDOUT,
+        )
+        print(f"[INFO] Policy server pid={server_proc.pid}  port={port}  ckpt={ckpt_stem}")
+        print(f"[INFO] Waiting for policy server (timeout={server_timeout}s)...")
+
+        if not _wait_for_port(port, server_timeout):
+            server_proc.terminate()
+            server_proc.wait()
+            sys.exit(f"[ERROR] Policy server not ready in {server_timeout}s. See {server_log}")
+        print("[INFO] Policy server ready")
+
+        rc = -1
+        try:
+            eval_log = log_dir / f"{ckpt_stem}.log"
+            print(f"[INFO] suite={task_suite}  gpu={gpu}  port={port}")
+            eval_proc = subprocess.Popen(
+                [
+                    libero_py,
+                    str(PROJECT_ROOT / "examples" / "LIBERO" / "eval_files" / "eval_libero.py"),
+                    "--args.pretrained-path", ckpt,
+                    "--args.host", "127.0.0.1",
+                    "--args.port", str(port),
+                    "--args.task-suite-name", task_suite,
+                    "--args.num-trials-per-task", num_trials,
+                    "--args.video-out-path", str(video_out),
+                ],
+                env=base_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            rc = _run(eval_proc, eval_log)
+            print(f"[INFO] eval exited with code {rc}")
+        finally:
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                server_proc.wait()
+            print("[INFO] Policy server stopped")
+
+            if rc != 0:
+                sys.exit(rc)  # non-zero exit → labtasker marks task failed and retries
+            # labtasker.finish() is called inside eval_libero.py when labtasker is installed
+
+    run_task()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/LIBERO/eval_files/parallel_eval_labtasker/submit.py
+++ b/examples/LIBERO/eval_files/parallel_eval_labtasker/submit.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Submit LIBERO evaluation tasks to Labtasker.
+
+Each task = one (ckpt × task_suite) pair.
+
+Workflow:
+  1. Edit the USER CONFIG section below.
+  2. python submit.py
+  3. Launch workers: CUDA_VISIBLE_DEVICES=<gpu> WORKER_CKPT=<ckpt> ... python run.py
+"""
+
+import itertools
+import pathlib
+
+try:
+    import labtasker
+except ImportError:
+    print("[ERROR] Labtasker not installed. Install it with `pip install 'labtasker[plugins]'`")
+    exit(1)
+
+###############################################################################
+# ============ USER CONFIG: modify this section ============
+###############################################################################
+
+# Checkpoints: auto-discover from a directory, or list explicitly
+CKPT_DIR  = ""   # scan all .pt files in this directory
+CKPT_LIST = [    # explicit list; overrides CKPT_DIR when non-empty
+    "/path/to/starVLA/playground/Pretrained_models/StarVLA/Qwen2.5-VL-OFT-LIBERO-4in1/checkpoints/steps_30000_pytorch_model.pt",
+]
+
+# Task suites to evaluate
+TASK_SUITES = [
+    "libero_spatial",
+    "libero_object",
+    "libero_goal",
+    "libero_10",
+    # "libero_90",
+]
+
+# Labtasker task settings
+MAX_RETRIES = 3
+PRIORITY    = 10  # 0-20
+
+###############################################################################
+# ============ END USER CONFIG ============
+###############################################################################
+
+def main() -> None:
+    ckpts = CKPT_LIST if CKPT_LIST else sorted(
+        str(p) for p in pathlib.Path(CKPT_DIR).glob("*.pt")
+    )
+    if not ckpts:
+        raise ValueError("No checkpoints found. Set CKPT_LIST or CKPT_DIR.")
+
+    # ── Submit tasks ──────────────────────────────────────────────────────────
+    submitted = 0
+    for ckpt, suite in itertools.product(ckpts, TASK_SUITES):
+        stem = pathlib.Path(ckpt).stem
+        result = labtasker.submit_task(
+            task_name=f"{stem}_{suite}",
+            args={"ckpt": ckpt, "task_suite": suite},
+            metadata={"benchmark": "LIBERO", "ckpt_stem": stem, "task_suite": suite},
+            max_retries=MAX_RETRIES,
+            priority=PRIORITY,
+        )
+        print(f"  submitted  {stem} x {suite}  =>  {result.task_id}")
+        submitted += 1
+    print(f"\nDone. {submitted} tasks submitted.\n")
+
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/.env.example
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/.env.example
@@ -1,0 +1,26 @@
+# ============================================================
+# Environment config for RoboTwin parallel eval worker (run.py)
+# Usage: python run.py --env /path/to/this/.env
+# ============================================================
+
+# Python interpreter with starVLA + labtasker installed
+STARVLA_PYTHON=/path/to/starvla/env/bin/python
+
+# Python interpreter with RoboTwin sim installed
+ROBOTWIN_PYTHON=/path/to/robotwin/env/bin/python
+
+# Root directory of the RoboTwin repo
+ROBOTWIN_PATH=/path/to/RoboTwin
+
+# ------------------------------------------------------------
+# Optional (defaults shown)
+# ------------------------------------------------------------
+
+# Root directory for logs and videos (default: <ckpt_dir>/logs|videos)
+# ROBOTWIN_LOG_ROOT=
+
+# Random seed
+ROBOTWIN_SEED=0
+
+# Seconds to wait for the policy server to become ready
+SERVER_TIMEOUT=600

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/README.md
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/README.md
@@ -1,0 +1,179 @@
+# RoboTwin 并行评测：Labtasker 使用说明
+
+本目录提供基于 [Labtasker](https://github.com/luocfprime/labtasker) 的 RoboTwin 并行评测脚本，支持多 GPU 弹性并行、失败自动重试、结果汇总。
+
+---
+
+## Labtasker 简介
+
+[Labtasker](https://github.com/luocfprime/labtasker) 是一个轻量级任务队列系统，专为 ML 实验设计。核心思路是把 `for` 循环替换为任务队列：
+
+- **submit**：把实验参数组合批量推入队列
+- **worker**：从队列拉取任务并执行，多个 worker 并行互不干扰
+- **retry**：任务失败自动重试，成功后将结果写入 summary
+
+### 安装
+
+```bash
+pip install 'labtasker[plugins]'
+```
+
+### 启动 Labtasker Server
+
+Labtasker 需要一个后端服务来管理任务队列。在远端机器上启动（建议放入 tmux）：
+
+```bash
+# 指定数据目录（队列数据持久化在此）
+labtasker-server serve &
+```
+
+### 初始化队列
+
+首次使用时，在项目根目录初始化配置并创建队列：
+
+```bash
+labtasker init          # 交互式填写 server 地址、队列名等，生成 .labtasker/config.toml
+labtasker queue create-from-config
+```
+
+此后同一机器上的所有 submit / worker 命令自动读取 `.labtasker/config.toml`，无需重复配置。
+
+---
+
+## 架构说明
+
+每个任务（checkpoint × task × mode）完全自洽：worker 为该任务启动 policy server，eval 结束后关闭，再处理下一个任务。
+
+```
+Queue                                    Worker (GPU 0)
+┌─────────────────────────────────┐      ┌──────────────────────────────────────────┐
+│  ckpt=A × stack_blocks × clean  │─────►│  start server(ckpt=A)                   │
+│  ckpt=A × stack_blocks × random │      │  run eval.sh(stack_blocks, demo_clean)  │
+│  ckpt=A × place_shoe × clean    │      │  stop server                            │
+│  ckpt=B × stack_blocks × clean  │      │  start server(ckpt=A)                   │
+│  ...（50 tasks × 2 modes）       │      │  run eval.sh(stack_blocks, demo_random) │
+└─────────────────────────────────┘      │  stop server                            │
+                                         │  ...                                    │
+                                         └──────────────────────────────────────────┘
+```
+
+## 文件说明
+
+| 文件 | 作用 |
+|---|---|
+| `submit.py` | 向任务队列提交 (ckpt × task_name × mode) 评测任务 |
+| `run.py` | Worker 脚本：循环拉取任务 → 启动 server → 运行评测 → 关闭 server → 上报结果 |
+| `.env.example` | 环境变量模板，复制为 `.env` 后填入实际路径 |
+| `collect_results.ipynb` | 结果汇总 notebook |
+
+任务粒度：**每个任务 = 一个 checkpoint × 一个 task × 一个 mode**（默认 50 tasks × 2 modes = 100 个任务）。
+
+---
+
+## 前提条件
+
+请先按照 `examples/Robotwin/README.md` 完成依赖安装，并确保 labtasker 在两个环境中都已安装：
+
+```bash
+# starVLA 环境（运行 run.py / policy server）
+${STARVLA_PYTHON} -m pip install 'labtasker[plugins]'
+
+# RoboTwin 环境（运行 eval_policy.py）
+${ROBOTWIN_PYTHON} -m pip install labtasker
+```
+
+---
+
+## 快速开始
+
+### 第一步：配置环境变量
+
+复制模板并填入实际路径：
+
+```bash
+cp .env.example .env
+# 编辑 .env，填入 STARVLA_PYTHON、ROBOTWIN_PYTHON、ROBOTWIN_PATH
+```
+
+`.env` 内容说明：
+
+```bash
+# 必填
+STARVLA_PYTHON=   # 运行 policy server 的 Python（starVLA conda env）
+ROBOTWIN_PYTHON=  # 运行 eval_policy.py 的 Python（robotwin conda env）
+ROBOTWIN_PATH=    # RoboTwin repo 根目录
+
+# 可选（括号内为默认值）
+ROBOTWIN_SEED=0        # 评测随机种子（0）
+SERVER_TIMEOUT=600     # 等待 policy server 就绪的超时秒数（600）
+# ROBOTWIN_LOG_ROOT=   # 覆盖日志根目录（默认 <ckpt_dir>/robotwin_eval_logs/...）
+```
+
+### 第二步：提交任务
+
+编辑 `submit.py` 顶部的 USER CONFIG，填写 `CKPT` 和 `POLICY_NAME`：
+
+```python
+CKPT = "/path/to/steps_30000_pytorch_model.pt"
+POLICY_NAME = "my_run_v1"   # 用于日志目录命名
+```
+
+提交：
+
+```bash
+${STARVLA_PYTHON} examples/Robotwin/eval_files/parallel_eval_labtasker/submit.py
+```
+
+### 第三步：启动 Worker
+
+每个 GPU 启动一个 worker，worker 自动从队列中拉取任务：
+
+```bash
+# GPU 0
+CUDA_VISIBLE_DEVICES=0 \
+    ${STARVLA_PYTHON} examples/Robotwin/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/Robotwin/eval_files/parallel_eval_labtasker/.env &
+
+# GPU 1
+CUDA_VISIBLE_DEVICES=1 \
+    ${STARVLA_PYTHON} examples/Robotwin/eval_files/parallel_eval_labtasker/run.py \
+    --env examples/Robotwin/eval_files/parallel_eval_labtasker/.env &
+
+wait
+```
+
+多个 worker 可以并行处理不同任务，labtasker 自动分配，不会重复。Worker 队列为空时自动退出。
+
+---
+
+## 查看进度
+
+```bash
+labtasker task count
+labtasker task ls
+labtasker task ls -s running
+labtasker task ls -s failed  --no-pager
+labtasker task ls -s success
+```
+
+## 汇总结果
+
+打开 `collect_results.ipynb` 查看每个 (policy_name × task × mode) 的成功率，以及按 policy 和 mode 的平均汇总。
+
+## 失败重试
+
+```bash
+# 查看失败任务
+labtasker task ls -s failed --no-pager
+
+# 批量重置为 pending（重新排队）
+labtasker task update -s failed -u "retries=0" --reset-pending --quiet
+```
+
+## 日志位置
+
+```
+<ckpt_dir>/robotwin_eval_logs/<policy_name>_<ckpt_stem>/
+  <ckpt_stem>_server.log          # policy server 日志
+  <task_name>_<mode>_eval.log     # eval.sh 完整输出
+```

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/collect_results.ipynb
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/collect_results.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "!pip install \"labtasker[plugins]\" pandas",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:54.455788Z",
+     "start_time": "2026-05-02T12:18:50.212396Z"
+    }
+   },
+   "source": [
+    "import os\n",
+    "os.chdir(\"/path/to/starVLA\")\n",
+    "print(os.getcwd())\n",
+    "from labtasker import ls_tasks"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/path/to/starVLA\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:56.282097Z",
+     "start_time": "2026-05-02T12:18:54.457480Z"
+    }
+   },
+   "source": "!labtasker task count -f \"metadata.benchmark == 'RoboTwin'\"",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🟡 Pending: \u001B[1;36m0\u001B[0m\r\n",
+      "🔵 Running: \u001B[1;36m0\u001B[0m\r\n",
+      "🟢 Success: >= \u001B[1;36m100\u001B[0m\r\n",
+      "🔴 Failed: \u001B[1;36m0\u001B[0m\r\n",
+      "⚪ Cancelled: \u001B[1;36m0\u001B[0m\r\n"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:56.915070Z",
+     "start_time": "2026-05-02T12:18:56.283696Z"
+    }
+   },
+   "source": "# Filter by benchmark to avoid mixing with LIBERO tasks\n# Add more conditions as needed:\n# e.g. extra_filter = 'metadata.benchmark == \"RoboTwin\" and args.policy_name == \"my_run_v1\"'\n# e.g. extra_filter = 'metadata.benchmark == \"RoboTwin\" and args.mode == \"demo_clean\"'\nextra_filter = 'metadata.benchmark == \"RoboTwin\"'\n\ntasks = ls_tasks(\n    status=\"success\",\n    extra_filter=extra_filter if extra_filter else None,\n    limit=1000,\n).content\nprint(f\"{len(tasks)} successful tasks\")",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 successful tasks\n"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:18:57.063676Z",
+     "start_time": "2026-05-02T12:18:56.966412Z"
+    }
+   },
+   "source": [
+    "tasks[0]"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Task(unknown_fields={}, task_id='2741f37f-b292-492c-ad2c-dce16e2d4296', queue_id='b5b7ed91-b5ef-46bc-a244-33216576b5d9', status='success', task_name='Qwen3-VL-OFT-RoboTwin2-All_beat_block_hammer_demo_randomized', created_at=datetime.datetime(2026, 4, 28, 16, 59, 5, 313000), start_time=datetime.datetime(2026, 4, 28, 18, 25, 10, 150000), last_heartbeat=datetime.datetime(2026, 4, 28, 20, 3, 0, 761000), last_modified=datetime.datetime(2026, 4, 28, 20, 3, 5, 556000), heartbeat_timeout=30.0, task_timeout=None, max_retries=3, retries=0, priority=10, metadata={'benchmark': 'RoboTwin', 'task_name': 'beat_block_hammer', 'mode': 'demo_randomized', 'policy_name': 'Qwen3-VL-OFT-RoboTwin2-All'}, args={'task_name': 'beat_block_hammer', 'mode': 'demo_randomized', 'ckpt': '/path/to/starVLA/.cache/huggingface/hub/models--StarVLA--Qwen3-VL-OFT-RoboTwin2-All/snapshots/2d8a0487b501c15bc96569f4ec7c09c8aba76820/checkpoints/steps_140000_pytorch_model.pt', 'policy_name': 'Qwen3-VL-OFT-RoboTwin2-All'}, cmd=['examples/Robotwin/eval_files/parallel_eval_labtasker/run.py', '--env', 'examples/Robotwin/eval_files/parallel_eval_labtasker/.env'], summary={'success_rate': 0.94, 'task_name': 'beat_block_hammer', 'mode': 'demo_randomized'}, worker_id=None)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:19:01.596821Z",
+     "start_time": "2026-05-02T12:18:57.069204Z"
+    }
+   },
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "rows = []\n",
+    "for t in tasks:\n",
+    "    rows.append({\n",
+    "        \"policy_name\": t.args[\"policy_name\"],\n",
+    "        \"task_name\":   t.summary[\"task_name\"],\n",
+    "        \"mode\":        t.summary[\"mode\"],\n",
+    "        \"success_rate\": t.summary[\"success_rate\"],\n",
+    "    })\n",
+    "\n",
+    "df = pd.DataFrame(rows)\n",
+    "df = df.set_index([\"policy_name\", \"task_name\", \"mode\"]).sort_index()\n",
+    "df"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                                               success_rate\n",
+       "policy_name                task_name          mode                         \n",
+       "Qwen3-VL-OFT-RoboTwin2-All adjust_bottle      demo_clean               1.00\n",
+       "                                              demo_randomized          0.99\n",
+       "                           beat_block_hammer  demo_clean               0.94\n",
+       "                                              demo_randomized          0.94\n",
+       "                           blocks_ranking_rgb demo_clean               0.99\n",
+       "...                                                                     ...\n",
+       "                           stack_bowls_two    demo_randomized          0.97\n",
+       "                           stamp_seal         demo_clean               0.84\n",
+       "                                              demo_randomized          0.92\n",
+       "                           turn_switch        demo_clean               0.69\n",
+       "                                              demo_randomized          0.61\n",
+       "\n",
+       "[100 rows x 1 columns]"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>success_rate</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>policy_name</th>\n",
+       "      <th>task_name</th>\n",
+       "      <th>mode</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"11\" valign=\"top\">Qwen3-VL-OFT-RoboTwin2-All</th>\n",
+       "      <th rowspan=\"2\" valign=\"top\">adjust_bottle</th>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>1.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>0.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">beat_block_hammer</th>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>0.94</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>0.94</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>blocks_ranking_rgb</th>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>0.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>stack_bowls_two</th>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>0.97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">stamp_seal</th>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>0.84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>0.92</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">turn_switch</th>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>0.69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>0.61</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 1 columns</p>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-05-02T12:19:01.889414Z",
+     "start_time": "2026-05-02T12:19:01.715199Z"
+    }
+   },
+   "source": [
+    "# Per-policy aggregate across all tasks and modes\n",
+    "summary_rows = []\n",
+    "for (policy_name, mode), grp in df.groupby([\"policy_name\", \"mode\"]):\n",
+    "    summary_rows.append({\n",
+    "        \"policy_name\": policy_name,\n",
+    "        \"mode\":        mode,\n",
+    "        \"n_tasks\":     len(grp),\n",
+    "        \"avg_success_rate\": grp[\"success_rate\"].mean(),\n",
+    "    })\n",
+    "\n",
+    "summary_df = pd.DataFrame(summary_rows).set_index([\"policy_name\", \"mode\"])\n",
+    "summary_df.sort_values(\"avg_success_rate\", ascending=False)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                            n_tasks  avg_success_rate\n",
+       "policy_name                mode                                      \n",
+       "Qwen3-VL-OFT-RoboTwin2-All demo_randomized       50            0.8884\n",
+       "                           demo_clean            50            0.8848"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>n_tasks</th>\n",
+       "      <th>avg_success_rate</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>policy_name</th>\n",
+       "      <th>mode</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">Qwen3-VL-OFT-RoboTwin2-All</th>\n",
+       "      <th>demo_randomized</th>\n",
+       "      <td>50</td>\n",
+       "      <td>0.8884</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>demo_clean</th>\n",
+       "      <td>50</td>\n",
+       "      <td>0.8848</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/requirements.extra.txt
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/requirements.extra.txt
@@ -1,0 +1,2 @@
+labtasker[plugins]
+python-dotenv

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/run.py
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/run.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Worker script for RoboTwin parallel evaluation.
+
+Launch one worker per GPU:
+
+    CUDA_VISIBLE_DEVICES=0 \\
+        ${STARVLA_PYTHON} examples/Robotwin/eval_files/parallel_eval_labtasker/run.py --env .env
+
+Each task is fully self-contained: the worker starts a policy server for the
+task's checkpoint, runs the eval, then shuts the server down before moving to
+the next task.
+
+Required env vars:
+    ROBOTWIN_PATH        Path to the local RoboTwin repository
+    STARVLA_PYTHON       Python interpreter with starVLA installed (runs the policy server)
+    ROBOTWIN_PYTHON      Python interpreter with RoboTwin eval deps installed
+
+Optional env vars:
+    ROBOTWIN_SEED        Eval seed (default: 0)
+    SERVER_TIMEOUT       Seconds to wait for the policy server (default: 600)
+    CUDA_VISIBLE_DEVICES GPU(s) to use; worker uses the first device listed (default: 0)
+    ROBOTWIN_LOG_ROOT    Override log root directory (default: <ckpt_dir>/robotwin_eval_logs/...)
+
+Optional flags:
+    --env <path>     Load a .env file before reading env vars (key=value, # comments ok)
+                     Copy .env.example to .env, fill in your paths, then pass --env .env
+"""
+
+import argparse
+import os
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import time
+
+from dotenv import load_dotenv
+
+try:
+    import labtasker
+    from labtasker import Required
+
+    _has_labtasker = True
+except ImportError:
+    _has_labtasker = False
+
+HERE = pathlib.Path(__file__).resolve().parent
+EVAL_DIR = HERE.parent  # examples/Robotwin/eval_files/
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        sys.exit(f"[ERROR] {name} is not set. Export it before launching this worker.")
+    return val
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(port: int, timeout: int) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(1.0)
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(2)
+    return False
+
+
+def _stream(proc: subprocess.Popen, log_path: pathlib.Path) -> tuple[int, str]:
+    """Tee proc stdout+stderr to our stdout and log_path; return (exit_code, full_output)."""
+    lines: list[str] = []
+    with open(log_path, "w") as lf:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            lf.write(line)
+            lines.append(line)
+    proc.wait()
+    return proc.returncode, "".join(lines)
+
+
+def _parse_success_rate(output: str) -> float | None:
+    # Strip ANSI escape codes (eval_policy.py emits them even to a pipe)
+    clean = re.sub(r'\x1b\[[0-9;]*m', '', output)
+    # Prefer the "=> Z%" form which gives the exact percentage
+    matches = re.findall(r"[Ss]uccess\s+rate:\s*\d+/\d+\s*=>\s*([0-9]+\.?[0-9]*)%", clean)
+    if matches:
+        return float(matches[-1]) / 100.0
+    # Fallback: plain "success rate: Z" (handles non-ANSI outputs)
+    matches = re.findall(r"[Ss]uccess\s+rate[:\s]+([0-9]+\.?[0-9]*)", clean)
+    if not matches:
+        return None
+    raw = float(matches[-1])
+    return raw / 100.0 if raw > 1.0 else raw
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--env", default=None)
+    args, _ = parser.parse_known_args()
+    if args.env:
+        load_dotenv(args.env, override=False)
+
+    robotwin_path = _require_env("ROBOTWIN_PATH")
+    starvla_py = _require_env("STARVLA_PYTHON")
+    robotwin_py = _require_env("ROBOTWIN_PYTHON")
+
+    gpu = os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
+    seed = os.environ.get("ROBOTWIN_SEED", "0")
+    server_timeout = int(os.environ.get("SERVER_TIMEOUT", "600"))
+    log_root = os.environ.get("ROBOTWIN_LOG_ROOT", "")
+
+    @labtasker.loop(extra_filter='metadata.benchmark == "RoboTwin"')
+    def run_task(
+            ckpt: str = Required(),
+            task_name: str = Required(),
+            mode: str = Required(),
+            policy_name: str = Required(),
+    ) -> None:
+        base_env = {
+            **os.environ,
+            "CUDA_VISIBLE_DEVICES": gpu,
+            "STARVLA_PYTHON": starvla_py,
+            "ROBOTWIN_PYTHON": robotwin_py,
+            "ROBOTWIN_PATH": robotwin_path,
+        }
+
+        ckpt_path = pathlib.Path(ckpt)
+        ckpt_stem = ckpt_path.stem
+        port = _find_free_port()
+
+        base_log_dir = (
+            pathlib.Path(log_root)
+            if log_root
+            else ckpt_path.parent / "robotwin_eval_logs" / f"{policy_name}_{ckpt_stem}"
+        )
+        base_log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Start policy server for this task's checkpoint
+        server_log = base_log_dir / f"{ckpt_stem}_server.log"
+        server_proc = subprocess.Popen(
+            [
+                "bash",
+                str(EVAL_DIR / "run_policy_server.sh"),
+                ckpt,
+                gpu,
+                str(port),
+            ],
+            env=base_env,
+            stdout=open(server_log, "w"),
+            stderr=subprocess.STDOUT,
+        )
+        print(f"[INFO] Policy server pid={server_proc.pid}  port={port}  ckpt={ckpt_stem}")
+        print(f"[INFO] Waiting for policy server (timeout={server_timeout}s)...")
+
+        if not _wait_for_port(port, server_timeout):
+            server_proc.terminate()
+            server_proc.wait()
+            sys.exit(f"[ERROR] Policy server not ready in {server_timeout}s. See {server_log}")
+        print("[INFO] Policy server ready")
+
+        try:
+            eval_log = base_log_dir / f"{task_name}_{mode}_eval.log"
+            print(f"[INFO] task={task_name}  mode={mode}  gpu={gpu}  port={port}")
+            eval_proc = subprocess.Popen(
+                [
+                    "bash",
+                    str(EVAL_DIR / "eval.sh"),
+                    task_name,
+                    mode,
+                    "starvla_demo",  # ckpt_setting
+                    seed,
+                    gpu,
+                    ckpt,
+                    str(port),
+                ],
+                env=base_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            rc, output = _stream(eval_proc, eval_log)
+            print(f"[INFO] eval exited with code {rc}")
+        finally:
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                server_proc.wait()
+            print("[INFO] Policy server stopped")
+
+        if rc != 0:
+            sys.exit(rc)  # non-zero exit → labtasker marks task failed and retries
+
+        success_rate = _parse_success_rate(output)
+        if success_rate is None:
+            sys.exit("[ERROR] Could not parse success rate from eval output")
+        labtasker.finish(
+            status="success",
+            summary={"success_rate": success_rate, "task_name": task_name, "mode": mode},
+        )
+
+    run_task()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/Robotwin/eval_files/parallel_eval_labtasker/submit.py
+++ b/examples/Robotwin/eval_files/parallel_eval_labtasker/submit.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Submit RoboTwin evaluation tasks to Labtasker.
+
+Each task = one (task_name, mode) pair.
+Worker command (one per GPU):
+    CUDA_VISIBLE_DEVICES=<gpu> labtasker loop -- \\
+        ${STARVLA_PYTHON} examples/Robotwin/eval_files/parallel_eval_labtasker/run.py \\
+            '%(task_name)' '%(mode)' '%(ckpt)' '%(policy_name)'
+"""
+
+import itertools
+
+import labtasker
+
+
+# ===== USER CONFIG =====
+CKPT = "/path/to/starVLA/.cache/huggingface/hub/models--StarVLA--Qwen3-VL-OFT-RoboTwin2-All/snapshots/2d8a0487b501c15bc96569f4ec7c09c8aba76820/checkpoints/steps_140000_pytorch_model.pt"
+POLICY_NAME = "Qwen3-VL-OFT-RoboTwin2-All"
+
+MODES = [
+    "demo_clean",
+    "demo_randomized",
+]
+
+TASKS = [
+    "adjust_bottle",
+    "beat_block_hammer",
+    "blocks_ranking_rgb",
+    "blocks_ranking_size",
+    "click_alarmclock",
+    "click_bell",
+    "dump_bin_bigbin",
+    "grab_roller",
+    "handover_block",
+    "handover_mic",
+    "hanging_mug",
+    "lift_pot",
+    "move_can_pot",
+    "move_pillbottle_pad",
+    "move_playingcard_away",
+    "move_stapler_pad",
+    "open_laptop",
+    "open_microwave",
+    "pick_diverse_bottles",
+    "pick_dual_bottles",
+    "place_a2b_left",
+    "place_a2b_right",
+    "place_bread_basket",
+    "place_bread_skillet",
+    "place_burger_fries",
+    "place_can_basket",
+    "place_cans_plasticbox",
+    "place_container_plate",
+    "place_dual_shoes",
+    "place_empty_cup",
+    "place_fan",
+    "place_mouse_pad",
+    "place_object_basket",
+    "place_object_scale",
+    "place_object_stand",
+    "place_phone_stand",
+    "place_shoe",
+    "press_stapler",
+    "put_bottles_dustbin",
+    "put_object_cabinet",
+    "rotate_qrcode",
+    "scan_object",
+    "shake_bottle_horizontally",
+    "shake_bottle",
+    "stack_blocks_three",
+    "stack_blocks_two",
+    "stack_bowls_three",
+    "stack_bowls_two",
+    "stamp_seal",
+    "turn_switch",
+]
+
+MAX_RETRIES = 3
+PRIORITY = 10  # 0-20
+# =======================
+
+
+def main():
+    if not CKPT:
+        raise ValueError("Set CKPT to the checkpoint path before submitting.")
+    if not POLICY_NAME:
+        raise ValueError("Set POLICY_NAME before submitting.")
+
+    submitted = 0
+    for task_name, mode in itertools.product(TASKS, MODES):
+        result = labtasker.submit_task(
+            task_name=f"{POLICY_NAME}_{task_name}_{mode}",
+            args={
+                "task_name": task_name,
+                "mode": mode,
+                "ckpt": CKPT,
+                "policy_name": POLICY_NAME,
+            },
+            metadata={
+                "benchmark": "RoboTwin",
+                "task_name": task_name,
+                "mode": mode,
+                "policy_name": POLICY_NAME,
+            },
+            max_retries=MAX_RETRIES,
+            priority=PRIORITY,
+        )
+        print(f"  submitted  {task_name} x {mode}  =>  task_id={result.task_id}")
+        submitted += 1
+
+    print(f"\nDone. {submitted} tasks submitted.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Adds three parallel evaluation setups under `examples/{LIBERO,LIBERO-plus,Robotwin}/eval_files/parallel_eval_labtasker/`, all built on top of [Labtasker](https://github.com/luocfprime/labtasker). Each setup turns the `for ckpt × task × ...` evaluation loop into a task queue: `submit.py` enqueues the parameter combinations, and one worker per GPU pulls tasks, runs the evaluation, and reports back. Failed tasks are auto-retried, and a `collect_results.ipynb` aggregates the success rates per run.

This is purely additive — you can use the original scripts as they were.

## Motivation

See linked issue for the full pain-point write-up. In short: today's manual `for ckpt × task × ...` shell loop has no elastic parallelism, no automatic retry, and no shared result view; this setup addresses all three.

Closes #307

## Changes

- New `examples/Robotwin/eval_files/parallel_eval_labtasker/` — `submit.py`, `run.py`, `collect_results.ipynb`, `README.md`, `.env.example`, `requirements.extra.txt` (task = ckpt × task_name × mode, default 50 tasks × 2 modes = 100 jobs).
- New `examples/LIBERO/eval_files/parallel_eval_labtasker/` — same layout (task = ckpt × task_suite, plus a small additive tweak in `examples/LIBERO/eval_files/eval_libero.py`).
- New `examples/LIBERO-plus/eval_files/parallel_eval_labtasker/` — same layout, with per-suite slice splitting (`SUITE_SIZES` / `NUM_SLICES`) so a single suite can be sharded across many workers.
- `.gitignore`: ignore local `.env` files under the new directories.

## Testing

- [x] Local benchmarking on LIBERO, LIBERO-plus and RoboTwin

## Demo

### Check task status via CLI

<img width="667" height="222" alt="image" src="https://github.com/user-attachments/assets/ee394260-31a4-44bc-b347-5a2f30f26487" />

### Filter and aggregate results via Python API in a notebook

<img width="1007" height="393" alt="image" src="https://github.com/user-attachments/assets/815346d9-6eb2-43fe-9290-67f201477063" />

<br>

<img width="984" height="454" alt="image" src="https://github.com/user-attachments/assets/84dfe4ec-bcbc-477b-998e-00ae0ebe6bef" />

<br>

<img width="991" height="203" alt="image" src="https://github.com/user-attachments/assets/07fe1283-1583-4703-9d76-4e88225c93f0" />





