### PR TITLE
 fix(examples): remove hardcoded local paths and align LIBERO dataset defaultsFix/libero data root

### DIFF
--- a/examples/Franka/eval_files/run_policy_server.sh
+++ b/examples/Franka/eval_files/run_policy_server.sh
@@ -1,15 +1,24 @@
-#!/bin/bash
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let Franka find the websocket tools from main repo
-export star_vla_python=/mnt/petrelfs/share/yejinhui/Envs/miniconda3/envs/starVLA/bin/python
-your_ckpt=results/Checkpoints/Franka_QwenPI_qwen3/checkpoints/steps_50000_pytorch_model.pt
-gpu_id=0
-port=5694
-################# star Policy Server ######################
+#!/usr/bin/env bash
+set -euo pipefail
 
-# export DEBUG=true
-CUDA_VISIBLE_DEVICES=$gpu_id ${star_vla_python} deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${port} \
-    --use_bf16
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+star_vla_python="${star_vla_python:-python}"
+your_ckpt="${your_ckpt:-results/Checkpoints/Franka_QwenPI_qwen3/checkpoints/steps_50000_pytorch_model.pt}"
+gpu_id="${gpu_id:-0}"
+port="${port:-5694}"
+USE_BF16="${USE_BF16:-1}"
 
-# #################################
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
+
+CMD=(
+  "${star_vla_python}" deployment/model_server/server_policy.py
+  --ckpt_path "${your_ckpt}"
+  --port "${port}"
+)
+
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${CMD[@]}"

--- a/examples/LIBERO-plus/eval_files/eval_libero.sh
+++ b/examples/LIBERO-plus/eval_files/eval_libero.sh
@@ -1,28 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-###########################################################################################
-# === Please modify the following paths according to your environment ===
-export LIBERO_HOME=path_to_LIBERO-plus_home
-export LIBERO_CONFIG_PATH=${LIBERO_HOME}/libero
-export LIBERO_Python=path_to_LIBERO-plus_env_python
-export MUJOCO_GL=osmesa
-export PYTHONPATH=$PYTHONPATH:${LIBERO_HOME} # let eval_libero find the LIBERO tools
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+LIBERO_HOME="${LIBERO_HOME:-}"
+LIBERO_Python="${LIBERO_Python:-python}"
+MUJOCO_GL="${MUJOCO_GL:-osmesa}"
+PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM:-osmesa}"
+host="${host:-127.0.0.1}"
+your_ckpt="${your_ckpt:-/path/to/checkpoint.pt}"
+output_dir="${output_dir:-${STARVLA_DIR}/results/libero_plus_eval}"
+gpu_id="${gpu_id:-0}"
 
+if [[ -z "${LIBERO_HOME}" ]]; then
+  echo "LIBERO_HOME is required."
+  exit 1
+fi
 
-host="127.0.0.1"
+cd "${STARVLA_DIR}"
+export LIBERO_CONFIG_PATH="${LIBERO_HOME}/libero"
+export PYTHONPATH="${PYTHONPATH:-}:${LIBERO_HOME}:${STARVLA_DIR}"
 
-unnorm_key="franka"
-your_ckpt=path_to_ABot_checkpoint
-output_dir=path_to_output_dir
 folder_name=$(echo "$your_ckpt" | awk -F'/' '{print $(NF-2)"_"$(NF-1)"_"$NF}')
-# === End of environment variable configuration ===
-###########################################################################################
-
-# export DEBUG=true
-
 LOG_DIR="${output_dir}/logs/$(date +"%Y%m%d_%H%M%S")"
-mkdir -p ${LOG_DIR}
+mkdir -p "${LOG_DIR}"
 
 base_port=9883
 task_suite_name=libero_goal
@@ -30,7 +30,7 @@ num_trials_per_task=1
 video_out_path="${output_dir}/${task_suite_name}/${folder_name}"
 log_file="${LOG_DIR}/${task_suite_name}.log"
 
