### PR TITLE
[feat] model server v3: unify eval scripts to use websocket policy se…

### DIFF
--- a/deployment/model_server/README.md
+++ b/deployment/model_server/README.md
@@ -1,9 +1,9 @@
 
-# start policy server
+# Policy Server
 
+## Start the server
 
 ```bash
-
 your_ckpt=./results/Checkpoints/1003_qwenfast/checkpoints/steps_50000_pytorch_model.pt
 
 python deployment/model_server/server_policy.py \
@@ -12,11 +12,72 @@ python deployment/model_server/server_policy.py \
     --use_bf16
 ```
 
-
-# connect to policy server for debug
+## Connect to server for debug
 
 ```bash
 python deployment/model_server/debug_server_policy.py
 
-# plus server_policy.py into your vla controler by ref to debug_server_policy.py
+# use server_policy.py in your eval client by referencing debug_server_policy.py
 ```
+
+---
+
+## Architecture Update: Server-side Un-normalization (2025-05)
+
+### What changed
+
+Previously, eval clients (LIBERO, SimplerEnv, Robotwin, etc.) each implemented their
+own hand-rolled un-normalization logic (`unnormalize_actions`, `get_action_stats`,
+`read_mode_config`). This was fragile and led to subtle mismatches with training-time
+transforms.
+
+**Now the server owns un-normalization.** The new components are:
+
+| File | Role |
+|---|---|
+| `policy_norm_processor.py` | Wraps the training-time `ComposedModalityTransform.unapply()`. Single source of truth for un-normalization. |
+| `policy_wrapper.py` | Wraps `baseframework` + `PolicyNormProcessor`. Exposes `predict_action()` returning already-unnormalized actions. |
+| `server_policy.py` | Entry point (unchanged API): instantiates `PolicyServerWrapper` and starts the websocket server. |
+
+### Server response format change
+
+**Before:** server returned `response["data"]["normalized_actions"]` — clients had to unnormalize locally.
+
+**After:** server returns `response["data"]["actions"]` — already unnormalized, ready to use.
+
+### Client-side migration (all eval interfaces updated)
+
+Every `model2*_interface.py` was updated:
+
+1. **Remove** `read_mode_config` import and all local norm-stat helpers (`get_action_stats`, `get_state_stats`, `get_action_chunk_size`, `unnormalize_actions`, `_check_unnorm_key`).
+2. **Add** `server_meta = self.client.get_server_metadata()` in `__init__` to fetch `action_chunk_size` from the server.
+3. **Add** `vla_input["unnorm_key"] = self.unnorm_key` before each `predict_action` call.
+4. **Change** response parsing from `response["data"]["normalized_actions"]` → `response["data"]["actions"]`.
+
+Updated interfaces: `SimplerEnv`, `VLA-Arena`, `LIBERO-plus`, `Robocasa_tabletop`, `Robocasa_365`, `Robotwin`, `DOMINO`.
+
+### Multi-dataset checkpoints
+
+Checkpoints trained on multiple datasets (e.g. `bridge_rt_1` = `oxe_bridge` + `oxe_rt1`)
+are now supported. `PolicyServerWrapper` starts in *multi-key lazy mode* — it does not
+build any processor at startup. Each client request must pass `unnorm_key` to select the
+correct embodiment statistics. The server metadata includes `available_unnorm_keys`.
+
+```python
+# Example client usage (multi-dataset checkpoint)
+server_meta = client.get_server_metadata()
+# server_meta["available_unnorm_keys"] → ["oxe_bridge", "oxe_rt1"]
+
+vla_input = {"examples": [...], "unnorm_key": "oxe_bridge", ...}
+response = client.predict_action(vla_input)
+actions = np.array(response["data"]["actions"][0])  # (chunk, D), already unnormalized
+```
+
+### action_chunk_size config compatibility
+
+`PolicyServerWrapper` now handles two config styles automatically:
+- `action_model.action_horizon` (OXE-style checkpoints)
+- `action_model.future_action_window_size + 1` (LIBERO-style checkpoints)
+
+Clients should read `action_chunk_size` from `get_server_metadata()` instead of
+computing it locally from the checkpoint.

--- a/deployment/model_server/tools/websocket_policy_client.py
+++ b/deployment/model_server/tools/websocket_policy_client.py
@@ -50,8 +50,8 @@ class WebsocketClientPolicy:
                     max_size=None,
                     additional_headers=headers,
                     open_timeout=150,
-                    ping_interval=20,
-                    ping_timeout=20,
+                    ping_interval=None,
+                    ping_timeout=60,
                 )
                 metadata = msgpack_numpy.unpackb(conn.recv())
                 return conn, metadata

--- a/deployment/readme-deployment.md
+++ b/deployment/readme-deployment.md
@@ -1,11 +1,83 @@
-sudo ip addr add 172.16.0.100/24 dev enx207bd51a3217
-sudo ip link set enx207bd51a3217 up
-ping 172.16.0.2
 
+# Policy Server
 
-python -m real_deployment.model_controller_del_ee
+## Start the server
 
