### PR TITLE
[feat] model server: add server-side policy loading, norm processing,…

### DIFF
--- a/deployment/model_server/policy_norm_processor.py
+++ b/deployment/model_server/policy_norm_processor.py
@@ -1,0 +1,396 @@
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License.
+"""PolicyNormProcessor — reuse the training-time ComposedModalityTransform.
+
+This class replaces the hand-rolled un-normalization math that previously
+lived in every eval client. It rebuilds the *exact* ``ComposedModalityTransform``
+used at training time from a checkpoint:
+
+  1. Read ``config.yaml`` next to the ckpt → resolve ``data_mix`` →
+     look up ``robot_type`` from ``DATASET_NAMED_MIXTURES`` →
+     fetch the ``DataConfig`` from ``ROBOT_TYPE_CONFIG_MAP``.
+  2. Build the transform pipeline via ``data_config.transform()``.
+  3. Reconstruct a ``DatasetMetadata`` from the saved
+     ``dataset_statistics.json`` (which stores **combined** per-modality
+     arrays of length ``D``) by splitting it into per-key entries that match
+     ``data_config.action_keys`` / ``state_keys``.
+  4. ``set_metadata(...)`` binds the metadata into every transform.
+
+After construction the caller simply invokes :meth:`unapply_actions` /
+:meth:`apply_state` to get/normalize tensors using the same code path as
+training — there is no second source of truth for normalization math.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+
+from starVLA.dataloader.gr00t_lerobot.registry import (
+    DATASET_NAMED_MIXTURES,
+    ROBOT_TYPE_CONFIG_MAP,
+)
+from starVLA.dataloader.gr00t_lerobot.schema import (
+    DatasetMetadata,
+    StateActionMetadata,
+)
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.model.framework.share_tools import read_mode_config
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_robot_type(
+    model_cfg: dict,
+    unnorm_key: Optional[str] = None,
+) -> str:
+    """Look up the training robot_type from the saved cfg.
+
+    Convention used by starVLA train scripts:
+      ``cfg.datasets.vla_data.data_mix`` is a key in
+      ``DATASET_NAMED_MIXTURES`` whose value is a list of
+      ``(dataset_name, weight, robot_type)`` tuples.
+
+    When a data_mix contains entries from multiple robot types (e.g.
+    ``bridge_rt_1`` covers ``oxe_bridge`` + ``oxe_rt1``), ``unnorm_key``
+    is used to identify which embodiment is requested.  In those mixtures
+    the ``robot_type`` field of each entry **matches** the top-level key in
+    ``dataset_statistics.json``, so ``unnorm_key`` serves as the selector.
+    """
+    try:
+        data_mix = model_cfg["datasets"]["vla_data"]["data_mix"]
+    except (KeyError, TypeError) as e:
+        raise KeyError(
+            "ckpt config.yaml is missing `datasets.vla_data.data_mix`; "
+            "cannot resolve training-time robot_type."
+        ) from e
+
+    if data_mix not in DATASET_NAMED_MIXTURES:
+        raise KeyError(
+            f"data_mix={data_mix!r} not in DATASET_NAMED_MIXTURES "
+            f"(available: {sorted(DATASET_NAMED_MIXTURES.keys())[:20]} ...). "
+            "Did you forget to register the example under examples/<bench>/train_files/data_registry/?"
+        )
+
+    mixture = DATASET_NAMED_MIXTURES[data_mix]
+    robot_types = sorted({entry[2] for entry in mixture})
+
+    if len(robot_types) == 1:
+        return robot_types[0]
+
+    # Multiple robot types in the mixture.
+    # Use unnorm_key as a direct selector: for multi-robot mixtures the
+    # dataset_statistics.json top-level keys equal the robot_type values.
+    if unnorm_key is not None and unnorm_key in robot_types:
+        return unnorm_key
+
+    raise ValueError(
+        f"data_mix={data_mix!r} contains multiple robot_types {robot_types}. "
+        "Pass `unnorm_key` matching one of them to disambiguate "
+        f"(e.g. unnorm_key={robot_types[0]!r})."
+    )
+
+
+def _infer_key_dims(
+    data_config: Any,
+    combined_stats: Dict[str, Any],
+    modality_keys: Sequence[str],
+    modality: str,
+) -> Dict[str, int]:
+    """Compute per-key dimensions for splitting combined stats arrays.
+
+    Lookup priority:
+      1. ``data_config.<modality>_key_dims`` — explicit dict classvar on the DataConfig
+         (required for DataConfigs with non-uniform or multi-dim keys).
+      2. Infer uniformly from stats array length: if ``D_total / n_keys`` is an
+         integer, use that as the uniform per-key dim.
+      3. Fall back to dim=1 when no stats are available (empty combined dict).
+
+    Args:
+        data_config: The DataConfig instance for the current robot type.
+        combined_stats: The raw stats dict for the chosen unnorm_key (the value
+            of ``norm_stats[unnorm_key]`` from ``dataset_statistics.json``).
+        modality_keys: Ordered list of full keys for this modality
+            (e.g. ``["action.left_joints", ...]``).
+        modality: ``"action"`` or ``"state"``.
+
+    Returns:
+        Dict mapping each full key to its integer dimension.
+    """
+    attr = f"{modality}_key_dims"
+    if hasattr(data_config, attr):
+        return dict(getattr(data_config, attr))
+
+    combined = combined_stats.get(modality, {})
+    stat_arr = next((v for k, v in combined.items() if k != "mask"), None)
+    n_keys = len(modality_keys)
+    if stat_arr is not None and n_keys > 0:
+        D_total = len(stat_arr)
+        if D_total == n_keys:
+            return {k: 1 for k in modality_keys}
+        elif n_keys > 0 and D_total % n_keys == 0:
+            dim = D_total // n_keys
+            return {k: dim for k in modality_keys}
+        else:
+            raise ValueError(
+                f"Cannot infer per-key dims for modality={modality!r}: "
+                f"D_total={D_total} is not evenly divisible by n_keys={n_keys}. "
+                f"Add `{attr} = {{key: dim, ...}}` to the DataConfig "
+                f"(keys={list(modality_keys)})."
+            )
+    return {k: 1 for k in modality_keys}
+
+
+def _build_dataset_metadata(
+    stats_for_key: Dict[str, Any],
+    embodiment_tag: Any,
+    action_keys: Sequence[str],
+    state_keys: Sequence[str],
+    action_key_dims: Optional[Dict[str, int]] = None,
+    state_key_dims: Optional[Dict[str, int]] = None,
+) -> DatasetMetadata:
+    """Convert the *combined* stats arrays from ``dataset_statistics.json``
+    back into a per-subkey :class:`DatasetMetadata` matching what the training
+    pipeline produced.
+
+    The saved ``dataset_statistics.json`` stores stats as flat arrays of
+    length ``D = sum(per_key_dims)``.  For each ``"action.<sub>"`` key we
+    slice out ``dim_k`` elements starting at the current cursor and store them
+    under ``statistics.action.<sub> = {"min": [v0..v_{k-1}], ...}``.
+
+    Args:
+        stats_for_key: ``norm_stats[unnorm_key]`` from ``dataset_statistics.json``.
+        embodiment_tag: Embodiment tag from the DataConfig.
+        action_keys: Ordered list of full action keys.
+        state_keys: Ordered list of full state keys.
+        action_key_dims: Per-key dimension dict (``{full_key: dim_k}``).
+            Defaults to dim=1 for every key.
+        state_key_dims: Per-key dimension dict for state keys.
+            Defaults to dim=1 for every key.
+    """
+    if action_key_dims is None:
+        action_key_dims = {k: 1 for k in action_keys}
+    if state_key_dims is None:
+        state_key_dims = {k: 1 for k in state_keys}
+
+    def _split_combined(
+        combined: Dict[str, Sequence[float]],
+        keys: Sequence[str],
+        key_dims: Dict[str, int],
+    ):
+        """Split combined arrays into per-subkey dicts using per-key dims.
+
+        ``combined`` looks like ``{"min": [..D..], "max": [..D..], "mask": [..D..], ...}``.
+        ``keys`` is the ordered list of full keys.
+        ``key_dims`` maps each full key to its integer dimension.
+        Returns ``(stats_per_subkey, meta_per_subkey)``.
+        """
+        stats_per_subkey: Dict[str, Dict[str, List[float]]] = {}
+        meta_per_subkey: Dict[str, StateActionMetadata] = {}
+        cursor = 0
+        for full_key in keys:
+            subkey = full_key.split(".", 1)[1]
+            dim_k = key_dims.get(full_key, 1)
+            per_key: Dict[str, List[float]] = {}
+            for stat_name, arr in combined.items():
+                if stat_name == "mask":
+                    continue
+                end = cursor + dim_k
+                if end > len(arr):
+                    # Saved combined array shorter than expected (truncated
+                    # pad channels etc.). Skip this stat field silently.
+                    continue
+                per_key[stat_name] = [float(v) for v in arr[cursor:end]]
+            stats_per_subkey[subkey] = per_key
+            meta_per_subkey[subkey] = StateActionMetadata(
+                absolute=True,
+                rotation_type=None,
+                shape=(dim_k,),
+                continuous=True,
+            )
+            cursor += dim_k
+        return stats_per_subkey, meta_per_subkey
+
+    action_combined = stats_for_key.get("action", {})
+    state_combined = stats_for_key.get("state", {})
+
+    action_stats, action_meta = _split_combined(action_combined, action_keys, action_key_dims)
+    state_stats, state_meta = _split_combined(state_combined, state_keys, state_key_dims)
+
+    # Pydantic accepts dict input with field validators
+    return DatasetMetadata.model_validate(
+        {
+            "statistics": {
+                "state": state_stats,
+                "action": action_stats,
+            },
+            "modalities": {
+                "video": {},
+                "state": state_meta,
+                "action": action_meta,
+            },
+            "embodiment_tag": embodiment_tag.value
+            if hasattr(embodiment_tag, "value")
+            else embodiment_tag,
+        }
+    )
+
+
+class PolicyNormProcessor:
+    """Server-side normalization helper backed by training-time transforms.
+
+    Construct once per checkpoint; call :meth:`unapply_actions` to convert
+    a normalized action chunk ``(T, D)`` back to env-space.
+
+    Args:
+        ckpt_path: Path to the ``*.pt`` checkpoint (the loader looks for
+            ``config.yaml`` and ``dataset_statistics.json`` two dirs up).
+        unnorm_key: Which top-level key in ``dataset_statistics.json`` to use.
+            ``None`` → auto-pick the only key.
+    """
+
+    def __init__(self, ckpt_path: str, unnorm_key: Optional[str] = None) -> None:
+        self._ckpt_path = str(ckpt_path)
+        cfg, norm_stats = read_mode_config(self._ckpt_path)
+        self._model_cfg = cfg
+        self._norm_stats = norm_stats
+
+        # 3-early) Pick the requested unnorm_key (or auto-select) BEFORE
+        # resolving robot_type so we can use it as a hint for multi-robot mixtures.
+        if unnorm_key is None:
+            if len(norm_stats) == 1:
+                unnorm_key = next(iter(norm_stats.keys()))
+            # else: defer error to step 3 below after robot_type resolution attempt
+        elif unnorm_key not in norm_stats:
+            raise KeyError(
+                f"unnorm_key={unnorm_key!r} not in {list(norm_stats.keys())}"
+            )
+        self._unnorm_key = unnorm_key  # may still be None for multi-key case
+
+        # 1) Resolve which DataConfig was used at training.
+        robot_type = _resolve_robot_type(cfg, unnorm_key=unnorm_key)
+        if robot_type not in ROBOT_TYPE_CONFIG_MAP:
+            raise KeyError(
+                f"robot_type={robot_type!r} not in ROBOT_TYPE_CONFIG_MAP "
+                f"(available: {sorted(ROBOT_TYPE_CONFIG_MAP.keys())}). "
+                "Make sure the example's data_registry/data_config.py is importable."
+            )
+        self._data_config = ROBOT_TYPE_CONFIG_MAP[robot_type]
+        self._action_keys: List[str] = list(self._data_config.action_keys)
+        self._state_keys: List[str] = list(getattr(self._data_config, "state_keys", []))
+
+        # 2) Build training-time transform pipeline.
+        transform = self._data_config.transform()
+        if not isinstance(transform, ComposedModalityTransform):
+            transform = ComposedModalityTransform(transforms=[transform])
+        self._transform = transform
+
+        # 3) Pick the requested unnorm_key (finalize; error if still None here).
+        if self._unnorm_key is None:
+            raise ValueError(
+                f"Multiple unnorm_keys in dataset_statistics.json: "
+                f"{list(norm_stats.keys())}. Pass unnorm_key explicitly."
+            )
+        unnorm_key = self._unnorm_key
+
+        # 4) Resolve per-key dims (handles multi-d action/state keys).
+        stats_for_unnorm = norm_stats[unnorm_key]
+        self._action_key_dims: Dict[str, int] = _infer_key_dims(
+            self._data_config, stats_for_unnorm, self._action_keys, "action"
+        )
+        self._state_key_dims: Dict[str, int] = _infer_key_dims(
+            self._data_config, stats_for_unnorm, self._state_keys, "state"
+        )
+
+        # 5) Build & bind metadata.
+        ds_meta = _build_dataset_metadata(
+            stats_for_key=stats_for_unnorm,
+            embodiment_tag=self._data_config.embodiment_tag,
+            action_keys=self._action_keys,
+            state_keys=self._state_keys,
+            action_key_dims=self._action_key_dims,
+            state_key_dims=self._state_key_dims,
+        )
+        self._transform.set_metadata(ds_meta)
+        self._transform.eval()  # mark transforms as eval-mode
+
+        logger.info(
+            "PolicyNormProcessor ready: robot_type=%s, unnorm_key=%s, "
+            "action_keys=%s (dims=%s), state_keys=%s",
+            robot_type,
+            unnorm_key,
+            self._action_keys,
+            [self._action_key_dims[k] for k in self._action_keys],
+            self._state_keys,
+        )
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+    @property
+    def action_keys(self) -> List[str]:
+        return list(self._action_keys)
+
+    @property
+    def state_keys(self) -> List[str]:
+        return list(self._state_keys)
+
+    @property
+    def unnorm_key(self) -> str:
+        return self._unnorm_key
+
+    @property
+    def available_unnorm_keys(self) -> List[str]:
+        return list(self._norm_stats.keys())
+
+    @property
+    def transform(self) -> ComposedModalityTransform:
+        return self._transform
+
+    # ------------------------------------------------------------------
+    # Inverse path (model output → env action)
+    # ------------------------------------------------------------------
+    def unapply_actions(self, normalized_actions: np.ndarray) -> np.ndarray:
+        """Invert action normalization using the training-time pipeline.
+
+        Args:
+            normalized_actions: shape ``(T, D)`` where
+                ``D == sum(action_key_dims.values())``.
+
+        Returns:
+            ``(T, D)`` un-normalized actions in env coordinates.
+        """
+        normalized_actions = np.asarray(normalized_actions)
+        assert normalized_actions.ndim == 2, (
+            f"Expected (T, D); got shape {normalized_actions.shape}"
+        )
+
+        # Split (T, D) into per-key {full_key: torch.Tensor[T, dim_k]}.
+        data: Dict[str, torch.Tensor] = {}
+        cursor = 0
+        for full_key in self._action_keys:
+            dim_k = self._action_key_dims.get(full_key, 1)
+            slice_ = normalized_actions[..., cursor : cursor + dim_k]
+            data[full_key] = torch.as_tensor(slice_, dtype=torch.float32)
+            cursor += dim_k
+
+        if cursor != normalized_actions.shape[-1]:
+            raise ValueError(
+                f"Sum of per-key dims ({cursor}) != action_dim "
+                f"({normalized_actions.shape[-1]}). "
+                f"action_keys={self._action_keys}, "
+                f"action_key_dims={self._action_key_dims}"
+            )
+
+        out = self._transform.unapply(data)
+
+        parts: List[np.ndarray] = []
+        for full_key in self._action_keys:
+            v = out[full_key]
+            if isinstance(v, torch.Tensor):
+                v = v.detach().cpu().numpy()
+            parts.append(np.asarray(v))
+        return np.concatenate(parts, axis=-1)

--- a/deployment/model_server/policy_wrapper.py
+++ b/deployment/model_server/policy_wrapper.py
@@ -1,0 +1,162 @@
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License.
+"""Policy server wrapper.
+
+Encapsulates a `baseframework` instance plus a :class:`PolicyNormProcessor`
+that reuses the *training-time* :class:`ComposedModalityTransform` for action
+un-normalization (no hand-rolled math). The websocket server returns
+already-unnormalized actions.
+
+Client-side responsibilities that REMAIN on the client:
+  - environment-specific adapters (image_history, gripper sticky, action
+    ensembling)
+  - chunk-cache scheduling (`step % chunk_size == 0` triggers a new infer)
+
+Exposed API:
+  - ``metadata`` (dict, sent at handshake): ``action_chunk_size``,
+    ``available_unnorm_keys``, ``action_keys``, ``state_keys``.
+  - ``predict_action(examples, unnorm_key=None, **kwargs)`` returns
+    ``{"actions": np.ndarray[B, T, action_dim]}``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.framework.share_tools import read_mode_config
+
+from deployment.model_server.policy_norm_processor import PolicyNormProcessor
+
+
+class PolicyServerWrapper:
+    """Wraps a `baseframework` for use as a websocket-server policy."""
+
+    def __init__(
+        self,
+        ckpt_path: str,
+        device: str = "cuda",
+        use_bf16: bool = False,
+        unnorm_key: Optional[str] = None,
+    ) -> None:
+        self._ckpt_path = str(ckpt_path)
+
+        logging.info("PolicyServerWrapper: loading framework from %s", self._ckpt_path)
+        framework = baseframework.from_pretrained(self._ckpt_path)
+        if use_bf16:
+            framework = framework.to(torch.bfloat16)
+        framework = framework.to(device).eval()
+        self._framework = framework
+
+        # Co-located metadata.
+        model_cfg, _ = read_mode_config(self._ckpt_path)
+        self._model_cfg = model_cfg
+
+        # action_chunk_size = future_action_window_size + 1 (matches old client).
+        action_model_cfg = model_cfg["framework"]["action_model"]
+        
+        if "action_horizon" in action_model_cfg:
+            self._action_chunk_size = int(action_model_cfg["action_horizon"])
+        elif "future_action_window_size" in action_model_cfg:
+            self._action_chunk_size = int(action_model_cfg["future_action_window_size"]) + 1
+        else:
+            raise ValueError(
+                f"PolicyServerWrapper: no action_horizon or future_action_window_size found in model config for {self._ckpt_path}"
+            )
+        # Cache of PolicyNormProcessor instances per unnorm_key.
+        # For single-dataset ckpts unnorm_key is auto-selected; for multi-dataset
+        # ckpts clients must pass unnorm_key per request.
+        self._default_unnorm_key = unnorm_key
+        self._norm_processors: Dict[str, PolicyNormProcessor] = {}
+
+        # Peek at available keys without building a full processor.
+        _, _ns = read_mode_config(self._ckpt_path)
+        self._available_unnorm_keys: List[str] = list(_ns.keys())
+
+        # Eagerly build when unambiguous; defer for multi-key / no explicit key.
+        if unnorm_key is not None or len(self._available_unnorm_keys) == 1:
+            default_proc = self._get_processor(unnorm_key)
+            self._default_unnorm_key = default_proc.unnorm_key
+            logging.info(
+                "PolicyServerWrapper ready: action_chunk_size=%d, default_unnorm_key=%s, "
+                "available_unnorm_keys=%s, action_keys=%s, state_keys=%s",
+                self._action_chunk_size,
+                default_proc.unnorm_key,
+                default_proc.available_unnorm_keys,
+                default_proc.action_keys,
+                default_proc.state_keys,
+            )
+        else:
+            logging.info(
+                "PolicyServerWrapper ready (multi-key): action_chunk_size=%d, "
+                "available_unnorm_keys=%s — clients must pass unnorm_key per request.",
+                self._action_chunk_size,
+                self._available_unnorm_keys,
+            )
+
+    def _get_processor(self, unnorm_key: Optional[str]) -> PolicyNormProcessor:
+        cache_key = unnorm_key if unnorm_key is not None else "__default__"
+        if cache_key not in self._norm_processors:
+            self._norm_processors[cache_key] = PolicyNormProcessor(
+                self._ckpt_path, unnorm_key=unnorm_key
+            )
+        return self._norm_processors[cache_key]
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        """Model-invariant metadata; sent to client at websocket handshake."""
+        base = {
+            "env": "starvla_policy_server",
+            "ckpt_path": self._ckpt_path,
+            "action_chunk_size": self._action_chunk_size,
+            "available_unnorm_keys": self._available_unnorm_keys,
+            "default_unnorm_key": self._default_unnorm_key,
+        }
+        # Enrich with per-embodiment keys when a default processor already exists.
+        if self._default_unnorm_key is not None:
+            proc = self._get_processor(self._default_unnorm_key)
+            base["action_keys"] = proc.action_keys
+            base["state_keys"] = proc.state_keys
+        return base
+
+    def predict_action(
+        self,
+        examples: List[dict],
+        unnorm_key: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, np.ndarray]:
+        """Run the framework, then un-normalize via training-time transforms.
+
+        Args:
+            examples: list of dicts (each with ``image`` / ``lang`` / optional ``state``).
+            unnorm_key: dataset key for un-normalization stats. ``None`` -->
+                use the wrapper's default (auto-picked at startup).
+            **kwargs: forwarded to the framework's ``predict_action``
+                (``do_sample``, ``use_ddim``, ``num_ddim_steps``, ...).
+
+        Returns:
+            ``{"actions": np.ndarray[B, T, D]}`` -- un-normalized.
+        """
+        effective_key = unnorm_key if unnorm_key is not None else self._default_unnorm_key
+        if effective_key is None:
+            if len(self._available_unnorm_keys) == 1:
+                effective_key = self._available_unnorm_keys[0]
+            else:
+                raise ValueError(
+                    f"predict_action: unnorm_key not specified and no default set. "
+                    f"Pass one of {self._available_unnorm_keys}."
+                )
+        proc = self._get_processor(effective_key)
+
+        out = self._framework.predict_action(examples=examples, **kwargs)
+        normalized = np.asarray(out["normalized_actions"])  # (B, T, D)
+
+        unnorm = np.stack(
+            [proc.unapply_actions(normalized[b]) for b in range(normalized.shape[0])],
+            axis=0,
+        )
+        return {"actions": unnorm}