-CUDA_VISIBLE_DEVICES=2 ${LIBERO_Python} ./examples/LIBERO-plus/eval_files/eval_libero.py \
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${LIBERO_Python}" ./examples/LIBERO-plus/eval_files/eval_libero.py \
     --args.pretrained-path ${your_ckpt} \
     --args.host "$host" \
     --args.port $base_port \
@@ -50,7 +50,7 @@ num_trials_per_task=1
 video_out_path="${output_dir}/${task_suite_name}/${folder_name}"
 log_file="${LOG_DIR}/${task_suite_name}.log"
 
-CUDA_VISIBLE_DEVICES=2 ${LIBERO_Python} ./examples/LIBERO-plus/eval_files/eval_libero.py \
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${LIBERO_Python}" ./examples/LIBERO-plus/eval_files/eval_libero.py \
     --args.pretrained-path ${your_ckpt} \
     --args.host "$host" \
     --args.port $base_port \
@@ -68,7 +68,7 @@ num_trials_per_task=1
 video_out_path="${output_dir}/${task_suite_name}/${folder_name}"
 log_file="${LOG_DIR}/${task_suite_name}.log"
 
-CUDA_VISIBLE_DEVICES=2 ${LIBERO_Python} ./examples/LIBERO-plus/eval_files/eval_libero.py \
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${LIBERO_Python}" ./examples/LIBERO-plus/eval_files/eval_libero.py \
     --args.pretrained-path ${your_ckpt} \
     --args.host "$host" \
     --args.port $base_port \
@@ -87,7 +87,7 @@ num_trials_per_task=1
 video_out_path="${output_dir}/${task_suite_name}/${folder_name}"
 log_file="${LOG_DIR}/${task_suite_name}.log"
 
-CUDA_VISIBLE_DEVICES=2 ${LIBERO_Python} ./examples/LIBERO-plus/eval_files/eval_libero.py \
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${LIBERO_Python}" ./examples/LIBERO-plus/eval_files/eval_libero.py \
     --args.pretrained-path ${your_ckpt} \
     --args.host "$host" \
     --args.port $base_port \

--- a/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_in_one.sh
+++ b/examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_in_one.sh
@@ -1,24 +1,22 @@
-#!/bin/bash
-eval "$(conda shell.bash hook)"
-# source activate
-conda activate python3.10
-# pip install -r requirements.txt
-# pip list
-# ls /usr/lib64/libOSMesa.so*
-###########################################################################################
-# === Please modify the following paths according to your environment ===
-export LIBERO_HOME=path_to_LIBERO-plus_code
-export LIBERO_CONFIG_PATH=${LIBERO_HOME}/libero
-export MUJOCO_GL=osmesa
-export PYTHONPATH=$PYTHONPATH:${LIBERO_HOME} # let eval_libero find the LIBERO tools
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
+#!/usr/bin/env bash
+set -euo pipefail
 
-unnorm_key="franka"
-tasks_per_gpu=3
-your_ckpt=path_to_checkpoint
-output_dir=path_to_output_dir
-# === End of environment variable configuration ===
-###########################################################################################
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../../.." && pwd)}"
+LIBERO_HOME="${LIBERO_HOME:-}"
+LIBERO_PYTHON="${LIBERO_PYTHON:-python}"
+MUJOCO_GL="${MUJOCO_GL:-osmesa}"
+tasks_per_gpu="${tasks_per_gpu:-3}"
+your_ckpt="${your_ckpt:-/path/to/checkpoint.pt}"
+output_dir="${output_dir:-${STARVLA_DIR}/results/libero_plus_parallel_eval}"
+
+if [[ -z "${LIBERO_HOME}" ]]; then
+  echo "LIBERO_HOME is required."
+  exit 1
+fi
+
+cd "${STARVLA_DIR}"
+export LIBERO_CONFIG_PATH="${LIBERO_HOME}/libero"
+export PYTHONPATH="${PYTHONPATH:-}:${LIBERO_HOME}:${STARVLA_DIR}"
 
 task_suite_name=$1
 start_idx=$2