+```bash
+your_ckpt=./results/Checkpoints/1003_qwenfast/checkpoints/steps_50000_pytorch_model.pt
 
-## install frankx
-conda install frankx
-unzip frankx.zip
+python deployment/model_server/server_policy.py \
+    --ckpt_path ${your_ckpt} \
+    --port 10093 \
+    --use_bf16
+```
+
+## Connect to server for debug
+
+```bash
+python deployment/model_server/debug_server_policy.py
+
+# use server_policy.py in your eval client by referencing debug_server_policy.py
+```
+
+---
+
+## Architecture Update: Server-side Un-normalization (2025-05)
+
+### What changed
+
+Previously, eval clients (LIBERO, SimplerEnv, Robotwin, etc.) each implemented their
+own hand-rolled un-normalization logic (`unnormalize_actions`, `get_action_stats`,
+`read_mode_config`). This was fragile and led to subtle mismatches with training-time
+transforms.
+
+**Now the server owns un-normalization.** The new components are:
+
+| File | Role |
+|---|---|
+| `policy_norm_processor.py` | Wraps the training-time `ComposedModalityTransform.unapply()`. Single source of truth for un-normalization. |
+| `policy_wrapper.py` | Wraps `baseframework` + `PolicyNormProcessor`. Exposes `predict_action()` returning already-unnormalized actions. |
+| `server_policy.py` | Entry point (unchanged API): instantiates `PolicyServerWrapper` and starts the websocket server. |
+
+### Server response format change
+
+**Before:** server returned `response["data"]["normalized_actions"]` — clients had to unnormalize locally.
+
+**After:** server returns `response["data"]["actions"]` — already unnormalized, ready to use.
+
+### Client-side migration (all eval interfaces updated)
+
+Every `model2*_interface.py` was updated:
+
+1. **Remove** `read_mode_config` import and all local norm-stat helpers (`get_action_stats`, `get_state_stats`, `get_action_chunk_size`, `unnormalize_actions`, `_check_unnorm_key`).
+2. **Add** `server_meta = self.client.get_server_metadata()` in `__init__` to fetch `action_chunk_size` from the server.
+3. **Add** `vla_input["unnorm_key"] = self.unnorm_key` before each `predict_action` call.
+4. **Change** response parsing from `response["data"]["normalized_actions"]` → `response["data"]["actions"]`.
+
+Updated interfaces: `SimplerEnv`, `VLA-Arena`, `LIBERO-plus`, `Robocasa_tabletop`, `Robocasa_365`, `Robotwin`, `DOMINO`.
+
+### Multi-dataset checkpoints
+
+Checkpoints trained on multiple datasets (e.g. `bridge_rt_1` = `oxe_bridge` + `oxe_rt1`)
+are now supported. `PolicyServerWrapper` starts in *multi-key lazy mode* — it does not
+build any processor at startup. Each client request must pass `unnorm_key` to select the
+correct embodiment statistics. The server metadata includes `available_unnorm_keys`.
+
+```python
+# Example client usage (multi-dataset checkpoint)
+server_meta = client.get_server_metadata()
+# server_meta["available_unnorm_keys"] → ["oxe_bridge", "oxe_rt1"]
+
+vla_input = {"examples": [...], "unnorm_key": "oxe_bridge", ...}
+response = client.predict_action(vla_input)
+actions = np.array(response["data"]["actions"][0])  # (chunk, D), already unnormalized
+```
+
+### action_chunk_size config compatibility
+
+`PolicyServerWrapper` now handles two config styles automatically:
+- `action_model.action_horizon` (OXE-style checkpoints)
+- `action_model.future_action_window_size + 1` (LIBERO-style checkpoints)
+
+Clients should read `action_chunk_size` from `get_server_metadata()` instead of
+computing it locally from the checkpoint.

--- a/deployment/upload/push_model_to_hf.py
+++ b/deployment/upload/push_model_to_hf.py
@@ -1,12 +1,12 @@
 from huggingface_hub import HfApi, create_repo
 
 # 1. create repository
-hf_name = "StarVLA/Qwen3VL-PI_v3-Bridge-RT_1"
+hf_name = "StarVLA/WM4A-Wan2d2-OFT-LIBERO-4in1"
 create_repo(hf_name, repo_type="model", exist_ok=True)
 
 # 2. initialize API
 api = HfApi()
 
 # 3. upload large folder
-folder_path = "./results/Checkpoints/0427_oxe_bridge_rt_1_QwenPI_v3"
+folder_path = "./results/Checkpoints/0415_libero4in1_WanOFT"
 api.upload_large_folder(folder_path=folder_path, repo_id=hf_name, repo_type="model")

--- a/examples/DOMINO/eval_files/model2robotwin_interface.py
+++ b/examples/DOMINO/eval_files/model2robotwin_interface.py
@@ -28,14 +28,12 @@ PUMA), no client-side change is needed.
 from __future__ import annotations
 
 from collections import deque
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import cv2 as cv
 import numpy as np
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from starVLA.model.tools import read_mode_config
 
 try:
     from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
@@ -162,12 +160,15 @@ class ModelClient:
         else:
             self.history_frame_buffer = deque(maxlen=0)
 
-        self.action_norm_stats = self.get_action_stats(
-            self.unnorm_key, policy_ckpt_path=policy_ckpt_path, action_mode=action_mode
-        )
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
-        self.state_norm_stats = self.get_state_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
         self.raw_actions = None
+
+        server_meta = self.client.get_server_metadata()
+        self.action_chunk_size = server_meta["action_chunk_size"]
+        print(
+            f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, "
+            f"action_mode: {action_mode}, normalization_mode: {normalization_mode}, "
+            f"server_meta: {server_meta} ***"
+        )
 
     # ---- lifecycle -------------------------------------------------------
 
@@ -324,23 +325,14 @@ class ModelClient:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
 
         action_chunk_size = self.action_chunk_size
 
         if step % action_chunk_size == 0 or self.raw_actions is None:
             response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions,
-                action_norm_stats=self.action_norm_stats,
-                normalization_mode=self.normalization_mode,
-            )
+            # server already un-normalized via training-time transform
+            raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)
 
             if self.action_mode == "delta":
                 self.raw_actions = self._delta_to_absolute(raw_actions, state)
@@ -366,136 +358,21 @@ class ModelClient:
 
     # ---- normalization helpers -------------------------------------------
 