--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -7,39 +7,36 @@ import logging
 import os
 import socket
 
-import torch
-
+from deployment.model_server.policy_wrapper import PolicyServerWrapper
 from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
-from starVLA.model.framework.base_framework import baseframework
 
 
 def main(args) -> None:
-    # Example usage:
-    # policy = YourPolicyClass()  # Replace with your actual policy class
-    # server = WebsocketPolicyServer(policy, host="localhost", port=10091)
-    # server.serve_forever()
+    """Build the policy wrapper and start the websocket server.
 
-    vla = baseframework.from_pretrained(  # TODO should auto detect framework from model path
-        args.ckpt_path,
+    The wrapper now owns un-normalization + chunk_size discovery so that all
+    eval clients (LIBERO / SimplerEnv / etc.) just need to forward `examples`
+    and consume already-unnormalized actions from the response.
+    """
+    wrapper = PolicyServerWrapper(
+        ckpt_path=args.ckpt_path,
+        device="cuda",
+        use_bf16=args.use_bf16,
     )
-
-    if args.use_bf16:  # False
-        vla = vla.to(torch.bfloat16)
-    vla = vla.to("cuda").eval()
 
     hostname = socket.gethostname()
     local_ip = socket.gethostbyname(hostname)
     logging.info("Creating server (host: %s, ip: %s)", hostname, local_ip)
 