@@ -46,7 +44,7 @@ for ((i=0; i<tasks_per_gpu; i++)); do
 
     echo "Part $((i)): start=$current_start, end=$current_end ([$current_start, $current_end))"
     # torchrun --nproc_per_node=$gpu_per_pod --nnodes=$WORLD_SIZE --node_rank=$RANK --master_addr=$((MASTER_ADDR+i)) --master_port=$MASTER_PORT 
-    python ./examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_model.py \
+    "${LIBERO_PYTHON}" ./examples/LIBERO-plus/eval_files/parallel_eval/eval_libero_model.py \
     --pretrained_path $your_ckpt \
     --task_suite_name $task_suite_name \
     --num_trials_per_task $num_trials_per_task \

--- a/examples/LIBERO-plus/eval_files/run_policy_server.sh
+++ b/examples/LIBERO-plus/eval_files/run_policy_server.sh
@@ -1,12 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-your_ckpt=path_to_ABot_checkpoint
-base_port=9883
-export ABot_python=path_to_ABot_env_python
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+ABot_python="${ABot_python:-python}"
+your_ckpt="${your_ckpt:-/path/to/checkpoint.pt}"
+base_port="${base_port:-9883}"
+gpu_id="${gpu_id:-0}"
+USE_BF16="${USE_BF16:-1}"
 
-export DEBUG=1
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
 
-CUDA_VISIBLE_DEVICES=3 python deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${base_port} \
-    --use_bf16
+CMD=(
+  "${ABot_python}" deployment/model_server/server_policy.py
+  --ckpt_path "${your_ckpt}"
+  --port "${base_port}"
+)
+
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${CMD[@]}"

--- a/examples/LIBERO/eval_files/auto_eval_scripts/auto_eval_libero.sh
+++ b/examples/LIBERO/eval_files/auto_eval_scripts/auto_eval_libero.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd /home/jye624/Projcets/starVLA
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../../.." && pwd)}"
+cd "${STARVLA_DIR}"
 SCRIPT_PATH="./examples/LIBERO/eval_files/auto_eval_scripts/eval_libero_parall.sh"
 
 ###############################################################################
@@ -93,4 +94,3 @@ for ((i=0; i<num_gpus; i++)); do
     echo "   GPU ${GPU_LIST[$i]}: ${gpu_job_count[$i]} jobs"
 done
 echo "=========================================="
-

--- a/examples/LIBERO/eval_files/auto_eval_scripts/eval_libero_parall.sh
+++ b/examples/LIBERO/eval_files/auto_eval_scripts/eval_libero_parall.sh
@@ -1,14 +1,19 @@
-###########################################################################################
-# === Please modify the following paths according to your environment ===
-export LIBERO_HOME=/home/jye624/Projcets/LIBERO  # Root directory of the LIBERO project
-export LIBERO_python=/home/jye624/.conda/envs/libero/bin/python  # Path to the Python environment
-export starVLA_python=/home/jye624/.conda/envs/starVLA/bin/python  # Path to the Python environment
+#!/usr/bin/env bash
+set -euo pipefail
 
-# === End of environment variable configuration ===
-export LIBERO_CONFIG_PATH=${LIBERO_HOME}/libero  # Path to LIBERO configuration files
-export PYTHONPATH=$PYTHONPATH:${LIBERO_HOME} # let eval_libero find the LIBERO tools
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from starVLA repo
-###########################################################################################
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../../.." && pwd)}"
+LIBERO_HOME="${LIBERO_HOME:-}"
+LIBERO_python="${LIBERO_python:-python}"
+starVLA_python="${starVLA_python:-python}"
+
+if [[ -z "${LIBERO_HOME}" ]]; then
+  echo "LIBERO_HOME is required."
+  exit 1
+fi
+
+cd "${STARVLA_DIR}"
+export LIBERO_CONFIG_PATH="${LIBERO_HOME}/libero"
+export PYTHONPATH="${PYTHONPATH:-}:${LIBERO_HOME}:${STARVLA_DIR}"
 
 
 
@@ -21,7 +26,6 @@ base_port=$4 # unique port for this eval instance
 
 num_trials_per_task=50
 host="127.0.0.1"