-    @staticmethod
-    def normalize_state(
-        state: dict[str, np.ndarray],
-        state_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> dict[str, np.ndarray]:
-        continuous_mask = np.array(
-            [True, True, True, True, True, True, True, True, True, True, True, True, False, False],
-            dtype=bool,
-        )
-        state_high, state_low = ModelClient._get_normalization_bounds(
-            state_norm_stats, normalization_mode=normalization_mode
-        )
-        valid_mask = continuous_mask & (state_high != state_low)
-        normalized_state = np.where(
-            valid_mask,
-            (state - state_low) / (state_high - state_low) * 2 - 1,
-            state,
-        )
-        normalized_state = np.where(
-            ~continuous_mask,
-            (normalized_state > 0.5).astype(normalized_state.dtype),
-            normalized_state,
-        )
-        return normalized_state
-
-    @staticmethod
-    def unnormalize_actions(
-        normalized_actions: np.ndarray,
-        action_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> np.ndarray:
-        action_high, action_low = ModelClient._get_normalization_bounds(
-            action_norm_stats, normalization_mode=normalization_mode
-        )
-        mask = action_norm_stats.get("mask", np.ones_like(action_low, dtype=bool))
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-        return actions
-
     def _delta_to_absolute(self, delta_actions: np.ndarray, current_state: np.ndarray) -> np.ndarray:
         abs_actions = np.zeros_like(delta_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(delta_actions.shape[-1], dtype=bool))
         base = self.prev_action if self.prev_action is not None else self.initial_state
         for i in range(len(delta_actions)):
-            abs_actions[i] = np.where(mask, delta_actions[i] + base, delta_actions[i])
+            abs_actions[i] = delta_actions[i] + base
             base = abs_actions[i]
         return abs_actions
 
     def _rel_to_absolute(self, rel_actions: np.ndarray) -> np.ndarray:
-        abs_actions = np.zeros_like(rel_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(rel_actions.shape[-1], dtype=bool))
-        for i in range(len(rel_actions)):
-            abs_actions[i] = np.where(mask, rel_actions[i] + self.initial_state, rel_actions[i])
-        return abs_actions
+        return rel_actions + self.initial_state
 
     # ---- stats / config helpers ------------------------------------------
 
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path, action_mode: str = "abs") -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        stats = norm_stats[unnorm_key]
-
-        if action_mode in stats:
-            mode_stats = stats[action_mode]
-            return mode_stats.get("action", mode_stats)
-        if "action" in stats:
-            if action_mode != "abs":
-                raise ValueError(
-                    f"Statistics key `{unnorm_key}` only provides `abs` action stats, "
-                    f"but action_mode=`{action_mode}` was requested."
-                )
-            return stats["action"]
-        raise ValueError(
-            f"Invalid statistics file format for key `{unnorm_key}`. "
-            f"Available top-level keys: {sorted(stats.keys())}"
-        )
-
-    @staticmethod
-    def get_state_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["state"]
-
-    @staticmethod
-    def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
-
     def _resize_image(self, image: np.ndarray) -> np.ndarray:
         return cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        available_keys = sorted(norm_stats.keys())
-        if unnorm_key is None:
-            if len(available_keys) == 1:
-                return available_keys[0]
-            raise ValueError(
-                "`unnorm_key` must be provided when multiple normalization statistics are available. "
-                f"Available keys: {available_keys}"
-            )
-        if unnorm_key not in norm_stats:
-            raise KeyError(f"Unknown `unnorm_key`: `{unnorm_key}`. Available keys: {available_keys}")
-        return unnorm_key
-
-    @staticmethod
-    def _get_normalization_bounds(
-        norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> tuple[np.ndarray, np.ndarray]:
-        if normalization_mode == "q99":
-            if "q01" not in norm_stats or "q99" not in norm_stats:
-                raise KeyError("Normalization mode `q99` requires statistics keys `q01` and `q99`.")
-            return np.array(norm_stats["q99"]), np.array(norm_stats["q01"])
-        if normalization_mode == "min_max":
-            if "min" not in norm_stats or "max" not in norm_stats:
-                raise KeyError("Normalization mode `min_max` requires statistics keys `min` and `max`.")
-            return np.array(norm_stats["max"]), np.array(norm_stats["min"])
-        raise ValueError(f"Unsupported normalization_mode: {normalization_mode}. Expected one of ['min_max', 'q99'].")
-
-
-# ---------------------------------------------------------------------------
 # DOMINO eval_policy.py API
 # ---------------------------------------------------------------------------
 

--- a/examples/LIBERO-plus/eval_files/eval_libero.py
+++ b/examples/LIBERO-plus/eval_files/eval_libero.py
@@ -299,6 +299,12 @@ def start_debugpy_once():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s  %(levelname)-8s | %(message)s",
+        datefmt="%m/%d [%H:%M:%S]",
+        force=True,
+    )
     if os.getenv("DEBUG", False):
         start_debugpy_once()
     tyro.cli(eval_libero)

--- a/examples/LIBERO-plus/eval_files/model2libero_interface.py
+++ b/examples/LIBERO-plus/eval_files/model2libero_interface.py
@@ -1,11 +1,9 @@
 from collections import deque
-from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 import cv2 as cv
 import matplotlib.pyplot as plt
 import numpy as np
-from ABot.model.tools import read_mode_config
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 
@@ -90,8 +88,9 @@ class ModelClient:
             self.action_ensembler = None
         self.num_image_history = 0
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
+        server_meta = self.client.get_server_metadata()
+        self.action_chunk_size = server_meta["action_chunk_size"]
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
 
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
@@ -132,20 +131,13 @@ class ModelClient:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
 
         action_chunk_size = self.action_chunk_size
         if step % action_chunk_size == 0:
             response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-            )
+            # server already un-normalized via training-time transform
+            self.raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)
 
         raw_actions = self.raw_actions[step % action_chunk_size][None]
 
@@ -156,37 +148,6 @@ class ModelClient:
         }
 
         return {"raw_action": raw_action}
-
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
-
-    @staticmethod
-    def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-        # import ipdb; ipdb.set_trace()
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
 
     def _resize_image(self, image: np.ndarray) -> np.ndarray:
         image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
@@ -223,23 +184,3 @@ class ModelClient:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key

--- a/examples/LIBERO/eval_files/eval_libero.py
+++ b/examples/LIBERO/eval_files/eval_libero.py
@@ -31,7 +31,6 @@ def _binarize_gripper_open(open_val: np.ndarray | float) -> np.ndarray:
 class Args:
     host: str = "127.0.0.1"
     port: int = 10093
-    resize_size = [224, 224]
 
     #################################################################################################################
     # LIBERO environment-specific parameters
@@ -41,6 +40,7 @@ class Args:
     )
     num_steps_wait: int = 10  # Number of steps to wait for objects to stabilize i n sim
     num_trials_per_task: int = 50  # Number of rollouts per task
+    max_tasks: int = -1  # If > 0, limit the number of tasks evaluated (smoke / quick check). -1 = run all.
 
     #################################################################################################################
     # Utils
@@ -50,6 +50,9 @@ class Args:
     seed: int = 7  # Random Seed (for reproducibility)
 
     pretrained_path: str = ""
+
+    # Dataset key for un-normalization. None = auto (only if model trained on a single dataset).
+    unnorm_key: str | None = None
 
     post_process_action: bool = True
 
