### PR TITLE
fix(examples/libero): align data_root_dir with LEROBOT_LIBERO_DATA layout

### DIFF
--- a/examples/LIBERO/train_files/starvla_cotrain_libero.yaml
+++ b/examples/LIBERO/train_files/starvla_cotrain_libero.yaml
@@ -33,7 +33,7 @@ datasets:
 
   vla_data:
     dataset_py: lerobot_datasets
-    data_root_dir: playground/Datasets/LIBERO
+    data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_all # libero_goal
     action_type: delta_qpos
     sequential_step_sampling: False


### PR DESCRIPTION
## Motivation

The cotrain config's `data_root_dir` didn't match the layout produced by `examples/LIBERO/data_preparation.sh` and documented in `docs/starVLA_guideline.md`. After following the guideline to download LIBERO into `playground/Datasets/LEROBOT_LIBERO_DATA`, the YAML still pointed at `playground/Datasets/LIBERO`, so the dataloader failed to find the data out of the box.

## Changes

- `examples/LIBERO/train_files/starvla_cotrain_libero.yaml`: `playground/Datasets/LIBERO` → `playground/Datasets/LEROBOT_LIBERO_DATA`

## Testing

- [x] `grep -rn "playground/Datasets/LIBERO[^_]" examples/ docs/ starVLA/` returns nothing — no other reference to the old path remains.
- [x] Path now matches `data_preparation.sh`, `run_libero_train.sh`, `data_registry/data_config.py`, `docs/starVLA_guideline.md`, and `examples/LIBERO/README.md`.

## Breaking Changes

None — anyone who followed `docs/starVLA_guideline.md` already has the data at the new path. The old path was a doc/code mismatch, not a supported layout.