-unnorm_key="franka"
 
 CUDA_VISIBLE_DEVICES=$gpu_id ${starVLA_python} deployment/model_server/server_policy.py \
     --ckpt_path ${your_ckpt} \
@@ -54,9 +58,6 @@ ${LIBERO_python} ./examples/LIBERO/eval_files/eval_libero.py \
     2>&1 | tee ${log_path}/${folder_name}.log
 
 echo "Evaluation completed. Videos saved to ${video_out_path}, logs saved to ${log_path}/${folder_name}.log"
-
-
-
 
 if [ -n "$server_pid" ]; then
     echo "Killing server process with PID: $server_pid"

--- a/examples/LIBERO/eval_files/eval_libero.sh
+++ b/examples/LIBERO/eval_files/eval_libero.sh
@@ -1,44 +1,37 @@
-#!/bin/bash
-# === Paths (adapted for this cluster) ===
-STARVLA_DIR=/home/jye624/Projcets/starVLA
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd ${STARVLA_DIR}
-# === Checkpoint ===
-CKPT=${STARVLA_DIR}/playground/Checkpoints/0405_libero4in1_CosmoPredict2GR00T/checkpoints/steps_50000_pytorch_model.pt
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+LIBERO_HOME="${LIBERO_HOME:-}"
+LIBERO_PYTHON="${LIBERO_PYTHON:-python}"
+CKPT="${CKPT:-${STARVLA_DIR}/playground/Checkpoints/libero_example/checkpoints/steps_50000_pytorch_model.pt}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-6694}"
+TASK_SUITE_NAME="${TASK_SUITE_NAME:-libero_goal}"
+NUM_TRIALS_PER_TASK="${NUM_TRIALS_PER_TASK:-50}"
+MUJOCO_GL_VALUE="${MUJOCO_GL_VALUE:-egl}"
+PYOPENGL_PLATFORM_VALUE="${PYOPENGL_PLATFORM_VALUE:-egl}"
 
-###########################################################################################
-# === Please modify the following paths according to your environment ===
-export LIBERO_HOME=/home/jye624/Projcets/LIBERO
-export LIBERO_CONFIG_PATH=${LIBERO_HOME}/libero
-export LIBERO_Python=/home/jye624/.conda/envs/libero/bin/python
+if [[ -z "${LIBERO_HOME}" ]]; then
+  echo "LIBERO_HOME is required."
+  echo "Example: LIBERO_HOME=/path/to/LIBERO LIBERO_PYTHON=/path/to/python bash $0"
+  exit 1
+fi
 
-export PYTHONPATH=$PYTHONPATH:${LIBERO_HOME} # let eval_libero find the LIBERO tools
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
+cd "${STARVLA_DIR}"
+export LIBERO_CONFIG_PATH="${LIBERO_HOME}/libero"
+export PYTHONPATH="${PYTHONPATH:-}:${LIBERO_HOME}:${STARVLA_DIR}"
+export MUJOCO_GL="${MUJOCO_GL_VALUE}"
+export PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM_VALUE}"
 
-export MUJOCO_GL=egl
-export PYOPENGL_PLATFORM=egl
+FOLDER_NAME="$(echo "${CKPT}" | awk -F'/' '{print $(NF-2)"_"$(NF-1)"_"$NF}')"
+MODEL_ROOT="$(echo "${CKPT}" | awk -F'/checkpoints/' '{print $1}')"
+VIDEO_OUT_PATH="${MODEL_ROOT}/results/${TASK_SUITE_NAME}/${FOLDER_NAME}"
 