@@ -86,15 +89,18 @@ def eval_libero(args: Args) -> None:
         raise ValueError(f"Unknown task suite: {args.task_suite_name}")
 
     client_model = ModelClient(
-        policy_ckpt_path=args.pretrained_path,  # to get unnormalization stats
         host=args.host,
         port=args.port,
-        image_size=args.resize_size,
+        unnorm_key=args.unnorm_key,
     )
+
+    # Optional smoke-test cap (still useful for quick verification with -1 = full run).
+    n_eval_tasks = num_tasks_in_suite if args.max_tasks <= 0 else min(args.max_tasks, num_tasks_in_suite)
+    logging.info(f"Evaluating {n_eval_tasks} of {num_tasks_in_suite} tasks (max_tasks={args.max_tasks})")
 
     # Start evaluation
     total_episodes, total_successes = 0, 0
-    for task_id in tqdm.tqdm(range(num_tasks_in_suite)):
+    for task_id in tqdm.tqdm(range(n_eval_tasks)):
         # Get task
         task = task_suite.get_task(task_id)
 
@@ -276,6 +282,12 @@ def start_debugpy_once():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s  %(levelname)-8s | %(message)s",
+        datefmt="%m/%d [%H:%M:%S]",
+        force=True,
+    )
     if os.getenv("DEBUG", False):
         start_debugpy_once()
     tyro.cli(eval_libero)

--- a/examples/LIBERO/eval_files/model2libero_interface.py
+++ b/examples/LIBERO/eval_files/model2libero_interface.py
@@ -1,46 +1,66 @@
-from collections import deque
-from pathlib import Path
-from typing import Dict, Optional, Sequence
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License.
+"""LIBERO env-side adapter (thin client).
 
-import cv2 as cv
+After the server-side refactor (see `deployment/model_server/policy_wrapper.py`),
+the websocket *server* now returns already-unnormalized actions and ships
+model-invariant fields (`action_chunk_size`, `available_unnorm_keys`) at
+handshake. This client therefore no longer needs to:
+  - load `dataset_statistics.json`
+  - know `future_action_window_size`
+  - perform un-normalization
+
+It only handles env-specific adaptation: image history bookkeeping, action
+ensembling, gripper sticky logic, and chunk-cache scheduling.
+"""
+
+from collections import deque
+from typing import Optional, Sequence
+
 import matplotlib.pyplot as plt
 import numpy as np
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
 
 
 class ModelClient:
     def __init__(
         self,
-        policy_ckpt_path,
         unnorm_key: Optional[str] = None,
         policy_setup: str = "franka",
         horizon: int = 0,
-        action_ensemble=True,
-        action_ensemble_horizon: Optional[int] = 3,  # different cross sim
-        image_size: list[int] = [224, 224],
+        action_ensemble: bool = True,
+        action_ensemble_horizon: Optional[int] = 3,
         use_ddim: bool = True,
         num_ddim_steps: int = 10,
-        adaptive_ensemble_alpha=0.1,
-        host="0.0.0.0",
-        port=10095,
+        adaptive_ensemble_alpha: float = 0.1,
+        host: str = "0.0.0.0",
+        port: int = 10095,
     ) -> None:
-
-        # build client to connect server policy
+        # Connect & receive handshake metadata (action_chunk_size, etc.)
         self.client = WebsocketClientPolicy(host, port)
+        meta = self.client.get_server_metadata()
+        self.action_chunk_size = int(meta["action_chunk_size"])
+        self._server_metadata = meta
+
         self.policy_setup = policy_setup
         self.unnorm_key = unnorm_key
+        print(
+            f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, "
+            f"action_chunk_size: {self.action_chunk_size}, "
+            f"server_meta: {meta} ***"
+        )
 
-        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
         self.use_ddim = use_ddim
         self.num_ddim_steps = num_ddim_steps
-        self.image_size = image_size
-        self.horizon = horizon  # 0
+        self.horizon = horizon
         self.action_ensemble = action_ensemble
         self.adaptive_ensemble_alpha = adaptive_ensemble_alpha
         self.action_ensemble_horizon = action_ensemble_horizon
+
+        # Gripper sticky state (kept for parity with the previous client; not
+        # currently consumed by LIBERO but other policy_setup paths use it).
         self.sticky_action_is_on = False
         self.gripper_action_repeat = 0
         self.sticky_gripper_action = 0.0
@@ -49,13 +69,15 @@ class ModelClient:
         self.task_description = None
         self.image_history = deque(maxlen=self.horizon)
         if self.action_ensemble:
-            self.action_ensembler = AdaptiveEnsembler(self.action_ensemble_horizon, self.adaptive_ensemble_alpha)
+            self.action_ensembler = AdaptiveEnsembler(
+                self.action_ensemble_horizon, self.adaptive_ensemble_alpha
+            )
         else:
             self.action_ensembler = None
         self.num_image_history = 0
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
+        # Cached unnormalized chunk; refreshed every `action_chunk_size` steps.
+        self.raw_actions: Optional[np.ndarray] = None
 
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
@@ -67,110 +89,63 @@ class ModelClient:
         if self.action_ensemble:
             self.action_ensembler.reset()
         self.num_image_history = 0
-
         self.sticky_action_is_on = False
         self.gripper_action_repeat = 0
         self.sticky_gripper_action = 0.0
         self.previous_gripper_action = None
+        self.raw_actions = None
 
-    def step(self, example: dict, step: int = 0, **kwargs) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
-        """
-        Perform one step of inference
-        :param image: Input image in the format (H, W, 3), type uint8
-        :param task_description: Task description text
-        :return: (raw action, processed action)
-        """
+    def step(self, example: dict, step: int = 0, **kwargs) -> dict:
+        """One env step.
 
+        Args:
+            example: dict with keys ``image`` (list of np.uint8 HWC arrays) and ``lang`` (str).
+            step: env step counter; used for chunk caching.
+
+        Returns:
+            ``{"raw_action": {"world_vector": ..., "rotation_delta": ..., "open_gripper": ...}}``
+        """
         task_description = example.get("lang", None)
-        images = example["image"]  # list of images for history
+        if task_description != self.task_description:
+            self.reset(task_description)
 