-    # start websocket server
+    # start websocket server; wrapper.metadata is sent at handshake.
     server = WebsocketPolicyServer(
-        policy=vla,
+        policy=wrapper,
         host="0.0.0.0",
         port=args.port,
         idle_timeout=args.idle_timeout,
-        metadata={"env": "simpler_env"},
+        metadata=wrapper.metadata,
     )
-    logging.info("server running ...")
+    logging.info("server running ... metadata=%s", wrapper.metadata)
     server.serve_forever()
 
 


### PR DESCRIPTION
## Summary

Adds the three server-side modules that complete the model server v3 stack
introduced in #314 (client interfaces) and complement the websocket server loop.

## Changes

**`deployment/model_server/server_policy.py`**
- Policy loading logic for the WebSocket policy server
- Loads a starVLA checkpoint and exposes a `predict()` interface consumed by the server loop

**`deployment/model_server/policy_wrapper.py`**
- `PolicyServerWrapper` — wraps any VLM4A framework instance to provide a
  uniform server-side `predict()` API, handling batching, device placement,
  and action post-processing

**`deployment/model_server/policy_norm_processor.py`**
- `PolicyNormProcessor` — rebuilds the exact `ComposedModalityTransform`
  used at training time directly from a checkpoint (`config.yaml` +
  `dataset_statistics.json`)
- Replaces hand-rolled un-normalization math that previously lived in every
  eval client — single source of truth for normalization logic

## Related

Follows up on #314 (client interfaces merged).