-host="127.0.0.1"
-base_port=6694
-unnorm_key="franka"
-your_ckpt=${CKPT}
-
-# export DEBUG=true
-
-folder_name=$(echo "$your_ckpt" | awk -F'/' '{print $(NF-2)"_"$(NF-1)"_"$NF}')
-# model_root: playground/Checkpoints/<run_id>
-model_root=$(echo "$your_ckpt" | awk -F'/checkpoints/' '{print $1}')
-# === End of environment variable configuration ===
-###########################################################################################
-
-task_suite_name=libero_goal
-num_trials_per_task=50
-video_out_path="${model_root}/results/${task_suite_name}/${folder_name}"
-
-${LIBERO_Python} ./examples/LIBERO/eval_files/eval_libero.py \
-    --args.pretrained-path ${your_ckpt} \
-    --args.host "$host" \
-    --args.port $base_port \
-    --args.task-suite-name "$task_suite_name" \
-    --args.num-trials-per-task "$num_trials_per_task" \
-    --args.video-out-path "$video_out_path"
+"${LIBERO_PYTHON}" ./examples/LIBERO/eval_files/eval_libero.py \
+  --args.pretrained-path "${CKPT}" \
+  --args.host "${HOST}" \
+  --args.port "${PORT}" \
+  --args.task-suite-name "${TASK_SUITE_NAME}" \
+  --args.num-trials-per-task "${NUM_TRIALS_PER_TASK}" \
+  --args.video-out-path "${VIDEO_OUT_PATH}"

--- a/examples/LIBERO/eval_files/install_libero.sh
+++ b/examples/LIBERO/eval_files/install_libero.sh
@@ -1,36 +1,62 @@
-#!/bin/bash
-# Install LIBERO environment for evaluation
-set -e
+#!/usr/bin/env bash
+# Install LIBERO environment for evaluation.
+set -euo pipefail
 
-echo "=== Step 1: Activate libero conda env ==="
-eval "$(conda shell.bash hook)"
-conda activate libero
+###########################################################################################
+# Usage
+#
+#   bash examples/LIBERO/eval_files/install_libero.sh
+#
+# Optional overrides:
+#
+#   LIBERO_CONDA_ENV=libero \
+#   LIBERO_PARENT_DIR=/mnt/sda/wangbo \
+#   bash examples/LIBERO/eval_files/install_libero.sh
+#
+# Or skip conda activation and use the current Python directly:
+#
+#   SKIP_CONDA_ACTIVATE=1 bash examples/LIBERO/eval_files/install_libero.sh
+###########################################################################################
 
-echo "=== Step 2: Install mujoco ==="
-pip install mujoco==3.2.3
+LIBERO_CONDA_ENV="${LIBERO_CONDA_ENV:-libero}"
+LIBERO_PARENT_DIR="${LIBERO_PARENT_DIR:-$HOME}"
+LIBERO_DIR="${LIBERO_DIR:-${LIBERO_PARENT_DIR}/LIBERO}"
+SKIP_CONDA_ACTIVATE="${SKIP_CONDA_ACTIVATE:-0}"
 
-echo "=== Step 3: Clone and install LIBERO ==="
-LIBERO_DIR=/home/jye624/Projcets/LIBERO
-if [ ! -d "$LIBERO_DIR" ]; then
-    cd /home/jye624/Projcets
-    git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git
-    cd LIBERO
+echo "=== Step 1: Activate LIBERO Python environment ==="
+if [[ "${SKIP_CONDA_ACTIVATE}" != "1" ]]; then
+    if ! command -v conda >/dev/null 2>&1; then
+        echo "conda not found. Either initialize conda first or run with SKIP_CONDA_ACTIVATE=1."
+        exit 1
+    fi
+    eval "$(conda shell.bash hook)"
+    conda activate "${LIBERO_CONDA_ENV}"
 else
-    echo "LIBERO already cloned at $LIBERO_DIR"
-    cd $LIBERO_DIR
+    echo "Skipping conda activation; using current python: $(command -v python)"
+fi
+
+echo "=== Step 2: Install MuJoCo and eval dependencies ==="
+python -m pip install mujoco==3.2.3
+python -m pip install tyro matplotlib mediapy websockets msgpack
+python -m pip install numpy==1.24.4
+
+echo "=== Step 3: Clone LIBERO if needed ==="
+mkdir -p "${LIBERO_PARENT_DIR}"
+if [[ ! -d "${LIBERO_DIR}" ]]; then
+    git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git "${LIBERO_DIR}"
+else
+    echo "LIBERO already exists at ${LIBERO_DIR}"
 fi
 
 echo "=== Step 4: Install LIBERO (editable) ==="