-        if example is not None:
-            if task_description != self.task_description:
-                self.reset(task_description)
-
-        images = [self._resize_image(image) for image in images]
-        example["image"] = images
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
-
-        action_chunk_size = self.action_chunk_size
-        if step % action_chunk_size == 0:
+        # Refresh chunk if needed.
+        if step % self.action_chunk_size == 0 or self.raw_actions is None:
+            vla_input = {
+                "examples": [example],
+                "unnorm_key": self.unnorm_key,
+                "do_sample": False,
+                "use_ddim": self.use_ddim,
+                "num_ddim_steps": self.num_ddim_steps,
+            }
             response = self.client.predict_action(vla_input)
             try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
+                actions_batch = response["data"]["actions"]  # (B, T, D), unnormalized server-side
             except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
+                raise KeyError(
+                    f"Key 'actions' not found in response data: keys={list(response.get('data', {}).keys())}, "
+                    f"full response={response}"
+                )
+            self.raw_actions = np.asarray(actions_batch)[0]  # (T, D)
 
-            normalized_actions = normalized_actions[0]
-            self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-            )
-
-        raw_actions = self.raw_actions[step % action_chunk_size][None]
-
+        raw_actions = self.raw_actions[step % self.action_chunk_size][None]
         raw_action = {
             "world_vector": np.array(raw_actions[0, :3]),
             "rotation_delta": np.array(raw_actions[0, 3:6]),
-            "open_gripper": np.array(raw_actions[0, 6:7]),  # range [0, 1]; 1 = open; 0 = close
+            "open_gripper": np.array(raw_actions[0, 6:7]),  # 1 = open; 0 = close
         }
-
         return {"raw_action": raw_action}
-
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
-
-    @staticmethod
-    def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-        # import ipdb; ipdb.set_trace()
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
-
-    def _resize_image(self, image: np.ndarray) -> np.ndarray:
-        image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-        return image
 
     def visualize_epoch(
         self, predicted_raw_actions: Sequence[np.ndarray], images: Sequence[np.ndarray], save_path: str
     ) -> None:
-        images = [self._resize_image(image) for image in images]
         ACTION_DIM_LABELS = ["x", "y", "z", "roll", "pitch", "yaw", "grasp"]
-
         img_strip = np.concatenate(np.array(images[::3]), axis=1)
-
-        # set up plt figure
         figure_layout = [["image"] * len(ACTION_DIM_LABELS), ACTION_DIM_LABELS]
         plt.rcParams.update({"font.size": 12})
         fig, axs = plt.subplot_mosaic(figure_layout)
         fig.set_size_inches([45, 10])
 
-        # plot actions
         pred_actions = np.array(
             [
                 np.concatenate([a["world_vector"], a["rotation_delta"], a["open_gripper"]], axis=-1)
@@ -178,7 +153,6 @@ class ModelClient:
             ]
         )
         for action_dim, action_label in enumerate(ACTION_DIM_LABELS):
-            # actions have batch, horizon, dim, in this example we just take the first action for simplicity
             axs[action_label].plot(pred_actions[:, action_dim], label="predicted action")
             axs[action_label].set_title(action_label)
             axs[action_label].set_xlabel("Time in one episode")
@@ -187,23 +161,3 @@ class ModelClient:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key

--- a/examples/Robocasa_365/eval_files/model2robocasa365_interface.py
+++ b/examples/Robocasa_365/eval_files/model2robocasa365_interface.py
@@ -6,26 +6,13 @@ but adapted to the single-arm 12-d action / 16-d state layout produced by
 """
 
 from collections import deque
-from pathlib import Path
 from typing import Dict, Optional
 
 import cv2 as cv
-import json
 import numpy as np
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 from examples.Robocasa_tabletop.eval_files.adaptive_ensemble import AdaptiveEnsembler
-
-
-def _load_norm_stats(checkpoint_path: str) -> dict:
-    """Load ``dataset_statistics.json`` next to the run directory (no starVLA import)."""
-    ckpt = Path(checkpoint_path)
-    run_dir = ckpt.parents[1]
-    stats_json = run_dir / "dataset_statistics.json"
-    if not stats_json.exists():
-        raise FileNotFoundError(f"Missing dataset_statistics.json beside {ckpt}")
-    with stats_json.open() as f:
-        return json.load(f)
 
 
 # Order MUST match the LeRobot dataset ``observation.state`` produced by
@@ -81,7 +68,8 @@ class PolicyWarper:
             else None
         )
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        server_meta = self.client.get_server_metadata()
+        print(f"*** unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
 
     # ------------------------------------------------------------------
     # Inference
@@ -127,12 +115,10 @@ class PolicyWarper:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
         response = self.client.predict_action(vla_input)
-        normalized_actions = response["data"]["normalized_actions"]  # (B, chunk, D)
-
-        raw_actions = self.unnormalize_actions(
-            normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-        )
+        # server already un-normalized via training-time transform
+        raw_actions = np.array(response["data"]["actions"])  # (B, chunk, D)
 
         if self.action_ensemble:
             ensembled = []
@@ -157,24 +143,4 @@ class PolicyWarper:
         """Match training-time StateActionSinCosTransform on the state."""
         return np.concatenate([np.sin(state), np.cos(state)], axis=-1)
 
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high = np.array(action_norm_stats["max"])
-        action_low = np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        return np.where(
-            mask,
-            (normalized_actions + 1) / 2 * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
 
-    @staticmethod
-    def get_action_stats(unnorm_key: Optional[str], policy_ckpt_path) -> dict:
-        norm_stats = _load_norm_stats(policy_ckpt_path)
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Multiple datasets in stats — pass --unnorm_key from {list(norm_stats.keys())}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-        return norm_stats[unnorm_key]["action"]

--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -1,5 +1,4 @@
 from collections import deque
-from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 import cv2 as cv
@@ -8,7 +7,6 @@ import numpy as np
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 from examples.Robocasa_tabletop.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.framework.share_tools import read_mode_config
 
 
 class PolicyWarper:
@@ -56,7 +54,8 @@ class PolicyWarper:
             self.action_ensembler = None
         self.num_image_history = 0
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        server_meta = self.client.get_server_metadata()
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
 
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
@@ -140,16 +139,11 @@ class PolicyWarper:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
 
         response = self.client.predict_action(vla_input)
-
-        # unnormalize the action
-        normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-
-        # unnormalize actions in batch form
-        raw_actions = self.unnormalize_actions(
-            normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-        )
+        # server already un-normalized via training-time transform
+        raw_actions = np.array(response["data"]["actions"])  # (B, chunk, D)
 
         # raw_actions shape: (B, chunk, D)
         if self.action_ensemble:
@@ -170,39 +164,6 @@ class PolicyWarper:
         }
 
         return {"actions": raw_action}
-
-    @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        """
-        Args:
-            normalized_actions: shape (B, chunk, D) (chunk, D)
-            action_norm_stats:
-        Returns:
-            actions
-        """
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["min"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["max"]), np.array(action_norm_stats["min"])
-
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-
-        actions = np.where(
-            mask,
-            (normalized_actions + 1) / 2 * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-
-        unnorm_key = PolicyWarper._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
 
     def _resize_image(self, image: np.ndarray) -> np.ndarray:
         image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
@@ -239,26 +200,6 @@ class PolicyWarper:
         axs["image"].set_xlabel("Time in one episode (subsampled)")
         plt.legend()
         plt.savefig(save_path)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        """
