### PR TITLE
[chore] benchmark data_config updates and training script improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,5 +249,16 @@ tmp
 
 
 logs/*
+bar
 **/.nf*
 code
+examples/RoboChallenge_table30v2/*
+examples/LIBERO/eval_files/auto_eval_scripts/run_all_libero_untested.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
+examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh
+starVLA/model/framework/VLM4A/QwenGR00T_v2.py

--- a/examples/DOMINO/train_files/data_registry/data_config.py
+++ b/examples/DOMINO/train_files/data_registry/data_config.py
@@ -16,9 +16,13 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 # DataConfig — Agilex (DOMINO, action_indices=16)
 # ---------------------------------------------------------------------------
 class AgilexDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = ["video.cam_high", "video.cam_left_wrist", "video.cam_right_wrist"]
     state_keys = ["state.left_joints", "state.right_joints", "state.left_gripper", "state.right_gripper"]
     action_keys = ["action.left_joints", "action.right_joints", "action.left_gripper", "action.right_gripper"]
+    # Per-key dims for PolicyNormProcessor (Agilex 6-DOF arms + binary gripper = 14-D total)
+    action_key_dims = {"action.left_joints": 6, "action.right_joints": 6, "action.left_gripper": 1, "action.right_gripper": 1}
+    state_key_dims  = {"state.left_joints": 6, "state.right_joints": 6, "state.left_gripper": 1, "state.right_gripper": 1}
     language_keys = ["annotation.human.action.task_description"]
     observation_indices = [0]
     action_indices = list(range(16))
@@ -57,7 +61,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    # Uses NEW_EMBODIMENT fallback (not in base embodiment_tags.py)
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 

--- a/examples/Franka/train_files/data_registry/data_config.py
+++ b/examples/Franka/train_files/data_registry/data_config.py
@@ -10,9 +10,13 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 # DataConfig — Franka Delta EEF
 # ---------------------------------------------------------------------------
 class SingleFrankaRobotiqDeltaEefDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = ["video.base_view", "video.ego_view"]
     state_keys = ["state.eef_position", "state.eef_rotation"]
     action_keys = ["action.delta_eef_position", "action.delta_eef_rotation", "action.gripper_close"]
+    # Per-key dims for PolicyNormProcessor (3+3+1 = 7-D total)
+    action_key_dims = {"action.delta_eef_position": 3, "action.delta_eef_rotation": 3, "action.gripper_close": 1}
+    state_key_dims  = {"state.eef_position": 3, "state.eef_rotation": 3}
     language_keys = ["annotation.human.action.task_description"]
     observation_indices = [0]
     action_indices = list(range(16))
@@ -48,9 +52,13 @@ class SingleFrankaRobotiqDeltaEefDataConfig:
 # DataConfig — Franka Delta Joints (sim)
 # ---------------------------------------------------------------------------
 class SingleFrankaRobotiqDeltaJointsDataConfig:
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = ["video.base_view", "video.ego_view"]
     state_keys = ["state.joints"]
     action_keys = ["action.delta_joints", "action.gripper_close"]
+    # Per-key dims for PolicyNormProcessor (7+1 = 8-D total)
+    action_key_dims = {"action.delta_joints": 7, "action.gripper_close": 1}
+    state_key_dims  = {"state.joints": 7}
     language_keys = ["annotation.human.action.task_description"]
     observation_indices = [0]
     action_indices = list(range(16))
@@ -79,6 +87,7 @@ class SingleFrankaRobotiqDeltaJointsDataConfig:
 # DataConfig — SO101
 # ---------------------------------------------------------------------------
 class SO101Config:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = ["video.primary_image", "video.wrist_image"]
     state_keys = [
         "state.shoulder_pan.pos", "state.shoulder_lift.pos", "state.elbow_flex.pos",
@@ -122,8 +131,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    "demo_sim_franka_delta_joints": EmbodimentTag.FRANKA,
-    "custom_robot_config": EmbodimentTag.NEW_EMBODIMENT,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 DATASET_NAMED_MIXTURES = {

--- a/examples/LIBERO/train_files/data_registry/data_config.py
+++ b/examples/LIBERO/train_files/data_registry/data_config.py
@@ -10,6 +10,7 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 # DataConfig
 # ---------------------------------------------------------------------------
 class Libero4in1DataConfig:
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = [
         "video.primary_image",
         "video.wrist_image",
@@ -36,12 +37,12 @@ class Libero4in1DataConfig:
     language_keys = ["annotation.human.action.task_description"]
     observation_indices = [0]
     action_indices = list(range(8))
-    state_indices = list(range(-16, 0))
+    state_indices = [0]
 
     def modality_config(self):
         return {
             "video": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
-            # "state": ModalityConfig(delta_indices=self.state_indices, modality_keys=self.state_keys), # igore state modality for now since some datasets don't have state and we want to be able to use them, can add back later if needed
+            "state": ModalityConfig(delta_indices=self.state_indices, modality_keys=self.state_keys), # igore state modality for now since some datasets don't have state and we want to be able to use them, can add back later if needed
             "action": ModalityConfig(delta_indices=self.action_indices, modality_keys=self.action_keys),
             "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
         }
@@ -72,7 +73,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 # Embodiment Tags
 # ---------------------------------------------------------------------------
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    "libero_franka": EmbodimentTag.FRANKA,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 

--- a/examples/LIBERO/train_files/run_libero_train.sh
+++ b/examples/LIBERO/train_files/run_libero_train.sh
@@ -10,9 +10,9 @@ export NCCL_TIMEOUT=10000  # timeout set to 1 hour (unit: seconds)
 export NCCL_SOCKET_TIMEOUT_MS=360000
 ###########################################################################################
 # === Please modify the following paths according to your environment ===
-Framework_name=QwenOFT
+Framework_name=QwenPI
 freeze_module_list=''
-base_vlm=playground/Pretrained_models/Qwen3-VL-4B-Instruct
+base_vlm=playground/Pretrained_models/Qwen3.5-0.8B
 config_yaml=./examples/LIBERO/train_files/starvla_cotrain_libero.yaml
 libero_data_root=playground/Datasets/LEROBOT_LIBERO_DATA
 data_mix=libero_all
@@ -30,9 +30,11 @@ mkdir -p ${output_dir}
 cp $0 ${output_dir}/
 
 
+num_processes=${NUM_PROCESSES:-$(nvidia-smi -L | wc -l)}
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
-  --num_processes 8 \
+  --num_processes ${num_processes} \
   starVLA/training/train_starvla.py \
   --config_yaml ${config_yaml} \
   --framework.name ${Framework_name} \

--- a/examples/Robocasa_365/train_files/data_registry/data_config.py
+++ b/examples/Robocasa_365/train_files/data_registry/data_config.py
@@ -23,6 +23,7 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 class PandaOmronRoboCasa365DataConfig:
     """Single-arm Franka PandaOmron used by upstream RoboCasa365."""
 
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = [
         "video.robot0_agentview_left",
         "video.robot0_agentview_right",
@@ -41,6 +42,23 @@ class PandaOmronRoboCasa365DataConfig:
         "action.base_motion",
         "action.control_mode",
     ]
+    # Per-key dims for PolicyNormProcessor
+    # action (12-D): eef_pos(3) + eef_rot(3) + gripper_close(1) + base_motion(4) + control_mode(1)
+    action_key_dims = {
+        "action.end_effector_position": 3,
+        "action.end_effector_rotation": 3,
+        "action.gripper_close": 1,
+        "action.base_motion": 4,
+        "action.control_mode": 1,
+    }
+    # state (16-D): base_position(3) + base_rotation(4) + eef_pos_rel(3) + eef_rot_rel(4) + gripper_qpos(2)
+    state_key_dims = {
+        "state.base_position": 3,
+        "state.base_rotation": 4,
+        "state.end_effector_position_relative": 3,
+        "state.end_effector_rotation_relative": 4,
+        "state.gripper_qpos": 2,
+    }
     language_keys = ["annotation.human.task_description"]
 
     observation_indices = [0]
@@ -71,8 +89,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    # Use NEW_EMBODIMENT since PandaOmron is not in the canonical EmbodimentTag enum
-    "panda_omron_robocasa365": EmbodimentTag.NEW_EMBODIMENT,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 # Each task lives at

--- a/examples/Robocasa_tabletop/train_files/data_registry/data_config.py
+++ b/examples/Robocasa_tabletop/train_files/data_registry/data_config.py
@@ -11,9 +11,13 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 
 
 class FourierGr1ArmsWaistDataConfig:
+    embodiment_tag = EmbodimentTag.GR1
     video_keys = ["video.ego_view"]
     state_keys = ["state.left_arm", "state.right_arm", "state.left_hand", "state.right_hand", "state.waist"]
     action_keys = ["action.left_arm", "action.right_arm", "action.left_hand", "action.right_hand", "action.waist"]
+    # Per-key dims for PolicyNormProcessor (GR1 7-DOF arms, 6-finger hands, 3-DOF waist = 29-D total)
+    action_key_dims = {"action.left_arm": 7, "action.right_arm": 7, "action.left_hand": 6, "action.right_hand": 6, "action.waist": 3}
+    state_key_dims  = {"state.left_arm": 7, "state.right_arm": 7, "state.left_hand": 6, "state.right_hand": 6, "state.waist": 3}
     language_keys = ["annotation.human.coarse_action"]
     observation_indices = [0]
     action_indices = list(range(16))
@@ -43,7 +47,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    "fourier_gr1_arms_waist": EmbodimentTag.GR1,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 DATASET_NAMED_MIXTURES = {

--- a/examples/Robotwin/train_files/data_registry/data_config.py
+++ b/examples/Robotwin/train_files/data_registry/data_config.py
@@ -10,9 +10,13 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 # DataConfig — Agilex (RobotWin, action_indices=16)
 # ---------------------------------------------------------------------------
 class AgilexDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = ["video.cam_high", "video.cam_left_wrist", "video.cam_right_wrist"]
     state_keys = ["state.left_joints", "state.right_joints", "state.left_gripper", "state.right_gripper"]
     action_keys = ["action.left_joints", "action.right_joints", "action.left_gripper", "action.right_gripper"]
+    # Per-key dims for PolicyNormProcessor (Agilex 6-DOF arms + binary gripper = 14-D total)
+    action_key_dims = {"action.left_joints": 6, "action.right_joints": 6, "action.left_gripper": 1, "action.right_gripper": 1}
+    state_key_dims  = {"state.left_joints": 6, "state.right_joints": 6, "state.left_gripper": 1, "state.right_gripper": 1}
     language_keys = ["annotation.human.action.task_description"]
     observation_indices = [0]
     action_indices = list(range(16))
@@ -79,6 +83,7 @@ class AgilexData50Config(AgilexDataConfig):
 # DataConfig — ARX X5
 # ---------------------------------------------------------------------------
 class ArxX5DataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
     video_keys = ["video.cam_high", "video.cam_left_wrist", "video.cam_right_wrist"]
     state_keys = ["state.left_joints", "state.right_joints", "state.left_gripper", "state.right_gripper"]
     action_keys = ["action.left_joints", "action.right_joints", "action.left_gripper", "action.right_gripper"]
@@ -122,7 +127,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    # Uses NEW_EMBODIMENT fallback (not in base embodiment_tags.py)
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 # ---------------------------------------------------------------------------

--- a/examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh
+++ b/examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh
@@ -16,22 +16,25 @@
 # ==============================================================================
 set -uo pipefail
 
+DIR_GLOB=
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # Parent directory holding all training experiments.
 ROOT_BASE="${ROOT_BASE:-$PROJECT_ROOT/results/Checkpoints}"
-
+ 
 # Experiment directory pattern (relative to ROOT_BASE). First positional arg
 # overrides the default; can also be set via env var DIR_GLOB.
 DIR_GLOB="${1:-${DIR_GLOB:-0427_oxe_bridge_rt_1_QwenPI_v3}}"
 
 # srun partition / gpus
 SLURM_PARTITION="${SLURM_PARTITION:-si}"
-SLURM_GRES="${SLURM_GRES:-gpu:4}"
+SLURM_GRES="${SLURM_GRES:-gpu:8}"
 
 # Bridge eval entry-point.
-SCRIPT_PATH="${SCRIPT_PATH:-$PROJECT_ROOT/examples/SimplerEnv/eval_files/auto_eval_scripts/star_bridge.sh}"
+# SCRIPT_PATH="${SCRIPT_PATH:-$PROJECT_ROOT/examples/SimplerEnv/eval_files/auto_eval_scripts/star_bridge.sh}"
+
+SCRIPT_PATH="$PROJECT_ROOT/examples/SimplerEnv/eval_files/auto_eval_scripts/bar/star_bridge.sh"
 
 # Expected result-log filename suffixes (without the steps_${step}_ prefix).
 LOG_SUFFIXES=(

--- a/examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
+++ b/examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh
@@ -12,6 +12,9 @@
 # ==============================================================================
 set -uo pipefail
 
+
+DIR_GLOB=0430*
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 

--- a/examples/SimplerEnv/train_files/data_registry/data_config.py
+++ b/examples/SimplerEnv/train_files/data_registry/data_config.py
@@ -21,6 +21,7 @@ from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
 # DataConfig — OXE Droid
 # ---------------------------------------------------------------------------
 class OxeDroidDataConfig:
+    embodiment_tag = EmbodimentTag.OXE_DROID
     video_keys = [
         "video.exterior_image_1",
         "video.exterior_image_2",
@@ -79,6 +80,7 @@ class OxeDroidDataConfig:
 # DataConfig — OXE Bridge
 # ---------------------------------------------------------------------------
 class OxeBridgeDataConfig:
+    embodiment_tag = EmbodimentTag.OXE_BRIDGE
     video_keys = ["video.image_0"]
     state_keys = [
         "state.x", "state.y", "state.z",
@@ -121,6 +123,7 @@ class OxeBridgeDataConfig:
 # DataConfig — OXE RT-1
 # ---------------------------------------------------------------------------
 class OxeRT1DataConfig:
+    embodiment_tag = EmbodimentTag.OXE_RT1
     video_keys = ["video.image"]
     state_keys = [
         "state.x", "state.y", "state.z",
@@ -170,9 +173,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 # Embodiment Tags
 # ---------------------------------------------------------------------------
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    "oxe_droid": EmbodimentTag.OXE_DROID,
-    "oxe_bridge": EmbodimentTag.OXE_BRIDGE,
-    "oxe_rt1": EmbodimentTag.OXE_RT1,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 

--- a/examples/VLA-Arena/train_files/data_registry/data_config.py
+++ b/examples/VLA-Arena/train_files/data_registry/data_config.py
@@ -28,6 +28,7 @@ class VLAArenaFrankaDataConfig:
     State         : EEF pos (3) + EEF axis-angle (3) + gripper qpos (1) = 7
     """
 
+    embodiment_tag = EmbodimentTag.FRANKA
     video_keys = [
         "video.primary_image",   # agentview camera
         "video.wrist_image",   # wrist camera
@@ -92,7 +93,9 @@ ROBOT_TYPE_CONFIG_MAP = {
 # Embodiment Tags
 # ---------------------------------------------------------------------------
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {
-    "vla_arena_franka": EmbodimentTag.FRANKA,
+    # Per Proposal A, embodiment_tag now lives as a classvar on each DataConfig.
+    # The registry derives ROBOT_TYPE_TO_EMBODIMENT_TAG automatically. Kept as
+    # an empty dict for backward compat (it is honored as legacy override).
 }
 
 

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -33,7 +33,7 @@ from transformers import AutoProcessor, get_scheduler
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
-from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, normalize_dotlist_args
+from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -70,32 +70,6 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     accelerator.dataloader_config.dispatch_batches = False
     dist.barrier()
     return vlm_train_dataloader
-
-
-def setup_optimizer_and_scheduler(model, cfg) -> Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler._LRScheduler]:
-    """Set optimizer and learning rate scheduler."""
-    param_groups = build_param_lr_groups(model=model, cfg=cfg)
-    optimizer = torch.optim.AdamW(
-        param_groups,
-        lr=cfg.trainer.learning_rate.base,
-        betas=tuple(cfg.trainer.optimizer.betas),
-        weight_decay=cfg.trainer.optimizer.weight_decay,
-        eps=cfg.trainer.optimizer.eps,
-    )
-
-    if dist.is_initialized() and dist.get_rank() == 0:
-        for group in optimizer.param_groups:
-            logger.info(f"LR Group {group['name']}: lr={group['lr']}, num_params={len(group['params'])}")
-
-    lr_scheduler = get_scheduler(
-        name=cfg.trainer.lr_scheduler_type,
-        optimizer=optimizer,
-        num_warmup_steps=cfg.trainer.num_warmup_steps,
-        num_training_steps=cfg.trainer.max_train_steps,
-        scheduler_specific_kwargs=cfg.trainer.scheduler_specific_kwargs,
-    )
-
-    return optimizer, lr_scheduler
 
 
 class VLAMTrainer(TrainerUtils):
@@ -224,7 +198,10 @@ class VLAMTrainer(TrainerUtils):
     def _log_metrics(self, metrics):
         """Record training metrics."""
         if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
-            metrics["learning_rate"] = self.lr_scheduler.get_last_lr()[0]
+            last_lrs = self.lr_scheduler.get_last_lr()
+            for i, group in enumerate(self.optimizer.param_groups):
+                group_name = group.get("name", str(i))
+                metrics[f"learning_rate/{group_name}"] = last_lrs[i] if i < len(last_lrs) else last_lrs[-1]
             if hasattr(self.vlm_train_dataloader, "__len__"):
                 dataloader_length = len(self.vlm_train_dataloader)
                 if dataloader_length:
@@ -307,7 +284,10 @@ class VLAMTrainer(TrainerUtils):
                 self.accelerator.clip_grad_norm_(self.model.parameters(), self.config.trainer.gradient_clipping)
 
             self.optimizer.step()
-            self.lr_scheduler.step()
+            # Only step the LR scheduler when gradients are actually synced.
+            # See train_starvla.py for full explanation.
+            if self.accelerator.sync_gradients:
+                self.lr_scheduler.step()
             log_dict["vlm_loss"] = vlm_loss.item()
 
         return log_dict


### PR DESCRIPTION
## Summary

Updates benchmark data registry configs across all supported embodiments,
improves the main training scripts, and adds WidowX eval automation for SimplerEnv.

## Changes

**Data configs** (DOMINO / Franka / LIBERO / Robocasa_365 / Robocasa_tabletop /
Robotwin / SimplerEnv / VLA-Arena)
- Migrate to per-example registry pattern with updated robot/episode/norm configs

**Training scripts**
- `examples/LIBERO/train_files/run_libero_train.sh`: updated default framework
- `starVLA/config/deepseeds/ds_config.yaml`: DeepSpeed config tuning
- `starVLA/training/train_starvlm.py`: VLM-only trainer improvements

**Eval automation**
- `examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/schedule_widowx_eval.sh`
- `examples/SimplerEnv/eval_files/auto_eval_scripts/auto_collect_results/summarize_widowx_all.sh`

**Misc**
- `.gitignore`: add common build/cache patterns