-pip install -e .
+cd "${LIBERO_DIR}"
+python -m pip install -e .
 
-echo "=== Step 5: Install additional eval deps ==="
-pip install tyro matplotlib mediapy websockets msgpack
-pip install numpy==1.24.4
-
-echo "=== Step 6: Verify installation ==="
+echo "=== Step 5: Verify installation ==="
 python -c "from libero.libero import benchmark; print('LIBERO OK:', benchmark)"
 python -c "import mujoco; print('MuJoCo OK:', mujoco.__version__)"
 python -c "import tyro; print('tyro OK')"
 python -c "import websockets; print('websockets OK')"
 
 echo "=== ALL DONE ==="
+echo "LIBERO_DIR=${LIBERO_DIR}"

--- a/examples/LIBERO/eval_files/run_policy_server.sh
+++ b/examples/LIBERO/eval_files/run_policy_server.sh
@@ -1,24 +1,24 @@
-#!/bin/bash
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
-# === Paths (adapted for this cluster) ===
-STARVLA_DIR=/home/jye624/Projcets/starVLA
-LIBERO_HOME=/home/jye624/Projcets/LIBERO
-STARVLA_PYTHON=/home/jye624/.conda/envs/starVLA/bin/python
-LIBERO_PYTHON=/home/jye624/.conda/envs/libero/bin/python
+#!/usr/bin/env bash
+set -euo pipefail
 
-# === Checkpoint ===
-CKPT=${STARVLA_DIR}/playground/Pretrained_models/StarVLA/Qwen3-VL-OFT-LIBERO-4in1/checkpoints/steps_50000_pytorch_model.pt
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+STARVLA_PYTHON="${STARVLA_PYTHON:-python}"
+CKPT="${CKPT:-${STARVLA_DIR}/playground/Checkpoints/libero_example/checkpoints/steps_50000_pytorch_model.pt}"
+GPU_ID="${GPU_ID:-0}"
+PORT="${PORT:-6694}"
+USE_BF16="${USE_BF16:-1}"
 
-export star_vla_python=${STARVLA_PYTHON}
-your_ckpt=${CKPT}   
-gpu_id=0
-port=6694
-################# star Policy Server ######################
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
 
-# export DEBUG=true
-CUDA_VISIBLE_DEVICES=$gpu_id ${star_vla_python} deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${port} \
-    --use_bf16
+CMD=(
+  "${STARVLA_PYTHON}" deployment/model_server/server_policy.py
+  --ckpt_path "${CKPT}"
+  --port "${PORT}"
+)
 
-# #################################
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${GPU_ID}" "${CMD[@]}"

--- a/examples/LIBERO/train_files/starvla_cotrain_libero.yaml
+++ b/examples/LIBERO/train_files/starvla_cotrain_libero.yaml
@@ -33,7 +33,7 @@ datasets:
 
   vla_data:
     dataset_py: lerobot_datasets
-    data_root_dir: playground/Datasets/LIBERO
+    data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_all # libero_goal
     action_type: delta_qpos
     sequential_step_sampling: False

--- a/examples/RoboChallenge_table30v2/train_files/download_table30v2.sh
+++ b/examples/RoboChallenge_table30v2/train_files/download_table30v2.sh
@@ -17,8 +17,8 @@ if [[ "${CONDA_DEFAULT_ENV:-}" != "starVLA" ]]; then
   conda activate starVLA
 fi
 
-RAW_ROOT=${RAW_ROOT:-/project/vonneumann1/jye624/Datasets/RoboChallenge_table30v2/raw}
-LEROBOT_ROOT=${LEROBOT_ROOT:-/project/vonneumann1/jye624/Datasets/RoboChallenge_table30v2/lerobot}
+RAW_ROOT=${RAW_ROOT:-./playground/Datasets/RoboChallenge_table30v2/raw}
+LEROBOT_ROOT=${LEROBOT_ROOT:-./playground/Datasets/RoboChallenge_table30v2/lerobot}
 mkdir -p "${RAW_ROOT}" "${LEROBOT_ROOT}" tmp/logs
 
 # Step 1: pull the HF parts and untar to ${RAW_ROOT}/<task>/. Removes