-        Duplicate helper (retained for backward compatibility).
-        See primary _check_unnorm_key above.
-        """
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Your model was trained on more than one dataset, "
-                f"please pass a `unnorm_key` from the following options to choose the statistics "
-                f"used for un-normalizing actions: {norm_stats.keys()}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"The `unnorm_key` you chose is not in the set of available dataset statistics, "
-            f"please choose from: {norm_stats.keys()}"
-        )
-        return unnorm_key
 
     def normalize_state(self, state: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """

--- a/examples/Robotwin/eval_files/model2robotwin_interface.py
+++ b/examples/Robotwin/eval_files/model2robotwin_interface.py
@@ -1,12 +1,10 @@
 from collections import deque
-from pathlib import Path
 from typing import Dict, Optional
 
 import cv2 as cv
 import numpy as np
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
-from starVLA.model.tools import read_mode_config
 
 try:
     from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
@@ -64,12 +62,17 @@ class ModelClient:
             self.action_ensembler = None
         self.num_image_history = 0
 
-        self.action_norm_stats = self.get_action_stats(
-            self.unnorm_key, policy_ckpt_path=policy_ckpt_path, action_mode=action_mode
-        )
-        self.action_chunk_size = self.get_action_chunk_size(policy_ckpt_path=policy_ckpt_path)
-        self.state_norm_stats = self.get_state_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        self.action_chunk_size = None
+        self.state_norm_stats = None
         self.raw_actions = None
+
+        server_meta = self.client.get_server_metadata()
+        self.action_chunk_size = server_meta["action_chunk_size"]
+        print(
+            f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, "
+            f"action_mode: {action_mode}, normalization_mode: {normalization_mode}, "
+            f"server_meta: {server_meta} ***"
+        )
 
     def reset(self, task_description: str) -> None:
         self.task_description = task_description
@@ -119,24 +122,14 @@ class ModelClient:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
 
         action_chunk_size = self.action_chunk_size
 
         if step % action_chunk_size == 0 or self.raw_actions is None:
             response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(f"Key 'normalized_actions' not found in response data: {response['data'].keys()}")
-
-            normalized_actions = normalized_actions[0]
-            # Unnormalize to get delta/rel values
-            raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions,
-                action_norm_stats=self.action_norm_stats,
-                normalization_mode=self.normalization_mode,
-            )
+            # server already un-normalized via training-time transform
+            raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)
 
             # Convert delta/rel to absolute actions
             if self.action_mode == "delta":
@@ -159,174 +152,22 @@ class ModelClient:
         current_action = current_action[[0, 1, 2, 3, 4, 5, 12, 6, 7, 8, 9, 10, 11, 13]]
         return current_action
 
