### PR TITLE
[feat] dataloader and framework improvements

### DIFF
--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -39,13 +39,20 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
         from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
         vla_dataset_cfg = cfg.datasets.vla_data
 
-        vla_dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
+        vla_dataset = get_vla_dataset(
+            data_cfg=vla_dataset_cfg,
+            balance_dataset_weights=vla_dataset_cfg.get("balance_dataset_weights", False),
+            balance_trajectory_weights=vla_dataset_cfg.get("balance_trajectory_weights", False),
+        )
         
         vla_train_dataloader = DataLoader(
             vla_dataset,
             batch_size=cfg.datasets.vla_data.per_device_batch_size,
             collate_fn=collate_fn,
-            num_workers=4,
+            num_workers=16,
+            pin_memory=True,
+            persistent_workers=True,
+            prefetch_factor=4,
             # shuffle=True
         )        
         if dist.get_rank() == 0: 

--- a/starVLA/dataloader/gr00t_lerobot/data_config.py
+++ b/starVLA/dataloader/gr00t_lerobot/data_config.py
@@ -6,6 +6,7 @@
 from abc import ABC, abstractmethod
 
 from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform, ModalityTransform
 from starVLA.dataloader.gr00t_lerobot.transform.concat import ConcatTransform
 from starVLA.dataloader.gr00t_lerobot.transform.state_action import (
@@ -36,6 +37,7 @@ class BaseDataConfig(ABC):
 ###########################################################################################
 
 class OxeDroidDataConfig:
+    embodiment_tag = EmbodimentTag.OXE_DROID
     video_keys = [
         "video.exterior_image_1",
         "video.exterior_image_2",
@@ -136,6 +138,7 @@ class OxeDroidDataConfig:
 
 
 class OxeBridgeDataConfig:
+    embodiment_tag = EmbodimentTag.OXE_BRIDGE
     video_keys = [
         "video.image_0",
     ]
@@ -250,6 +253,7 @@ class OxeBridgeDataConfig:
 ###########################################################################################
 
 class OxeRT1DataConfig:
+    embodiment_tag = EmbodimentTag.OXE_RT1
     video_keys = [
         "video.image",
     ]
@@ -365,6 +369,7 @@ class OxeRT1DataConfig:
 
 
 class SingleFrankaRobotiqDeltaEefDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = [
         "video.base_view",
         "video.ego_view",
@@ -436,6 +441,7 @@ class SingleFrankaRobotiqDeltaEefDataConfig:
 ###########################################################################################
 
 class Libero4in1DataConfig:
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = [
         "video.primary_image",
         "video.wrist_image",
@@ -515,6 +521,7 @@ class Libero4in1DataConfig:
 
 
 class SingleFrankaRobotiqDeltaJointsDataConfig:
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = [
         "video.base_view",
         "video.ego_view",
@@ -583,6 +590,7 @@ class SingleFrankaRobotiqDeltaJointsDataConfig:
 ###########################################################################################
 
 class FourierGr1ArmsWaistDataConfig:
+    embodiment_tag = EmbodimentTag.GR1
     video_keys = ["video.ego_view"]
     state_keys = [
         "state.left_arm",
@@ -667,6 +675,7 @@ class FourierGr1ArmsWaistDataConfig:
 ###########################################################################################
 
 class SO101Config:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     #input
     video_keys = [
         "video.primary_image",
@@ -748,6 +757,7 @@ class SO101Config:
 
 
 class ArxX5DataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = [
         "video.cam_high",
         "video.cam_left_wrist",
@@ -827,6 +837,7 @@ class ArxX5DataConfig:
 
 
 class AgilexDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = [
         "video.cam_high",
         "video.cam_left_wrist",
@@ -906,6 +917,7 @@ class AgilexDataConfig:
 
 
 class AgilexData50Config:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = [
         "video.cam_high",
         "video.cam_left_wrist",
@@ -994,6 +1006,7 @@ class VLAArenaFrankaDataConfig:
     State         : EEF pos (3) + EEF axis-angle (3) + gripper qpos (1) = 7
     """
 
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = [
         "video.primary_image",   # agentview camera
     ]

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -50,6 +50,7 @@ from starVLA.dataloader.gr00t_lerobot.schema import (
     LeRobotStateActionMetadata,
 )
 from starVLA.dataloader.gr00t_lerobot.transform import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionTransform
 
 from functools import partial
 from typing import Tuple, List
@@ -86,7 +87,13 @@ def calculate_dataset_statistics(parquet_paths: list[Path]) -> dict:
         parquet_data = pd.read_parquet(parquet_path)
         parquet_data = parquet_data
         all_low_dim_data_list.append(parquet_data)
-    
+
+    if not all_low_dim_data_list:
+        raise FileNotFoundError(
+            f"No parquet files found under the provided paths: {[str(p) for p in parquet_paths[:3]]}..."
+            f" — make sure the dataset has been downloaded/converted before training."
+        )
+
     all_low_dim_data = pd.concat(all_low_dim_data_list, axis=0)
     # Compute dataset statistics
     dataset_statistics = {}
@@ -230,7 +237,8 @@ def _compute_statistics_for_mode(
     action_mode_apply_keys: list[str] | None,
     action_mode_state_map: dict[str, str] | None,
 ) -> dict:
-    print(f"[RANK 0] Calculating dataset statistics for {dataset_name} (mode={action_mode})")
+    if int(os.environ.get("RANK", "0")) == 0:
+        print(f"[RANK 0] Calculating dataset statistics for {dataset_name} (mode={action_mode})")
 
     base_stats = calculate_dataset_statistics(parquet_paths)
     
@@ -631,8 +639,8 @@ class LeRobotSingleDataset(Dataset):
         self.set_transforms_metadata(self.metadata)
         self.set_epoch(0)
 
-        print(f"Initialized dataset {self.dataset_name} with {embodiment_tag}")
-
+        if int(os.environ.get("RANK", "0")) == 0:
+            print(f"Initialized dataset {self.dataset_name} with {embodiment_tag}")
 
         # Check if the dataset is valid
         self._check_integrity()
@@ -1391,10 +1399,19 @@ class LeRobotSingleDataset(Dataset):
 
         if self.data_cfg is not None and self.data_cfg.get("include_state", False) not in ["False", False]:
             state = []
-            for state_key in self.modality_keys["state"]:
+            for state_key in self.modality_keys.get("state", []):
                 state.append(data[state_key])
-            state = np.concatenate(state, axis=1).astype(np.float16)
-            sample["state"] = state
+            if not state:
+                import warnings
+                warnings.warn(
+                    "include_state=True but no state modality keys found in modality_configs "
+                    "(state modality may be disabled in the dataset's DataConfig). "
+                    "Skipping state packing.",
+                    stacklevel=2,
+                )
+            else:
+                state = np.concatenate(state, axis=1).astype(np.float16)
+                sample["state"] = state
 
         return sample
 
@@ -1852,9 +1869,11 @@ class LeRobotSingleDataset(Dataset):
                 # Combine statistics from filtered action sub-keys
                 combined_action_stats = combine_modality_stats(filtered_action_stats)
                 
-                # Add mask field based on whether it's gripper or not
+                # mask=False for dimensions whose normalization mode is "binary"
+                _action_norm_modes = _extract_action_normalization_modes(self.transforms)
                 mask = generate_action_mask_for_used_keys(
-                    self.metadata.modalities.action, filtered_action_stats.keys()
+                    self.metadata.modalities.action, filtered_action_stats.keys(),
+                    normalization_modes=_action_norm_modes,
                 )
                 combined_action_stats["mask"] = mask
                 
@@ -2060,38 +2079,64 @@ def combine_modality_stats(modality_stats: dict) -> dict:
     
     return combined_stats
 
-def generate_action_mask_for_used_keys(action_modalities: dict, used_action_keys_ordered) -> list[bool]:
+def _extract_action_normalization_modes(transforms) -> dict:
+    """Extract normalization modes for action keys from a ComposedModalityTransform.
+
+    Returns:
+        dict: {subkey_without_action_prefix -> normalization_mode_str}
     """
-    Generate mask based on action modalities, but only for used keys.
-    Gripper-related are False, others are True.
-    
+    modes = {}
+    for t in transforms.transforms:
+        if isinstance(t, StateActionTransform):
+            for key, mode in t.normalization_modes.items():
+                if key.startswith("action."):
+                    subkey = key[len("action."):]
+                    modes[subkey] = mode
+    return modes
+
+
+def generate_action_mask_for_used_keys(
+    action_modalities: dict,
+    used_action_keys_ordered,
+    normalization_modes: dict | None = None,
+) -> list[bool]:
+    """Generate per-dimension mask for action statistics.
+
+    A dimension gets ``mask=False`` only when its normalization mode is ``"binary"``.
+    This tells the inference code to skip continuous de-normalization for that dimension.
+    All other modes (q99, mean_std, min_max ...) produce ``mask=True``.
+
     Args:
         action_modalities (dict): Configuration information for action modalities.
-        used_action_keys_ordered: Iterable of actually used action keys in the correct order.
-        
+        used_action_keys_ordered: Iterable of actually used action keys (no "action." prefix).
+        normalization_modes (dict | None): Mapping {subkey -> mode} (no "action." prefix).
+            If ``None``, all dimensions default to ``mask=True``.
+
     Returns:
-        list[bool]: List of mask values
+        list[bool]: Per-dimension mask values.
     """
     mask = []
-    
-    # Generate mask in the same order as the statistics were combined
+
     for subkey in used_action_keys_ordered:
         if subkey in action_modalities:
             subkey_config = action_modalities[subkey]
-            
+
             # Get dimension count from shape
             if hasattr(subkey_config, 'shape') and len(subkey_config.shape) > 0:
                 dim_count = subkey_config.shape[0]
             else:
                 dim_count = 1
-            
-            # Check if it's gripper-related
-            is_gripper = "gripper" in subkey.lower()
-            
-            # Generate mask value for each dimension
+
+            # mask=False only when the normalization mode is explicitly "binary"
+            is_binary = (
+                normalization_modes.get(subkey) == "binary"
+                if normalization_modes is not None
+                else False
+            )
+
             for _ in range(dim_count):
-                mask.append(not is_gripper)  # gripper is False, others are True
-    
+                mask.append(not is_binary)
+
     return mask
 
 def get_used_modality_keys(modality_keys: dict) -> tuple[list, list]:
@@ -2229,21 +2274,6 @@ class LeRobotMixtureDataset(Dataset):
 
         # Set the epoch and sample the first epoch
         self.set_epoch(0)
-
-        self._sequential_step_sampling = True
-        if self.data_cfg is not None:
-            seq_cfg = self.data_cfg.get("sequential_step_sampling", True)
-            self._sequential_step_sampling = seq_cfg not in ["False", False]
-
-        self._step_order: list[np.ndarray] = []
-        self._step_pos: list[int] = []
-        if self._sequential_step_sampling:
-            for dataset in self.datasets:
-                self._step_order.append(np.arange(len(dataset.all_steps)))
-                if self.mode == "train":
-                    rng = np.random.default_rng(self.seed)
-                    rng.shuffle(self._step_order[-1])
-                self._step_pos.append(0)
 
         self.update_metadata(metadata_config)
 
@@ -2686,8 +2716,17 @@ class LeRobotMixtureDataset(Dataset):
                 if filtered_action_stats:
                     combined_action_stats = combine_modality_stats(filtered_action_stats)
                     
+                    # Collect action normalization modes from datasets of this tag.
+                    # "binary" takes precedence: if any dataset marks a key as binary, use binary.
+                    _action_norm_modes: dict = {}
+                    for _ds in self.datasets:
+                        if _ds.tag == tag:
+                            for _k, _m in _extract_action_normalization_modes(_ds.transforms).items():
+                                if _k not in _action_norm_modes or _m == "binary":
+                                    _action_norm_modes[_k] = _m
                     mask = generate_action_mask_for_used_keys(
-                        merged_metadata.modalities.action, filtered_action_stats.keys()
+                        merged_metadata.modalities.action, filtered_action_stats.keys(),
+                        normalization_modes=_action_norm_modes,
                     )
                     combined_action_stats["mask"] = mask
                     

--- a/starVLA/dataloader/gr00t_lerobot/embodiment_tags.py
+++ b/starVLA/dataloader/gr00t_lerobot/embodiment_tags.py
@@ -52,6 +52,23 @@ class EmbodimentTag(Enum):
     The Franka Emika Panda robot.
     """
 
+    ALOHA = 'aloha'
+    """
+    The ALOHA bimanual robot (RoboChallenge dual-arm).
+    """
+
+    UR5 = 'ur5'
+    """ The UR5 single-arm robot.
+    """
+
+    ARX5 = 'arx5'
+    """ The ARX5 single-arm robot.
+    """
+
+    DOS_W1 = 'dos-w1'
+    """ The DOS-W1 single-arm robot.
+    """
+
 # Embodiment tag string: to projector index in the Action Expert Module
 EMBODIMENT_TAG_MAPPING = {
     EmbodimentTag.NEW_EMBODIMENT.value: 31,
@@ -61,6 +78,10 @@ EMBODIMENT_TAG_MAPPING = {
     EmbodimentTag.AGIBOT_GENIE1.value: 26,
     EmbodimentTag.GR1.value: 24,
     EmbodimentTag.FRANKA.value: 25,
+    EmbodimentTag.ALOHA.value: 7,
+    EmbodimentTag.UR5.value: 8,
+    EmbodimentTag.ARX5.value: 9,
+    EmbodimentTag.DOS_W1.value: 10,
 }
 
 # Robot type to embodiment tag mapping

--- a/starVLA/dataloader/gr00t_lerobot/registry.py
+++ b/starVLA/dataloader/gr00t_lerobot/registry.py
@@ -6,8 +6,14 @@ registries defined in this package.
 Three registries are maintained:
 
 * ``DATASET_NAMED_MIXTURES``       – mixture_name → [(dataset, weight, robot_type)]
-* ``ROBOT_TYPE_CONFIG_MAP``       – robot_type → DataConfig instance
+* ``ROBOT_TYPE_CONFIG_MAP``        – robot_type → DataConfig instance
 * ``ROBOT_TYPE_TO_EMBODIMENT_TAG`` – robot_type → EmbodimentTag
+
+``ROBOT_TYPE_TO_EMBODIMENT_TAG`` is **derived** from ``ROBOT_TYPE_CONFIG_MAP``
+by reading each DataConfig class's ``embodiment_tag`` classvar (Proposal A).
+Classes without the classvar fall back to ``EmbodimentTag.NEW_EMBODIMENT``.
+Legacy bench files exposing their own ``ROBOT_TYPE_TO_EMBODIMENT_TAG`` dict are
+still honored as overrides for backward compatibility.
 
 
 Usage::
@@ -32,8 +38,7 @@ from starVLA.dataloader.gr00t_lerobot.data_config import (
     ROBOT_TYPE_CONFIG_MAP as _BASE_CONFIG_MAP,
 )
 from starVLA.dataloader.gr00t_lerobot.embodiment_tags import (
-    ROBOT_TYPE_TO_EMBODIMENT_TAG as _BASE_EMBODIMENT_MAP,
-    EmbodimentTag,  # noqa: F401  – re-export for convenience
+    EmbodimentTag,  # re-export for convenience
 )
 from starVLA.dataloader.gr00t_lerobot.mixtures import (
     DATASET_NAMED_MIXTURES as _BASE_MIXTURES,
@@ -45,8 +50,34 @@ logger = logging.getLogger(__name__)
 # Mutable copies – will be extended by discovered modules
 # ---------------------------------------------------------------------------
 ROBOT_TYPE_CONFIG_MAP: dict = dict(_BASE_CONFIG_MAP)
-ROBOT_TYPE_TO_EMBODIMENT_TAG: dict = dict(_BASE_EMBODIMENT_MAP)
 DATASET_NAMED_MIXTURES: dict = dict(_BASE_MIXTURES)
+
+# Legacy explicit overrides (rarely needed; prefer the classvar on DataConfig).
+_LEGACY_TAG_OVERRIDES: dict = {}
+
+
+def _derive_tag_map() -> dict:
+    """Build robot_type -> EmbodimentTag from ROBOT_TYPE_CONFIG_MAP.
+
+    Reads each DataConfig instance's ``embodiment_tag`` classvar. Falls back to
+    ``EmbodimentTag.NEW_EMBODIMENT`` if the classvar is missing. Legacy
+    overrides from bench files take precedence.
+    """
+    out: dict = {}
+    for rt, cfg in ROBOT_TYPE_CONFIG_MAP.items():
+        tag = getattr(cfg, "embodiment_tag", None)
+        if tag is None:
+            logger.warning(
+                "[registry] DataConfig for robot_type=%r has no `embodiment_tag` "
+                "classvar; defaulting to EmbodimentTag.NEW_EMBODIMENT.", rt
+            )
+            tag = EmbodimentTag.NEW_EMBODIMENT
+        out[rt] = tag
+    out.update(_LEGACY_TAG_OVERRIDES)
+    return out
+
+
+ROBOT_TYPE_TO_EMBODIMENT_TAG: dict = {}  # populated by discover_and_merge()
 
 # ---------------------------------------------------------------------------
 # Discovery logic
@@ -85,7 +116,7 @@ def _load_module_from_path(module_name: str, file_path: Path):
 
 def discover_and_merge() -> None:
     """Scan ``examples/*/train_files/data_registry/`` and merge into global registries."""
-    global _DISCOVERED
+    global _DISCOVERED, ROBOT_TYPE_TO_EMBODIMENT_TAG
     if _DISCOVERED:
         return
     _DISCOVERED = True
@@ -101,13 +132,17 @@ def discover_and_merge() -> None:
             if mod:
                 if hasattr(mod, "ROBOT_TYPE_CONFIG_MAP"):
                     ROBOT_TYPE_CONFIG_MAP.update(mod.ROBOT_TYPE_CONFIG_MAP)
-                    logger.info(f"[registry] Loaded data_config from {bench_name}: {list(mod.ROBOT_TYPE_CONFIG_MAP.keys())}")
+                    logger.debug(f"[registry] Loaded data_config from {bench_name}: {list(mod.ROBOT_TYPE_CONFIG_MAP.keys())}")
+                # Legacy: bench file may still expose an explicit dict override.
                 if hasattr(mod, "ROBOT_TYPE_TO_EMBODIMENT_TAG"):
-                    ROBOT_TYPE_TO_EMBODIMENT_TAG.update(mod.ROBOT_TYPE_TO_EMBODIMENT_TAG)
-                    logger.info(f"[registry] Loaded embodiment_tags from {bench_name} (data_config): {list(mod.ROBOT_TYPE_TO_EMBODIMENT_TAG.keys())}")
+                    _LEGACY_TAG_OVERRIDES.update(mod.ROBOT_TYPE_TO_EMBODIMENT_TAG)
+                    logger.debug(f"[registry] Legacy embodiment_tag overrides from {bench_name}: {list(mod.ROBOT_TYPE_TO_EMBODIMENT_TAG.keys())}")
                 if hasattr(mod, "DATASET_NAMED_MIXTURES"):
                     DATASET_NAMED_MIXTURES.update(mod.DATASET_NAMED_MIXTURES)
-                    logger.info(f"[registry] Loaded mixtures from {bench_name} (data_config): {list(mod.DATASET_NAMED_MIXTURES.keys())}")
+                    logger.debug(f"[registry] Loaded mixtures from {bench_name} (data_config): {list(mod.DATASET_NAMED_MIXTURES.keys())}")
+
+    # Re-derive after all benches are loaded so classvars + legacy overrides combine.
+    ROBOT_TYPE_TO_EMBODIMENT_TAG = _derive_tag_map()
 
 
 # Run discovery on first import

--- a/starVLA/dataloader/gr00t_lerobot/transform/state_action.py
+++ b/starVLA/dataloader/gr00t_lerobot/transform/state_action.py
@@ -132,7 +132,7 @@ class Normalizer:
             normalized[..., ~mask] = x[..., ~mask].to(x.dtype)
 
             # Clip the normalized values to be between -1 and 1
-            normalized = torch.clamp(normalized, -1, 1)
+            normalized = torch.clamp(normalized, -2.2, 2.2)
 
         elif self.mode == "mean_std":
             # Range of mean_std is not fixed, but can be positive or negative

--- a/starVLA/dataloader/lerobot_datasets.py
+++ b/starVLA/dataloader/lerobot_datasets.py
@@ -4,6 +4,7 @@
 # Modified by [Jinhui YE/ HKUST University] in [2025]. 
 # Modification: [suport topdowm processing, suport param from config].
 
+import logging
 from pathlib import Path
 from typing import Sequence
 from omegaconf import OmegaConf
@@ -11,10 +12,11 @@ from omegaconf import OmegaConf
 from starVLA.dataloader.gr00t_lerobot.datasets import LeRobotSingleDataset, LeRobotMixtureDataset
 from starVLA.dataloader.gr00t_lerobot.registry import (
     ROBOT_TYPE_CONFIG_MAP,
-    ROBOT_TYPE_TO_EMBODIMENT_TAG,
     DATASET_NAMED_MIXTURES,
     EmbodimentTag,
 )
+
+logger = logging.getLogger(__name__)
 
 def collate_fn(batch):
     return batch
@@ -40,13 +42,28 @@ def make_LeRobotSingleDataset(
     modality_config = data_config.modality_config()
     transforms = data_config.transform()
     dataset_path = data_root_dir / data_name
-    if robot_type not in ROBOT_TYPE_TO_EMBODIMENT_TAG:
-        print(f"Warning: Robot type {robot_type} not found in ROBOT_TYPE_TO_EMBODIMENT_TAG, using {EmbodimentTag.NEW_EMBODIMENT} as default")
+    embodiment_tag = getattr(data_config, "embodiment_tag", None)
+    if embodiment_tag is None:
+        print(f"Warning: DataConfig for robot_type={robot_type!r} has no embodiment_tag, using {EmbodimentTag.NEW_EMBODIMENT} as default")
         embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
-    else:
-        embodiment_tag = ROBOT_TYPE_TO_EMBODIMENT_TAG[robot_type]
     
     video_backend = data_cfg.get("video_backend", "decord") if data_cfg else "torchvision_av"
+
+    # Opt-in factory hook: a DataConfig may define ``make_dataset(dataset_name=..., **ds_kwargs)``
+    # to swap in a custom dataset class (e.g. with per-task filtering / chunk stride).
+    # When absent, fall through to the default LeRobotSingleDataset construction below.
+    if hasattr(data_config, "make_dataset"):
+        return data_config.make_dataset(
+            dataset_path=dataset_path,
+            modality_configs=modality_config,
+            transforms=transforms,
+            embodiment_tag=embodiment_tag,
+            video_backend=video_backend,
+            delete_pause_frame=delete_pause_frame,
+            data_cfg=data_cfg,
+            dataset_name=data_name,
+        )
+
     return LeRobotSingleDataset(
         dataset_path=dataset_path,
         modality_configs=modality_config,
@@ -72,6 +89,7 @@ def get_vla_dataset(
     data_mix = data_cfg.data_mix
     delete_pause_frame = data_cfg.get("delete_pause_frame", False)
     mixture_spec = DATASET_NAMED_MIXTURES[data_mix]
+    logger.info(f"[dataloader] Using mixture '{data_mix}': {[(d, w, r) for d, w, r in mixture_spec]}")
     included_datasets, filtered_mixture_spec = set(), []
     for d_name, d_weight, robot_type in mixture_spec:  
         dataset_key = (d_name, robot_type)  
@@ -103,8 +121,10 @@ if __name__ == "__main__":
     import os
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config_yaml", type=str, default="examples/LIBERO/train_files/starvla_cotrain_libero.yaml", help="Path to YAML config")
-    args, clipargs = parser.parse_known_args()
+    parser.add_argument("--config_yaml", type=str, default="./examples/LIBERO/train_files/bar/starvla_cotrain_libero.yaml", help="Path to YAML config")
+    parser.add_argument("--data_mix", type=str, default=None, help="Override data_mix from config")
+    parser.add_argument("--data_root_dir", type=str, default=None, help="Override data_root_dir from config")
+    args = parser.parse_args()
 
     if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
@@ -114,10 +134,13 @@ if __name__ == "__main__":
 
     cfg = OmegaConf.load(args.config_yaml)
     vla_dataset_cfg = cfg.datasets.vla_data
-    for task_id in ["all"]:
-        vla_dataset_cfg.task_id = task_id
-        print(f"Testing Task ID: {task_id}")
-        dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
+    vla_dataset_cfg.data_root_dir = Path(vla_dataset_cfg.data_root_dir)
+    if args.data_mix is not None:
+        vla_dataset_cfg.data_mix = args.data_mix
+    if args.data_root_dir is not None:
+        vla_dataset_cfg.data_root_dir = Path(args.data_root_dir)
+
+    dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
     from torch.utils.data import DataLoader
     train_dataloader = DataLoader(
         dataset,
@@ -133,7 +156,7 @@ if __name__ == "__main__":
     from tqdm import tqdm
     count = 0
     for batch in tqdm(train_dataloader, desc="Processing Batches"):
-        if count > 100:
+        if count > 3:
             break
         count += 1
         pass

--- a/starVLA/model/framework/VLM4A/CosmosGR00T.py
+++ b/starVLA/model/framework/VLM4A/CosmosGR00T.py
@@ -130,6 +130,7 @@ class Cosmos_GR00T(baseframework):
         state = [example["state"] for example in examples] if "state" in examples[0] else None
 
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        backbone_attention_mask = qwen_inputs.get("attention_mask", None)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -150,13 +151,20 @@ class Cosmos_GR00T(baseframework):
             )
             actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
             last_hidden_repeated = last_hidden.repeat(repeated_diffusion_steps, 1, 1)
+            if backbone_attention_mask is not None:
+                backbone_attention_mask = backbone_attention_mask.repeat(repeated_diffusion_steps, 1).to(
+                    dtype=torch.bool
+                )
 
             state_repeated = None
             if state is not None:
                 state = torch.tensor(np.array(state), device=last_hidden.device, dtype=last_hidden.dtype)
                 state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
 
-            action_loss = self.action_model(last_hidden_repeated, actions_target_repeated, state_repeated)
+            action_loss = self.action_model(
+                last_hidden_repeated, actions_target_repeated, state_repeated,
+                encoder_attention_mask=backbone_attention_mask,
+            )
 
         return {"action_loss": action_loss}
 
@@ -173,6 +181,9 @@ class Cosmos_GR00T(baseframework):
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        backbone_attention_mask = qwen_inputs.get("attention_mask", None)
+        if backbone_attention_mask is not None:
+            backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -189,7 +200,9 @@ class Cosmos_GR00T(baseframework):
         )
 
         with torch.autocast("cuda", dtype=torch.float32):
-            pred_actions = self.action_model.predict_action(last_hidden, state)
+            pred_actions = self.action_model.predict_action(
+                last_hidden, state, encoder_attention_mask=backbone_attention_mask
+            )
 
         normalized_actions = pred_actions.detach().cpu().numpy()
         return {"normalized_actions": normalized_actions}

--- a/starVLA/model/framework/VLM4A/QwenGR00T.py
+++ b/starVLA/model/framework/VLM4A/QwenGR00T.py
@@ -178,6 +178,7 @@ class Qwen_GR00T(baseframework):
 
         # Step 1: QWenVL input format
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        backbone_attention_mask = qwen_inputs.get("attention_mask", None)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -202,6 +203,10 @@ class Qwen_GR00T(baseframework):
             )
             actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
             last_hidden_repeated = last_hidden.repeat(repeated_diffusion_steps, 1, 1)
+            if backbone_attention_mask is not None:
+                backbone_attention_mask = backbone_attention_mask.repeat(repeated_diffusion_steps, 1).to(
+                    dtype=torch.bool
+                )
 
             state_repeated = None
             if state is not None:
@@ -209,7 +214,8 @@ class Qwen_GR00T(baseframework):
                 state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
 
             action_loss = self.action_model(
-                last_hidden_repeated, actions_target_repeated, state_repeated
+                last_hidden_repeated, actions_target_repeated, state_repeated,
+                encoder_attention_mask=backbone_attention_mask,
             )  # (B, chunk_len, action_dim)
 
         return {"action_loss": action_loss}
@@ -242,6 +248,9 @@ class Qwen_GR00T(baseframework):
 
         # Step 1: QWenVL input format
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        backbone_attention_mask = qwen_inputs.get("attention_mask", None)
+        if backbone_attention_mask is not None:
+            backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -261,7 +270,9 @@ class Qwen_GR00T(baseframework):
 
         # Step 4: Action Expert Forward
         with torch.autocast("cuda", dtype=torch.float32):
-            pred_actions = self.action_model.predict_action(last_hidden, state)  # (B, chunk_len, action_dim)
+            pred_actions = self.action_model.predict_action(
+                last_hidden, state, encoder_attention_mask=backbone_attention_mask
+            )  # (B, chunk_len, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()
         return {"normalized_actions": normalized_actions}

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -166,11 +166,12 @@ class Qwen_PI(baseframework):
 
     def _encode_vl_hidden_states(
         self, batch_images: List, instructions: List[str]
-    ) -> List[torch.Tensor]:
-        """Run QwenVL and return the last-N layer-wise hidden states for the Action DiT."""
+    ) -> tuple:
+        """Run QwenVL and return (layer-wise hidden states, attention_mask) for the Action DiT."""
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
             images=batch_images, instructions=instructions
         )
+        attention_mask = qwen_inputs.get("attention_mask", None)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -180,7 +181,7 @@ class Qwen_PI(baseframework):
             )
             expected_layers = len(self.action_model.model.transformer_blocks)
             vl_embs_list = list(qwenvl_outputs.hidden_states[-expected_layers:])
-        return vl_embs_list
+        return vl_embs_list, attention_mask
 
     def forward(
         self,
@@ -204,7 +205,7 @@ class Qwen_PI(baseframework):
         state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
 
         # Step 1: encode through QwenVL
-        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
 
         # Step 4: Action Expert Forward and Loss
@@ -224,6 +225,10 @@ class Qwen_PI(baseframework):
             actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
             # Repeat features for each layer
             vl_embs_list_repeated = [h.repeat(repeated_diffusion_steps, 1, 1) for h in vl_embs_list]
+            if backbone_attention_mask is not None:
+                backbone_attention_mask = backbone_attention_mask.repeat(repeated_diffusion_steps, 1).to(
+                    dtype=torch.bool
+                )
 
             state_repeated = None
             if state is not None:
@@ -234,6 +239,7 @@ class Qwen_PI(baseframework):
                 vl_embs_list_repeated,
                 actions_target_repeated,
                 state_repeated,
+                encoder_attention_mask=backbone_attention_mask,
             )  # (B, chunk_len, action_dim)
 
         return {"action_loss": action_loss}
@@ -269,8 +275,10 @@ class Qwen_PI(baseframework):
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
         # Step 1: encode through QwenVL
-        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
+        if backbone_attention_mask is not None:
+            backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
 
         state = (
             torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
@@ -280,7 +288,7 @@ class Qwen_PI(baseframework):
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action(
-                vl_embs_list, state
+                vl_embs_list, state, encoder_attention_mask=backbone_attention_mask
             )  # (B, chunk_len, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()

--- a/starVLA/model/framework/VLM4A/QwenPI_v3.py
+++ b/starVLA/model/framework/VLM4A/QwenPI_v3.py
@@ -245,11 +245,12 @@ class Qwen_PI_v3(baseframework):
 
     def _encode_vl_hidden_states(
         self, batch_images: List, instructions: List[str]
-    ) -> List[torch.Tensor]:
-        """Run QwenVL, project hidden states, and return the layer-wise embeddings for the Action DiT."""
+    ) -> tuple:
+        """Run QwenVL, project hidden states, and return (layer-wise embeddings, attention_mask) for the Action DiT."""
         qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
             images=batch_images, instructions=instructions
         )
+        attention_mask = qwen_inputs.get("attention_mask", None)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
                 **qwen_inputs,
@@ -259,7 +260,7 @@ class Qwen_PI_v3(baseframework):
             )
             vl_embs_list = list(qwenvl_outputs.hidden_states[-self.num_action_dit_layers:])
             vl_embs_list = self._project_vl_hidden_for_action(vl_embs_list)
-        return vl_embs_list
+        return vl_embs_list, attention_mask
 
     def forward(
         self,
@@ -290,7 +291,7 @@ class Qwen_PI_v3(baseframework):
         state = None  # state is now encoded in the instruction tokens
 
         # Step 1: encode through QwenVL
-        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
 
         # Step 2: compute flow-matching loss over the action chunk
@@ -302,12 +303,16 @@ class Qwen_PI_v3(baseframework):
             actions_target = actions[:, -self.action_horizon :, :]  # (B, action_horizon, action_dim)
 
             repeated_diffusion_steps = (
-                self.config.trainer.get("repeated_diffusion_steps", 4) if self.config and self.config.trainer else 4
+                self.config.trainer.get("repeated_diffusion_steps", 16) if self.config and self.config.trainer else 4
             )
-            repeated_diffusion_steps = 2  # No repeat for the large action FM to save memory.
+            
             actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
             # Repeat every VLM layer embedding to match the duplicated action batch.
             vl_embs_list_repeated = [h.repeat(repeated_diffusion_steps, 1, 1) for h in vl_embs_list]
+            if backbone_attention_mask is not None:
+                backbone_attention_mask = backbone_attention_mask.repeat(repeated_diffusion_steps, 1).to(
+                    dtype=torch.bool
+                )
 
             state_repeated = None
             if state is not None:
@@ -318,6 +323,7 @@ class Qwen_PI_v3(baseframework):
                 vl_embs_list_repeated,
                 actions_target_repeated,
                 state_repeated,
+                encoder_attention_mask=backbone_attention_mask,
             )
 
         return {"action_loss": action_loss}
@@ -365,8 +371,10 @@ class Qwen_PI_v3(baseframework):
             batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
         # Step 1: encode through QwenVL
-        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
+        if backbone_attention_mask is not None:
+            backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
 
         state = (
             torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
@@ -376,7 +384,7 @@ class Qwen_PI_v3(baseframework):
         # Step 2: run the flow-matching sampler to produce the denoised action chunk.
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action(
-                vl_embs_list, state
+                vl_embs_list, state, encoder_attention_mask=backbone_attention_mask
             )  # (B, action_horizon, action_dim)
 
         normalized_actions = pred_actions.detach().cpu().numpy()

--- a/starVLA/model/modules/action_model/GR00T_ActionHeader.py
+++ b/starVLA/model/modules/action_model/GR00T_ActionHeader.py
@@ -363,7 +363,12 @@ class FlowmatchingActionHead(nn.Module):
         return loss
 
     @torch.no_grad()
-    def predict_action(self, vl_embs: torch.Tensor, state: torch.Tensor = None) -> torch.Tensor:
+    def predict_action(
+        self,
+        vl_embs: torch.Tensor,
+        state: torch.Tensor = None,
+        encoder_attention_mask=None,
+    ) -> torch.Tensor:
         # Set initial actions as the sampled noise.
         batch_size = vl_embs.shape[0]
         device = vl_embs.device
@@ -404,6 +409,7 @@ class FlowmatchingActionHead(nn.Module):
             model_output = self.model(
                 hidden_states=sa_embs,
                 encoder_hidden_states=vl_embs,
+                encoder_attention_mask=encoder_attention_mask,
                 timestep=timesteps_tensor,
             )
             pred = self.action_decoder(model_output)

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -285,10 +285,17 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)
 
-    def forward(self, vl_embs_list: list, actions: torch.Tensor, state: torch.Tensor = None):
+    def forward(
+        self,
+        vl_embs_list: list,
+        actions: torch.Tensor,
+        state: torch.Tensor = None,
+        encoder_attention_mask=None,
+    ):
         """
         vl_embs: list of torch.Tensor, each shape (B, seq_length, feature_dim)
         actions: shape (B, action_horizon, D_action)
+        encoder_attention_mask: optional (B, seq_length) bool/int
         """
         device = actions.device
         num_layers = len(vl_embs_list)
@@ -331,6 +338,7 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
             model_output = layer(
                 hidden_states=model_output,
                 encoder_hidden_states=vl_embs_list[layer_idx],  # Use layer-specific vl_embs
+                encoder_attention_mask=encoder_attention_mask,
                 temb=temb,
             )
 
@@ -343,7 +351,12 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
         return loss
 
     @torch.no_grad()
-    def predict_action(self, vl_embs_list: list, state: torch.Tensor = None) -> torch.Tensor:
+    def predict_action(
+        self,
+        vl_embs_list: list,
+        state: torch.Tensor = None,
+        encoder_attention_mask=None,
+    ) -> torch.Tensor:
         # Set initial actions as the sampled noise.
         batch_size = vl_embs_list[0].shape[0]
         device = vl_embs_list[0].device
@@ -391,6 +404,7 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
                 model_output = layer(
                     hidden_states=model_output,
                     encoder_hidden_states=vl_embs_list[layer_idx],
+                    encoder_attention_mask=encoder_attention_mask,
                     temb=temb,
                 )
             # TODO miss self att and _process_output

--- a/starVLA/model/modules/vlm/QWen3.py
+++ b/starVLA/model/modules/vlm/QWen3.py
@@ -49,7 +49,7 @@ class _QWen3_VL_Interface(nn.Module):
         qwenvl_config = config.framework.get("qwenvl", {})
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3-VL-4B-Instruct")
         attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
-
+        attn_implementation = "sdpa"
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
             try:

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -58,6 +58,7 @@ class _QWen3_5_VL_Interface(nn.Module):
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3.5-VL-4B-Instruct")
         attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
+        attn_implementation = "sdpa"
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
             try:


### PR DESCRIPTION
## Summary

Dataloader robustness improvements and new/updated VLM4A framework backends.

## Changes

**Dataloader**
- `starVLA/dataloader/__init__.py`: improved registry and import handling
- `gr00t_lerobot/`: data_config, datasets, embodiment_tags, registry,
  transform/state_action — GR00T lerobot adapter layer improvements
- `lerobot_datasets.py`: lerobot dataset interface updates

**VLM4A Frameworks**
- `VLM4A/CosmosGR00T.py`: Cosmos + GR00T backbone
- `VLM4A/QwenGR00T.py`: Qwen + GR00T backbone
- `VLM4A/QwenPI.py`, `VLM4A/QwenPI_v3.py`: QwenPI v1/v3 updates

**Modules**
- `modules/action_model/GR00T_ActionHeader.py`
- `modules/action_model/LayerwiseFM_ActionHeader.py`
- `modules/vlm/QWen3.py`, `modules/vlm/QWen3_5.py`: Qwen3 / Qwen3.5 VLM support