--- a/examples/SimplerEnv/eval_files/run_policy_server.sh
+++ b/examples/SimplerEnv/eval_files/run_policy_server.sh
@@ -1,22 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
 
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+star_vla_python="${star_vla_python:-python}"
+port="${port:-6678}"
+gpu_id="${gpu_id:-0}"
+your_ckpt="${your_ckpt:-./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt}"
+USE_BF16="${USE_BF16:-1}"
 
-# Environment setup
-
-############# Environment setup #############
-cd /home/jye624/Projcets/starVLA
-export star_vla_python=/home/jye624/.conda/envs/starVLA/bin/python
-export sim_python=/home/jye624/.conda/envs/simpler_env/bin/python
-export SimplerEnv_PATH=/project/vonneumann1/jye624/Projcets/SimplerEnv
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-export LD_LIBRARY_PATH=/home/jye624/.conda/envs/simpler_env/lib:${LD_LIBRARY_PATH}
-port=6678 
-gpu_id=0
-
-your_ckpt=./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt
-
-
-
-############# End environment setup #############
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
 
 ckpt_dir=$(dirname "${your_ckpt}")
 ckpt_base=$(basename "${your_ckpt}")
@@ -25,10 +18,14 @@ output_server_dir="${ckpt_dir}/output_server"
 mkdir -p "${output_server_dir}"
 log_file="${output_server_dir}/${ckpt_name}_policy_server_${port}.log"
 
+CMD=(
+  "${star_vla_python}" deployment/model_server/server_policy.py
+  --ckpt_path "${your_ckpt}"
+  --port "${port}"
+)
 
-#### run server #####
-CUDA_VISIBLE_DEVICES=${gpu_id} ${star_vla_python} deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${port} \
-    --use_bf16 \
-    2>&1 | tee "${log_file}"
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${CMD[@]}" 2>&1 | tee "${log_file}"

--- a/examples/SimplerEnv/eval_files/start_simpler_env.sh
+++ b/examples/SimplerEnv/eval_files/start_simpler_env.sh
@@ -1,29 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo `which python`
+echo "$(which python)"
 
-
-############# Environment setup #############
-cd /home/jye624/Projcets/starVLA
-export star_vla_python=/home/jye624/.conda/envs/starVLA/bin/python
-export sim_python=/home/jye624/.conda/envs/simpler_env/bin/python
-export SimplerEnv_PATH=/project/vonneumann1/jye624/Projcets/SimplerEnv
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-export LD_LIBRARY_PATH=/home/jye624/.conda/envs/simpler_env/lib:${LD_LIBRARY_PATH}
-port=6678 
-gpu_id=0
-
-
-
-your_ckpt=./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt
-
-
-
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+sim_python="${sim_python:-python}"
+SimplerEnv_PATH="${SimplerEnv_PATH:-}"
+SIMPLER_ENV_LIB_DIR="${SIMPLER_ENV_LIB_DIR:-}"
+port="${port:-6678}"
+gpu_id="${gpu_id:-0}"
+your_ckpt="${your_ckpt:-./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt}"
 
 MODEL_PATH=${1:-"${your_ckpt}"}
 port=${2:-"${port}"}
 
-############# Environment setup #############
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
+if [[ -n "${SIMPLER_ENV_LIB_DIR}" ]]; then
+  export LD_LIBRARY_PATH="${SIMPLER_ENV_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+fi
 
 #### build output directory #####
 ckpt_path=${MODEL_PATH}

--- a/examples/VLA-Arena/eval_files/run_policy_server.sh
+++ b/examples/VLA-Arena/eval_files/run_policy_server.sh
@@ -1,21 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # run_policy_server.sh
 #
 # Launches the starVLA WebSocket policy server for VLA-Arena evaluation.
 # Run this script first, then launch eval_vla_arena.sh in a separate terminal.
 