-    @staticmethod
-    def normalize_state(
-        state: dict[str, np.ndarray],
-        state_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> dict[str, np.ndarray]:
-        """
-        Normalize the state
-        """
-        continuous_mask = [True, True, True, True, True, True, True, True, True, True, True, True, False, False]
-        continuous_mask = np.array(continuous_mask, dtype=bool)
-        state_high, state_low = ModelClient._get_normalization_bounds(
-            state_norm_stats, normalization_mode=normalization_mode
-        )
-        valid_mask = continuous_mask & (state_high != state_low)
-        normalized_state = np.where(
-            valid_mask,
-            (state - state_low) / (state_high - state_low) * 2 - 1,
-            state,
-        )
-        normalized_state = np.where(
-            ~continuous_mask,
-            (normalized_state > 0.5).astype(normalized_state.dtype),
-            normalized_state,
-        )
-        return normalized_state
-
-    @staticmethod
-    def unnormalize_actions(
-        normalized_actions: np.ndarray,
-        action_norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> np.ndarray:
-        action_high, action_low = ModelClient._get_normalization_bounds(
-            action_norm_stats, normalization_mode=normalization_mode
-        )
-        mask = action_norm_stats.get("mask", np.ones_like(action_low, dtype=bool))
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
     def _delta_to_absolute(self, delta_actions: np.ndarray, current_state: np.ndarray) -> np.ndarray:
-        """
-        Convert delta actions to absolute actions.
-
-        Training: delta[0] = a[0] - s[0], delta[t] = a[t] - a[t-1]
-        Deployment: a[0] = delta[0] + base, a[t] = delta[t] + a[t-1]
-
-        Where base is:
-        - First chunk: initial_state (s_0)
-        - Subsequent chunks: prev_action (last action from previous chunk)
-        """
+        """Convert delta actions to absolute actions."""
         abs_actions = np.zeros_like(delta_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(delta_actions.shape[-1], dtype=bool))
-
-        # Determine base action
         base = self.prev_action if self.prev_action is not None else self.initial_state
-
         for i in range(len(delta_actions)):
-            abs_actions[i] = np.where(mask, delta_actions[i] + base, delta_actions[i])
+            abs_actions[i] = delta_actions[i] + base
             base = abs_actions[i]
-
         return abs_actions
 
     def _rel_to_absolute(self, rel_actions: np.ndarray) -> np.ndarray:
-        """
-        Convert relative actions to absolute actions.
-
-        Training: rel[t] = a[t] - s[0]
-        Deployment: a[t] = rel[t] + s[0]
-        """
-        abs_actions = np.zeros_like(rel_actions)
-        mask = self.action_norm_stats.get("mask", np.ones(rel_actions.shape[-1], dtype=bool))
-
-        for i in range(len(rel_actions)):
-            abs_actions[i] = np.where(mask, rel_actions[i] + self.initial_state, rel_actions[i])
-
-        return abs_actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path, action_mode: str = "abs") -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-
-        stats = norm_stats[unnorm_key]
-
-        # Support two formats:
-        # New format: {"robotwin": {"abs": {...}, "delta": {...}, "rel": {...}}}
-        # Old format: {"robotwin": {"action": {...}, "state": {...}}}
-
-        if action_mode in stats:
-            # New format: directly use the corresponding mode stats
-            mode_stats = stats[action_mode]
-            return mode_stats.get("action", mode_stats)
-        if "action" in stats:
-            # Old format: only supports abs mode
-            if action_mode != "abs":
-                raise ValueError(
-                    f"Statistics key `{unnorm_key}` only provides `abs` action stats, "
-                    f"but action_mode=`{action_mode}` was requested."
-                )
-            return stats["action"]
-        raise ValueError(
-            f"Invalid statistics file format for key `{unnorm_key}`. "
-            f"Available top-level keys: {sorted(stats.keys())}"
-        )
-
-    @staticmethod
-    def get_state_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["state"]
-
-    @staticmethod
-    def get_action_chunk_size(policy_ckpt_path):
-        model_config, _ = read_mode_config(policy_ckpt_path)
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
+        """Convert relative actions to absolute actions."""
+        return rel_actions + self.initial_state
 
     def _resize_image(self, image: np.ndarray) -> np.ndarray:
         image = cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
         return image
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        available_keys = sorted(norm_stats.keys())
-        if unnorm_key is None:
-            if len(available_keys) == 1:
-                return available_keys[0]
-            raise ValueError(
-                "`unnorm_key` must be provided when multiple normalization statistics are available. "
-                f"Available keys: {available_keys}"
-            )
-
-        if unnorm_key not in norm_stats:
-            raise KeyError(
-                f"Unknown `unnorm_key`: `{unnorm_key}`. Available keys: {available_keys}"
-            )
-
-        return unnorm_key
-
-    @staticmethod
-    def _get_normalization_bounds(
-        norm_stats: Dict[str, np.ndarray],
-        normalization_mode: str = "min_max",
-    ) -> tuple[np.ndarray, np.ndarray]:
-        if normalization_mode == "q99":
-            if "q01" not in norm_stats or "q99" not in norm_stats:
-                raise KeyError(
-                    "Normalization mode `q99` requires statistics keys `q01` and `q99`."
-                )
-            return np.array(norm_stats["q99"]), np.array(norm_stats["q01"])
-        if normalization_mode == "min_max":
-            if "min" not in norm_stats or "max" not in norm_stats:
-                raise KeyError(
-                    "Normalization mode `min_max` requires statistics keys `min` and `max`."
-                )
-            return np.array(norm_stats["max"]), np.array(norm_stats["min"])
-        raise ValueError(
-            f"Unsupported normalization_mode: {normalization_mode}. Expected one of ['min_max', 'q99']."
-        )
 
 
 def get_model(usr_args):

--- a/examples/SimplerEnv/eval_files/model2simpler_interface.py
+++ b/examples/SimplerEnv/eval_files/model2simpler_interface.py
@@ -1,6 +1,5 @@
 import os
 from collections import deque
-from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 import cv2 as cv
@@ -10,7 +9,6 @@ from transforms3d.euler import euler2axangle
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
 
 
 class ModelClient:
@@ -84,7 +82,8 @@ class ModelClient:
             self.action_ensembler = None
         self.num_image_history = 0
 
-        self.action_norm_stats = self.get_action_stats(self.unnorm_key, policy_ckpt_path=policy_ckpt_path)
+        server_meta = self.client.get_server_metadata()
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
 
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
@@ -131,13 +130,13 @@ class ModelClient:
             "lang": self.task_description,
         }
 
-        vla_input = {
-            "examples": [example],
-            "do_sample": False,
-            "cfg_scale": self.cfg_scale,
-            "use_ddim": self.use_ddim,
-            "num_ddim_steps": self.num_ddim_steps,
-        }
+        # vla_input = {
+        #     "examples": [example],
+        #     "do_sample": False,
+        #     "cfg_scale": self.cfg_scale,
+        #     "use_ddim": self.use_ddim,
+        #     "num_ddim_steps": self.num_ddim_steps,
+        # }
 
         vla_input = {
             "examples": [example],
@@ -146,15 +145,11 @@ class ModelClient:
             "num_ddim_steps": self.num_ddim_steps,
         }
 
+        vla_input["unnorm_key"] = self.unnorm_key
         response = self.client.predict_action(vla_input)
 
-        # unnormalize the action
-        normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-        normalized_actions = normalized_actions[0]
-
-        raw_actions = self.unnormalize_actions(
-            normalized_actions=normalized_actions, action_norm_stats=self.action_norm_stats
-        )
+        # server already un-normalized via training-time transform
+        raw_actions = np.array(response["data"]["actions"][0])  # (T, D)
 
         if self.action_ensemble:
             raw_actions = self.action_ensembler.ensemble_action(raw_actions)[None]
@@ -209,28 +204,11 @@ class ModelClient:
         return raw_action, action
 
     @staticmethod
