### PR TITLE
introduce molmo2 into vlm

### DIFF
--- a/starVLA/model/modules/vlm/Molmo2.py
+++ b/starVLA/model/modules/vlm/Molmo2.py
@@ -1,0 +1,209 @@
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License").
+"""
+Molmo2 VL Interface for starVLA.
+
+Mirrors `_QWen3_VL_Interface` (./QWen3.py) and `_Gemma4_VL_Interface` (./Gemma4.py)
+so framework files calling `qwen_vl_interface.{forward, generate, build_qwenvl_inputs}`
+work unchanged when the dispatcher in `__init__.py` returns this class.
+
+Backed by the AllenAI Molmo2 collection:
+    https://huggingface.co/collections/allenai/molmo2
+
+    | Model               | Text backbone           | Vision backbone        |
+    |---------------------|-------------------------|------------------------|
+    | allenai/Molmo2-4B   | Qwen3-4B-Instruct-2507  | SigLIP 2 so400m/14-384 |
+    | allenai/Molmo2-8B   | Qwen3-8B                | SigLIP 2 so400m/14-384 |
+    | allenai/Molmo2-O-7B | OLMo-2-7B               | SigLIP 2 so400m/14-384 |
+    | allenai/Molmo2-VideoPoint-4B | Qwen3-4B-Instruct-2507 | SigLIP 2        |
+
+All checkpoints ship custom modeling code, so loading goes through
+`AutoModelForImageTextToText` with `trust_remote_code=True`.
+
+Notable feature for VLA: Molmo2 natively emits 2D pointing tokens in the form
+`<points coords="x:y, ..."/>` (and `<tracks .../>` for the VideoPoint variant),
+with coordinates normalized to [0, 1000]. This is useful as an auxiliary grounding
+signal when training action heads on top of the last hidden state.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from transformers import AutoModelForImageTextToText, AutoProcessor
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+from starVLA.training.trainer_utils import initialize_overwatch
+
+logger = initialize_overwatch(__name__)
+
+IGNORE_INDEX = -100
+
+
+class _Molmo2_VL_Interface(nn.Module):
+    """
+    Lightweight wrapper around `allenai/Molmo2-*` checkpoints.
+
+    Purpose:
+        - Match the interface of `_QWen3_VL_Interface` exactly so framework files
+          can be VLM-agnostic.
+        - Centralize Molmo2-specific preprocessing (chat template + multimodal packing).
+        - Surface `model.config.hidden_size = text_config.hidden_size` so downstream
+          DiT / flow-matching heads can read it the same way they read it for Qwen3-VL.
+    """
+
+    def __init__(self, config: Optional[dict] = None, **kwargs):
+        super().__init__()
+
+        qwenvl_config = config.framework.get("qwenvl", {})
+        model_id = qwenvl_config.get("base_vlm", "allenai/Molmo2-4B")
+        attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
+        enable_grad_ckpt = bool(qwenvl_config.get("enable_gradient_checkpointing", False))
+
+        # Fall back to sdpa if flash_attention_2 is requested but flash_attn isn't installed.
+        if attn_implementation == "flash_attention_2":
+            try:
+                import flash_attn  # noqa: F401
+            except ImportError:
+                print("[Molmo2][WARNING] flash_attn not installed, falling back to sdpa")
+                attn_implementation = "sdpa"
+
+        model = AutoModelForImageTextToText.from_pretrained(
+            model_id,
+            trust_remote_code=True,
+            attn_implementation=attn_implementation,
+            dtype=torch.bfloat16,
+        )
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        if hasattr(processor, "tokenizer") and processor.tokenizer is not None:
+            processor.tokenizer.padding_side = "left"
+
+        if enable_grad_ckpt:
+            try:
+                model.gradient_checkpointing_enable(
+                    gradient_checkpointing_kwargs={"use_reentrant": False}
+                )
+                if hasattr(model, "enable_input_require_grads"):
+                    model.enable_input_require_grads()
+                print("[Molmo2] gradient_checkpointing ENABLED (use_reentrant=False)", flush=True)
+            except Exception as e:
+                print(f"[Molmo2] failed to enable gradient_checkpointing: {e}", flush=True)
+
+        self.model = model
+        self.processor = processor
+        self.config = config
+
+        # Surface the text-tower hidden size at the top level so downstream code that
+        # reads `model.config.hidden_size` keeps working without a Molmo2 special case.
+        text_cfg = getattr(self.model.config, "text_config", None)
+        if text_cfg is None or not hasattr(text_cfg, "hidden_size"):
+            raise RuntimeError(
+                f"[Molmo2] could not locate text_config.hidden_size on `{model_id}`. "
+                f"Check that the checkpoint exposes a Qwen3/OLMo-style text_config."
+            )
+        self.model.config.hidden_size = text_cfg.hidden_size
+
+    def forward(self, **kwargs) -> CausalLMOutputWithPast:
+        """
+        Forward pass through the underlying Molmo2 backbone.
+
+        Action / flow-matching heads consume only `hidden_states`, so we cap
+        `logits_to_keep=1` by default to avoid materializing a huge (B, L, vocab)
+        bf16 tensor. Callers can override.
+        """
+        kwargs.setdefault("logits_to_keep", 1)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            outputs = self.model(**kwargs)
+        return outputs
+
+    def generate(self, **kwargs):
+        with torch.autocast("cuda", dtype=torch.float16):
+            return self.model.generate(**kwargs)
+
+    def build_qwenvl_inputs(self, images, instructions, solutions=None, **kwargs):
+        """
+        Build a model-ready batch from raw (images, instructions). Same name and
+        signature as `_QWen3_VL_Interface.build_qwenvl_inputs`.
+
+        Args:
+            images:       list[list[PIL.Image]] — multi-view images per sample.
+            instructions: list[str]            — one instruction per sample.
+            solutions:    optional list[str]   — assistant turn for SFT-style training.
+
+        Returns:
+            BatchFeature on `self.model.device`.
+        """
+        assert len(images) == len(instructions), "images and instructions must batch-align"
+
+        messages = []
+        for imgs, instruction in zip(images, instructions):
+            content = [{"type": "image", "image": img} for img in imgs]
+
+            if "CoT_prompt" in self.config.datasets.vla_data:
+                cot_prompt = self.config.datasets.vla_data.get("CoT_prompt", "")
+                prompt = cot_prompt.replace("{instruction}", instruction)
+            else:
+                prompt = instruction
+
+            content.append({"type": "text", "text": prompt})
+            msg = [{"role": "user", "content": content}]
+
+            if solutions is not None:
+                msg.append(
+                    {"role": "assistant", "content": [{"type": "text", "text": solutions[len(messages)]}]}
+                )
+            messages.append(msg)
+
+        batch_inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            padding=True,
+            add_generation_prompt=(solutions is None),
+            return_dict=True,
+            return_tensors="pt",
+        )
+        return batch_inputs.to(self.model.device)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import numpy as np
+    from omegaconf import OmegaConf
+    from PIL import Image
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="allenai/Molmo2-4B",
+        help="HF model id or local path (any allenai/Molmo2-* checkpoint).",
+    )
+    parser.add_argument("--attn", type=str, default="sdpa", choices=["eager", "sdpa", "flash_attention_2"])
+    args = parser.parse_args()
+
+    cfg = OmegaConf.create(
+        {
+            "framework": {
+                "qwenvl": {
+                    "base_vlm": args.model_id,
+                    "attn_implementation": args.attn,
+                }
+            },
+            "datasets": {"vla_data": {}},
+        }
+    )
+
+    iface = _Molmo2_VL_Interface(cfg)
+    print(f"[Molmo2] hidden_size = {iface.model.config.hidden_size}")
+    print(f"[Molmo2] device = {next(iface.model.parameters()).device}")
+
+    img = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
+    batch = iface.build_qwenvl_inputs(
+        images=[[img, img], [img, img]],
+        instructions=["Pick up the red block.", "Stack the green cube on the blue cube."],
+    )
+    print(f"[Molmo2] input_ids shape = {batch['input_ids'].shape}")
+    out = iface(**batch, output_hidden_states=True, return_dict=True)
+    print(f"[Molmo2] last hidden state shape = {tuple(out.hidden_states[-1].shape)}")
+    print("[Molmo2] OK")

--- a/starVLA/model/modules/vlm/README.md
+++ b/starVLA/model/modules/vlm/README.md
@@ -31,6 +31,8 @@ vlm = get_vlm_model(config)  # 根据 config.framework.qwenvl.base_vlm 路由
 | `QWen3.py` | `_QWen3_VL_Interface` | Qwen3-VL 系列 |
 | `QWen3_5.py` | `_QWen3_5_VL_Interface` | Qwen3.5-VL 系列 |
 | `Florence2.py` | `_Florence_Interface` | Florence-2 系列 |
+| `Gemma4.py` | `_Gemma4_VL_Interface` | Gemma-4 (E2B 等) |
+| `Molmo2.py` | `_Molmo2_VL_Interface` | AllenAI Molmo2 (4B / 8B / O-7B / VideoPoint-4B) |
 
 ## 与 World Model 的关系
 

--- a/starVLA/model/modules/vlm/__init__.py
+++ b/starVLA/model/modules/vlm/__init__.py
@@ -18,6 +18,10 @@ def get_vlm_model(config):
         from .Gemma4 import _Gemma4_VL_Interface
 
         return _Gemma4_VL_Interface(config)
+    elif "molmo2" in vlm_name.lower():
+        from .Molmo2 import _Molmo2_VL_Interface
+
+        return _Molmo2_VL_Interface(config)
     elif "florence" in vlm_name.lower():  # temp for some ckpt
         from .Florence2 import _Florence_Interface
 


### PR DESCRIPTION
## Description
Introduces the AllenAI **Molmo2** VLM family (4B / 8B / O-7B / VideoPoint-4B) as a new backend under `starVLA/model/modules/vlm/`, behind the same `qwen_vl_interface` contract that existing VLA frameworks already call.

## Motivation
Molmo2 pairs Qwen3 / OLMo-2 text towers with SigLIP-2 vision and natively emits 2D `<points coords=".../>` grounding tokens — a strong fit as a VLA backbone where pointing can serve as an auxiliary action-grounding signal. the recent Molmo2Act also apply Molmo2 as backbone. also Molmo2 have lightweight size 4b and 8b.

Closes #

## Changes
- `starVLA/model/modules/vlm/Molmo2.py` — new `_Molmo2_VL_Interface(nn.Module)` mirroring `_QWen3_VL_Interface` / `_Gemma4_VL_Interface`. Loads via `AutoModelForImageTextToText` with `trust_remote_code=True`, surfaces `text_config.hidden_size` on `model.config.hidden_size`, implements `forward` / `generate` / `build_qwenvl_inputs`, honors `attn_implementation`, `enable_gradient_checkpointing`, and the `CoT_prompt` rewrite. Defaults to `allenai/Molmo2-4B`.
- `starVLA/model/modules/vlm/__init__.py` — added a `"molmo2" in vlm_name.lower()` branch in `get_vlm_model` that routes to `_Molmo2_VL_Interface`.
- `starVLA/model/modules/vlm/README.md` — added rows for Molmo2 (and the previously missing Gemma-4) to the implementations table.

## Testing
<!-- - [ ] `make check` passes  TODO: enable later -->
- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
|           |        |        |

- **Checkpoint**: <!-- TODO: public HF link to Molmo2-VLA finetune -->
- **Config**: <!-- TODO: examples/.../molmo2_*.yaml -->
- **Reproduce**: `python -m starVLA.model.modules.vlm.Molmo2 --model_id allenai/Molmo2-4B` for the standalone smoke test; full training reproduction command pending checkpoint.

## Type of Change
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` <!-- TODO: add a Molmo2 example yaml -->
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — only `starVLA/model/modules/vlm/` was touched (no `dataloader/`, `training/`, or `config/` edits)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public) <!-- N/A: backbone integration only, no new framework -->

## Screenshots / Logs (optional)
<!-- Add Molmo2 smoke-test output and any training curves once a Molmo2-based VLA finetune is run. -->