-export PYTHONPATH=$(pwd):${PYTHONPATH}
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+starVLA_python="${starVLA_python:-python}"
+your_ckpt="${your_ckpt:-/path/to/checkpoint.pt}"
+gpu_id="${gpu_id:-0}"
+port="${port:-10090}"
+USE_BF16="${USE_BF16:-1}"
 
-###########################################################################################
-# === Please modify the following paths according to your environment ===
-export starVLA_python=python   # or: /path/to/conda/envs/starVLA/bin/python
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
 
-your_ckpt=/mnt/file2/jiachen/pr/starVLA/playground/test/qwen2.5-libero/checkpoints/steps_30000_pytorch_model.pt
-gpu_id=7
-port=1009${gpu_id}
-###########################################################################################
+CMD=(
+  "${starVLA_python}" deployment/model_server/server_policy.py
+  --ckpt_path "${your_ckpt}"
+  --port "${port}"
+)
 
-CUDA_VISIBLE_DEVICES=${gpu_id} ${starVLA_python} deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${port} \
-    --use_bf16
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${CMD[@]}"

--- a/examples/calvin/eval_files/run_policy_server.sh
+++ b/examples/calvin/eval_files/run_policy_server.sh
@@ -1,15 +1,24 @@
-#!/bin/bash
-export PYTHONPATH=$(pwd):${PYTHONPATH} # let LIBERO find the websocket tools from main repo
-export star_vla_python=/mnt/data/miniconda3/envs/starvla/bin/python
-your_ckpt=results/Checkpoints/0118_starvla_qwenpi_calvin_task_D_D/checkpoints/steps_30000_pytorch_model.pt
-gpu_id=0
-port=5694
-################# star Policy Server ######################
+#!/usr/bin/env bash
+set -euo pipefail
 
-# export DEBUG=true
-CUDA_VISIBLE_DEVICES=$gpu_id ${star_vla_python} deployment/model_server/server_policy.py \
-    --ckpt_path ${your_ckpt} \
-    --port ${port} \
-    --use_bf16
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+star_vla_python="${star_vla_python:-python}"
+your_ckpt="${your_ckpt:-results/Checkpoints/0118_starvla_qwenpi_calvin_task_D_D/checkpoints/steps_30000_pytorch_model.pt}"
+gpu_id="${gpu_id:-0}"
+port="${port:-5694}"
+USE_BF16="${USE_BF16:-1}"
 
-# #################################
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
+
+CMD=(
+  "${star_vla_python}" deployment/model_server/server_policy.py
+  --ckpt_path "${your_ckpt}"
+  --port "${port}"
+)
+
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${gpu_id}" "${CMD[@]}"


### PR DESCRIPTION
 ## Summary

  This PR fixes several path-related issues in runnable example scripts and aligns the LIBERO training config with the current documented
  dataset layout.

  ## Included fixes

  ### 1. Align LIBERO dataset root with docs and data preparation script

  `examples/LIBERO/train_files/starvla_cotrain_libero.yaml` previously used:

  ```yaml
  data_root_dir: playground/Datasets/LIBERO

  but the official guide and examples/LIBERO/data_preparation.sh prepare datasets under:

  playground/Datasets/LEROBOT_LIBERO_DATA

  This mismatch could cause users following docs/starVLA_guideline.md to hit:

  FileNotFoundError: Dataset path playground/Datasets/LIBERO/... does not exist

  ### 2. Remove hardcoded machine-specific paths from runnable example scripts

  Several example scripts contained author-local paths such as:

  - /home/...
  - .conda/envs/...
  - /mnt/...
  - Projcets/...

  These were replaced with portable patterns based on:

  - repo-root auto detection
  - environment-variable overrides
  - generic Python defaults where appropriate

  ## Scope

  Updated scripts include examples under:

  - examples/LIBERO
  - examples/LIBERO-plus
  - examples/SimplerEnv
  - examples/VLA-Arena
  - examples/calvin
  - examples/Franka
  - examples/RoboChallenge_table30v2

  ## Why

  These changes make the example entrypoints more portable and reduce failure cases for users running the repository outside the original author
  environment.