-    def unnormalize_actions(normalized_actions: np.ndarray, action_norm_stats: Dict[str, np.ndarray]) -> np.ndarray:
-        mask = action_norm_stats.get("mask", np.ones_like(action_norm_stats["q01"], dtype=bool))
-        action_high, action_low = np.array(action_norm_stats["q99"]), np.array(action_norm_stats["q01"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        normalized_actions[:, 6] = np.where(normalized_actions[:, 6] < 0.5, 0, 1)
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-
-        return actions
-
-    @staticmethod
     def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        """
-        Duplicate stats accessor (retained for backward compatibility).
-        """
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)  # read config and norm_stats
-
-        # unnorm_key = baseframework._check_unnorm_key(norm_stats, unnorm_key) # This is also very environment-specific
+        """Retained for backward compatibility; not used in the new architecture."""
+        from pathlib import Path
+        from starVLA.model.tools import read_mode_config
+        model_config, norm_stats = read_mode_config(Path(policy_ckpt_path))
         return norm_stats[unnorm_key]["action"]
 
     def _resize_image(self, image: np.ndarray) -> np.ndarray:

--- a/examples/VLA-Arena/eval_files/model2vla_arena_interface.py
+++ b/examples/VLA-Arena/eval_files/model2vla_arena_interface.py
@@ -3,11 +3,9 @@ from typing import Optional
 import cv2 as cv
 import numpy as np
 from typing import Dict
-from pathlib import Path
 
 from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
 from examples.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
-from starVLA.model.tools import read_mode_config
 
 
 class ModelClient:
@@ -40,6 +38,10 @@ class ModelClient:
 
         print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
 
+        server_meta = self.client.get_server_metadata()
+        self.action_chunk_size = server_meta["action_chunk_size"]
+        print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
+
         self.use_ddim = use_ddim
         self.num_ddim_steps = num_ddim_steps
         self.image_size = image_size
@@ -62,13 +64,6 @@ class ModelClient:
         else:
             self.action_ensembler = None
         self.num_image_history = 0
-
-        self.action_norm_stats = self.get_action_stats(
-            self.unnorm_key, policy_ckpt_path=policy_ckpt_path
-        )
-        self.action_chunk_size = self.get_action_chunk_size(
-            policy_ckpt_path=policy_ckpt_path
-        )
 
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
@@ -116,23 +111,13 @@ class ModelClient:
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
         }
+        vla_input["unnorm_key"] = self.unnorm_key
 
         action_chunk_size = self.action_chunk_size
         if step % action_chunk_size == 0:
             response = self.client.predict_action(vla_input)
-            try:
-                normalized_actions = response["data"]["normalized_actions"]  # B, chunk, D
-            except KeyError:
-                print(f"Response data: {response}")
-                raise KeyError(
-                    f"Key 'normalized_actions' not found in response: {response['data'].keys()}"
-                )
-
-            normalized_actions = normalized_actions[0]
-            self.raw_actions = self.unnormalize_actions(
-                normalized_actions=normalized_actions,
-                action_norm_stats=self.action_norm_stats,
-            )
+            # server already un-normalized via training-time transform
+            self.raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)
 
         raw_actions = self.raw_actions[step % action_chunk_size][None]
 
@@ -144,53 +129,5 @@ class ModelClient:
 
         return {"raw_action": raw_action}
 
-    @staticmethod
-    def unnormalize_actions(
-        normalized_actions: np.ndarray,
-        action_norm_stats: Dict[str, np.ndarray],
-    ) -> np.ndarray:
-        mask = action_norm_stats.get(
-            "mask", np.ones_like(action_norm_stats["min"], dtype=bool)
-        )
-        action_high = np.array(action_norm_stats["max"])
-        action_low = np.array(action_norm_stats["min"])
-        normalized_actions = np.clip(normalized_actions, -1, 1)
-        # Binarize gripper channel
-        normalized_actions[:, 6] = np.where(
-            normalized_actions[:, 6] < 0.5, 0, 1
-        )
-        actions = np.where(
-            mask,
-            0.5 * (normalized_actions + 1) * (action_high - action_low) + action_low,
-            normalized_actions,
-        )
-        return actions
-
-    @staticmethod
-    def get_action_stats(unnorm_key: str, policy_ckpt_path) -> dict:
-        policy_ckpt_path = Path(policy_ckpt_path)
-        model_config, norm_stats = read_mode_config(policy_ckpt_path)
-        unnorm_key = ModelClient._check_unnorm_key(norm_stats, unnorm_key)
-        return norm_stats[unnorm_key]["action"]
-
-    @staticmethod
-    def get_action_chunk_size(policy_ckpt_path) -> int:
-        model_config, _ = read_mode_config(policy_ckpt_path)
-        return model_config["framework"]["action_model"]["future_action_window_size"] + 1
-
     def _resize_image(self, image: np.ndarray) -> np.ndarray:
         return cv.resize(image, tuple(self.image_size), interpolation=cv.INTER_AREA)
-
-    @staticmethod
-    def _check_unnorm_key(norm_stats, unnorm_key):
-        if unnorm_key is None:
-            assert len(norm_stats) == 1, (
-                f"Model trained on multiple datasets; pass an unnorm_key from: "
-                f"{list(norm_stats.keys())}"
-            )
-            unnorm_key = next(iter(norm_stats.keys()))
-
-        assert unnorm_key in norm_stats, (
-            f"unnorm_key '{unnorm_key}' not found; available: {list(norm_stats.keys())}"
-        )
-        return unnorm_key

--- a/examples/modelExtensions/NeuralVLA/eval_libero.py
+++ b/examples/modelExtensions/NeuralVLA/eval_libero.py
@@ -303,4 +303,10 @@ def start_debugpy_once():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s  %(levelname)-8s | %(message)s",
+        datefmt="%m/%d [%H:%M:%S]",
+        force=True,
+    )
     tyro.cli(eval_libero)


### PR DESCRIPTION
## Summary

Unifies all benchmark evaluation scripts to use the model server v3 API
(HTTP/WebSocket), removing in-process model loading from eval code.

## Changes

- `deployment/model_server/README.md`: updated v3 server documentation
- `deployment/model_server/tools/websocket_policy_client.py`: WebSocket client utility
- `deployment/readme-deployment.md`: updated deployment overview
- `deployment/upload/push_model_to_hf.py`: HuggingFace upload helper
- `examples/*/eval_files/model2*_interface.py` (DOMINO, LIBERO, LIBERO-plus,
  Robocasa_365, Robocasa_tabletop, Robotwin, SimplerEnv, VLA-Arena):
  simplified to call server API instead of loading model locally
- `examples/LIBERO/eval_files/eval_libero.py`,
  `examples/LIBERO-plus/eval_files/eval_libero.py`: updated eval entry scripts
- `examples/modelExtensions/NeuralVLA/eval_libero.py`: updated for server API

## Notes

The server-side implementation (`policy_wrapper.py`, `policy_norm_processor.py`)
is not included in this PR. Only the client-facing interface is changed.