### PR TITLE
[feat] trainer: make dataloader throughput configurable

### DIFF
--- a/docs/starVLA_guideline.md
+++ b/docs/starVLA_guideline.md
@@ -179,12 +179,35 @@ datasets:
   vlm_data:                       # VLM co-training data (improves generalization)
     dataset_py: vlm_datasets
     per_device_batch_size: 4
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
 
   vla_data:                       # Robot action data
     dataset_py: lerobot_datasets
     data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_all          # all 4 suites; use "libero_goal" for single suite
     per_device_batch_size: 16
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
+```
+
+Each dataset section accepts the same PyTorch DataLoader throughput options:
+`num_workers`, `pin_memory`, `persistent_workers`, `prefetch_factor`,
+`drop_last`, and `timeout`. The defaults above match the historical hard-coded
+loader behavior, and old configs that omit these fields continue to work.
+When `num_workers: 0`, `prefetch_factor` is ignored and
+`persistent_workers: true` is invalid. Command-line overrides work as usual:
+
+```bash
+--datasets.vla_data.num_workers 8 --datasets.vla_data.pin_memory true
 ```
 
 The `data_mix` field selects which datasets to combine. These mixtures are defined in [`examples/LIBERO/train_files/data_registry/data_config.py`](../examples/LIBERO/train_files/data_registry/data_config.py):

--- a/starVLA/config/training/starvla_cotrain_libero.yaml
+++ b/starVLA/config/training/starvla_cotrain_libero.yaml
@@ -56,6 +56,12 @@ datasets:
     model_max_length: 2048 
     model_type: qwen2.5vl
     per_device_batch_size: 4
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
 
   vla_data:
     dataset_py: lerobot_datasets
@@ -65,6 +71,12 @@ datasets:
     action_type: delta_qpos
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
     per_device_batch_size: 16
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
     load_all_data_for_training: true
 
 trainer:

--- a/starVLA/config/training/starvla_cotrain_oxe.yaml
+++ b/starVLA/config/training/starvla_cotrain_oxe.yaml
@@ -54,6 +54,12 @@ datasets:
     model_max_length: 2048
     model_type: qwen2.5vl
     per_device_batch_size: 4
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
 
   vla_data:
     dataset_py: lerobot_datasets
@@ -63,6 +69,12 @@ datasets:
     action_type: delta_ee
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
     per_device_batch_size: 16
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
     load_all_data_for_training: true
     obs_image_size: [224, 224]
 

--- a/starVLA/config/training/starvla_train_adapter.yaml
+++ b/starVLA/config/training/starvla_train_adapter.yaml
@@ -35,6 +35,12 @@ datasets:
     action_type: delta_qpos
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
     per_device_batch_size: 16
+    num_workers: 4
+    pin_memory: false
+    persistent_workers: false
+    prefetch_factor: 2
+    drop_last: false
+    timeout: 0
     load_all_data_for_training: true
     video_backend: torchvision_av
 

--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -1,14 +1,17 @@
 import json
 import os
-from accelerate.logging import get_logger
-import numpy as np
-from torch.utils.data import DataLoader
+from pathlib import Path
+
 import numpy as np
 import torch.distributed as dist
-from pathlib import Path
+from accelerate.logging import get_logger
+from torch.utils.data import DataLoader
+
+from starVLA.dataloader.dataloader_options import build_dataloader_kwargs
 from starVLA.dataloader.vlm_datasets import make_vlm_dataloader
 
 logger = get_logger(__name__)
+
 
 def save_dataset_statistics(dataset_statistics, run_dir):
     """Saves a `dataset_statistics.json` file."""
@@ -32,29 +35,31 @@ def save_dataset_statistics(dataset_statistics, run_dir):
     logger.info(f"Saved dataset statistics file at path {out_path}")
 
 
-
-def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here only is get dataset, we need mv dataloader to here
+def build_dataloader(
+    cfg, dataset_py="lerobot_datasets_oxe"
+):  # TODO now here only is get dataset, we need mv dataloader to here
 
     if dataset_py == "lerobot_datasets":
-        from starVLA.dataloader.lerobot_datasets import get_vla_dataset, collate_fn
+        from starVLA.dataloader.lerobot_datasets import collate_fn, get_vla_dataset
+
         vla_dataset_cfg = cfg.datasets.vla_data
 
         vla_dataset = get_vla_dataset(data_cfg=vla_dataset_cfg)
-        
+
         vla_train_dataloader = DataLoader(
             vla_dataset,
             batch_size=cfg.datasets.vla_data.per_device_batch_size,
             collate_fn=collate_fn,
-            num_workers=4,
+            **build_dataloader_kwargs(vla_dataset_cfg),
             # shuffle=True
-        )        
-        if dist.get_rank() == 0: 
-            
+        )
+        if dist.get_rank() == 0:
+
             output_dir = Path(cfg.output_dir)
             vla_dataset.save_dataset_statistics(output_dir / "dataset_statistics.json")
         return vla_train_dataloader
     elif dataset_py == "vlm_datasets":
         vlm_data_module = make_vlm_dataloader(cfg)
         vlm_train_dataloader = vlm_data_module["train_dataloader"]
-        
+
         return vlm_train_dataloader

--- a/starVLA/dataloader/dataloader_options.py
+++ b/starVLA/dataloader/dataloader_options.py
@@ -1,0 +1,79 @@
+"""Helpers for dataset-level PyTorch DataLoader options."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DATALOADER_DEFAULTS = {
+    "num_workers": 4,
+    "pin_memory": False,
+    "persistent_workers": False,
+    "prefetch_factor": 2,
+    "drop_last": False,
+    "timeout": 0,
+}
+
+
+def _get_config_value(config: Any, key: str, default: Any) -> Any:
+    if hasattr(config, "get"):
+        value = config.get(key, default)
+    else:
+        value = getattr(config, key, default)
+    return default if value is None else value
+
+
+def _as_bool(value: Any, key: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off"}:
+            return False
+    raise ValueError(f"DataLoader option `{key}` must be a boolean, got {value!r}.")
+
+
+def _as_int(value: Any, key: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"DataLoader option `{key}` must be an integer, got {value!r}.")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"DataLoader option `{key}` must be an integer, got {value!r}.") from exc
+
+
+def build_dataloader_kwargs(data_cfg: Any) -> dict[str, Any]:
+    """Build DataLoader kwargs from a dataset config, preserving legacy defaults."""
+    num_workers = _as_int(_get_config_value(data_cfg, "num_workers", DATALOADER_DEFAULTS["num_workers"]), "num_workers")
+    timeout = _as_int(_get_config_value(data_cfg, "timeout", DATALOADER_DEFAULTS["timeout"]), "timeout")
+    persistent_workers = _as_bool(
+        _get_config_value(data_cfg, "persistent_workers", DATALOADER_DEFAULTS["persistent_workers"]),
+        "persistent_workers",
+    )
+
+    if num_workers < 0:
+        raise ValueError("DataLoader option `num_workers` must be non-negative.")
+    if timeout < 0:
+        raise ValueError("DataLoader option `timeout` must be non-negative.")
+    if num_workers == 0 and persistent_workers:
+        raise ValueError("DataLoader option `persistent_workers=True` requires `num_workers > 0`.")
+
+    kwargs = {
+        "num_workers": num_workers,
+        "pin_memory": _as_bool(
+            _get_config_value(data_cfg, "pin_memory", DATALOADER_DEFAULTS["pin_memory"]), "pin_memory"
+        ),
+        "persistent_workers": persistent_workers,
+        "drop_last": _as_bool(_get_config_value(data_cfg, "drop_last", DATALOADER_DEFAULTS["drop_last"]), "drop_last"),
+        "timeout": timeout,
+    }
+    if num_workers > 0:
+        prefetch_factor = _as_int(
+            _get_config_value(data_cfg, "prefetch_factor", DATALOADER_DEFAULTS["prefetch_factor"]),
+            "prefetch_factor",
+        )
+        if prefetch_factor <= 0:
+            raise ValueError("DataLoader option `prefetch_factor` must be positive when `num_workers > 0`.")
+        kwargs["prefetch_factor"] = prefetch_factor
+    return kwargs

--- a/starVLA/dataloader/vlm_datasets.py
+++ b/starVLA/dataloader/vlm_datasets.py
@@ -1,28 +1,26 @@
-import os
 import copy
-import json
-import random
-import logging
-import re
-import time
-import math
 import itertools
-import ast
-from dataclasses import dataclass
-from typing import Dict, Optional, Sequence, List, Tuple
-from io import BytesIO
-import base64
+import json
+import os
+import random
+import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Dict, List
+
 import numpy as np
 import torch
-from torch.utils.data import Dataset
-from PIL import Image
-from decord import VideoReader
 import transformers
+from decord import VideoReader
 from omegaconf import OmegaConf
+from PIL import Image
+from torch.utils.data import Dataset
+from transformers import AutoProcessor
+
+from starVLA.dataloader.dataloader_options import build_dataloader_kwargs
 from starVLA.dataloader.qwenvl_llavajson.qwen_data_config import data_list
-from starVLA.dataloader.qwenvl_llavajson.rope2d import get_rope_index_25, get_rope_index_2
+from starVLA.dataloader.qwenvl_llavajson.rope2d import get_rope_index_2, get_rope_index_25
 
 IGNORE_INDEX = -100
 IMAGE_TOKEN_INDEX = 151655
@@ -46,16 +44,22 @@ def read_jsonl(path):
 def preprocess_qwen_2_visual(
     sources,
     tokenizer: transformers.PreTrainedTokenizer,
-    grid_thw: List = [],
+    grid_thw: List | None = None,
     visual_type: str = "image",
 ) -> Dict:
+    if grid_thw is None:
+        grid_thw = []
     roles = {"human": "user", "gpt": "assistant"}
     system_message = "You are a helpful assistant."
     if visual_type not in ["image", "video"]:
         raise ValueError("visual_type must be either 'image' or 'video'")
 
     tokenizer = copy.deepcopy(tokenizer)
-    chat_template = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
+    chat_template = (
+        "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] "
+        "+ '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}"
+        "{{ '<|im_start|>assistant\n' }}{% endif %}"
+    )
     tokenizer.chat_template = chat_template
 
     visual_replicate_index = 0
@@ -65,7 +69,7 @@ def preprocess_qwen_2_visual(
         try:
             if roles[source[0]["from"]] != roles["human"]:
                 source = source[1:]
-        except:
+        except Exception:
             print(sources)
 
         input_id, target = [], []
@@ -77,7 +81,7 @@ def preprocess_qwen_2_visual(
             try:
                 role = conv["role"]
                 content = conv["content"]
-            except:
+            except Exception:
                 role = conv["from"]
                 content = conv["value"]
 
@@ -263,7 +267,6 @@ class LazySupervisedDataset(Dataset):
 
     def __getitem__(self, i) -> Dict[str, torch.Tensor]:
         num_base_retries = 3
-        num_final_retries = 30
 
         # try the current sample first
         for attempt_idx in range(num_base_retries):
@@ -309,7 +312,7 @@ class LazySupervisedDataset(Dataset):
                 if len(image_file) > 1:
                     image_file = [os.path.join(image_folder, file) for file in image_file]
                     results = [self.process_image_unified(file) for file in image_file]
-                    image, grid_thw = zip(*results)
+                    image, grid_thw = zip(*results, strict=False)
                 else:
                     image_file = image_file[0]
                     image_file = os.path.join(image_folder, image_file)
@@ -340,7 +343,7 @@ class LazySupervisedDataset(Dataset):
                 if len(video_file) > 1:
                     video_file = [os.path.join(video_folder, file) for file in video_file]
                     results = [self.process_video(file) for file in video_file]
-                    video, grid_thw, second_per_grid_ts = zip(*results)
+                    video, grid_thw, second_per_grid_ts = zip(*results, strict=False)
                 else:
                     video_file = video_file[0]
                     video_file = os.path.join(video_folder, video_file)
@@ -567,7 +570,8 @@ def make_vlm_dataloader(cfg):
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         cfg.framework.qwenvl.base_vlm,
         model_max_length=data_args.model_max_length,
-        padding_side="left",  # flash Attention version of Qwen2.5_VL. Make sure to  call `tokenizer.padding_side  = 'left'` before tokenizing the input.
+        # Flash Attention Qwen2.5-VL expects left padding before tokenizing inputs.
+        padding_side="left",
         use_fast=False,
     )
 
@@ -589,7 +593,7 @@ def make_vlm_dataloader(cfg):
         train_dataset,
         batch_size=cfg.datasets.vlm_data.per_device_batch_size,
         collate_fn=data_collator,
-        num_workers=4,
+        **build_dataloader_kwargs(data_args),
     )
 
     return {
@@ -597,23 +601,27 @@ def make_vlm_dataloader(cfg):
     }
 
 
-from transformers import AutoTokenizer, AutoProcessor
-
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config_yaml", type=str, default="examples/LIBERO/train_files/starvla_cotrain_libero.yaml", help="Path to YAML config")
+    parser.add_argument(
+        "--config_yaml",
+        type=str,
+        default="examples/LIBERO/train_files/starvla_cotrain_libero.yaml",
+        help="Path to YAML config",
+    )
     args, clipargs = parser.parse_known_args()
 
     if os.getenv("DEBUGPY_ENABLE", "0") == "1":
         import debugpy
+
         debugpy.listen(("0.0.0.0", 10092))
         print("Rank 0 waiting for debugger attach on port 10092...")
         debugpy.wait_for_client()
 
     cfg = OmegaConf.load(args.config_yaml)
-    
+
     data_args = cfg.datasets.vlm_data
     image_processor = AutoProcessor.from_pretrained(
         cfg.framework.qwenvl.base_vlm,

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -3,11 +3,12 @@
 # Implemented by [Jinhui YE / HKUST University] in [2025].
 
 """
-StarVLA’s trainer is built directly on native PyTorch + Accelerate + DeepSpeed, keeping the loop explicit and easy to hack.
+StarVLA's trainer is built directly on native PyTorch + Accelerate + DeepSpeed,
+keeping the loop explicit and easy to hack.
 Conventions:
 1. Store runtime state in dicts where possible (simplifies data info, procesing info, config, etc).
 2. Use multiple dataloaders to adapt heterogeneous data types / task mixtures.
-3. Put each training strategy in its own `trainer_*.py` file (avoid large if‑else chains).
+3. Put each training strategy in its own `trainer_*.py` file (avoid large if-else chains).
 """
 
 # Standard Library
@@ -36,7 +37,12 @@ from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.model.framework.share_tools import apply_config_compat
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
-from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
+from starVLA.training.trainer_utils.throughput import build_step_performance_metrics, count_batches_samples
+from starVLA.training.trainer_utils.trainer_tools import (
+    TrainerUtils,
+    build_param_lr_groups,
+    normalize_dotlist_args,
+)
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -327,6 +333,14 @@ class VLATrainer(TrainerUtils):
 
             step_metrics["timing/data"] = t_end_data - t_start_data
             step_metrics["timing/model"] = t_end_model - t_start_model
+            sample_count = count_batches_samples(batch_vla) * self.accelerator.num_processes
+            step_metrics.update(
+                build_step_performance_metrics(
+                    data_time=t_end_data - t_start_data,
+                    model_time=t_end_model - t_start_model,
+                    sample_count=sample_count,
+                )
+            )
             self._log_metrics(step_metrics)
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
@@ -337,7 +351,7 @@ class VLATrainer(TrainerUtils):
 
         self._finalize_training()
 
-    def eval_action_model(self, step_metrics: dict = None) -> float:
+    def eval_action_model(self, step_metrics: dict | None = None) -> float:
         """Run simple action-eval on current batch and attach score to metrics."""
         examples = self._get_next_batch()
         actions = [example["action"] for example in examples]

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -3,11 +3,12 @@
 # Implemented by [Jinhui YE / HKUST University] in [2025].
 
 """
-StarVLA’s trainer is built directly on native PyTorch + Accelerate + DeepSpeed, keeping the loop explicit and easy to hack.
+StarVLA's trainer is built directly on native PyTorch + Accelerate + DeepSpeed,
+keeping the loop explicit and easy to hack.
 Conventions:
 1. Store runtime state in dicts where possible (simplifies data info, procesing info, config, etc).
 2. Use multiple dataloaders to adapt heterogeneous data types / task mixtures.
-3. Put each training strategy in its own `trainer_*.py` file (avoid large if‑else chains).
+3. Put each training strategy in its own `trainer_*.py` file (avoid large if-else chains).
 """
 
 # Standard Library
@@ -29,14 +30,19 @@ from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoProcessor, get_scheduler
+from transformers import AutoProcessor
 
 # Local Modules
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.model.framework.share_tools import apply_config_compat
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
-from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
+from starVLA.training.trainer_utils.throughput import build_step_performance_metrics, count_batches_samples
+from starVLA.training.trainer_utils.trainer_tools import (
+    TrainerUtils,
+    normalize_dotlist_args,
+    setup_optimizer_and_scheduler,
+)
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -285,6 +291,14 @@ class VLAMTrainer(TrainerUtils):
 
             step_metrics["timing/data"] = t_end_data - t_start_data
             step_metrics["timing/model"] = t_end_model - t_start_model
+            sample_count = count_batches_samples(batch_vla, batch_vlm) * self.accelerator.num_processes
+            step_metrics.update(
+                build_step_performance_metrics(
+                    data_time=t_end_data - t_start_data,
+                    model_time=t_end_model - t_start_model,
+                    sample_count=sample_count,
+                )
+            )
             self._log_metrics(step_metrics)
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
@@ -296,7 +310,7 @@ class VLAMTrainer(TrainerUtils):
 
         self._finalize_training()
 
-    def eval_action_model(self, step_metrics: dict = None) -> float:
+    def eval_action_model(self, step_metrics: dict | None = None) -> float:
         """Evaluate action prediction with current model."""
         if self.accelerator.is_main_process:
             examples, _ = self._get_next_batch()

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -3,19 +3,20 @@
 # Implemented by [Jinhui YE / HKUST University] in [2025].
 
 """
-StarVLA’s trainer is built directly on native PyTorch + Accelerate + DeepSpeed, keeping the loop explicit and easy to hack.
+StarVLA's trainer is built directly on native PyTorch + Accelerate + DeepSpeed,
+keeping the loop explicit and easy to hack.
 Conventions:
 1. Store runtime state in dicts where possible (simplifies data info, procesing info, config, etc).
 2. Use multiple dataloaders to adapt heterogeneous data types / task mixtures.
-3. Put each training strategy in its own `trainer_*.py` file (avoid large if‑else chains).
+3. Put each training strategy in its own `trainer_*.py` file (avoid large if-else chains).
 """
 
 # Standard Library
 import argparse
 import json
 import os
+import time
 from pathlib import Path
-from typing import Tuple
 
 # Third-Party Libraries
 import torch
@@ -27,13 +28,18 @@ from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoProcessor, get_scheduler
+from transformers import AutoProcessor
 
 # Local Modules
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
-from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
+from starVLA.training.trainer_utils.throughput import build_step_performance_metrics, count_batches_samples
+from starVLA.training.trainer_utils.trainer_tools import (
+    TrainerUtils,
+    normalize_dotlist_args,
+    setup_optimizer_and_scheduler,
+)
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -234,16 +240,39 @@ class VLAMTrainer(TrainerUtils):
         )
 
         while self.completed_steps < self.config.trainer.max_train_steps:
+            t_start_data = time.perf_counter()
             batch_vlm = self._get_next_batch()
+            t_end_data = time.perf_counter()
+
+            t_start_model = time.perf_counter()
             step_metrics = self._train_step(batch_vlm)
+            t_end_model = time.perf_counter()
 
             if self.accelerator.sync_gradients:
                 progress_bar.update(1)
                 self.completed_steps += 1
 
+            if self.accelerator.is_local_main_process:
+                progress_bar.set_postfix(
+                    {
+                        "data_times": f"{t_end_data - t_start_data:.3f}",
+                        "model_times": f"{t_end_model - t_start_model:.3f}",
+                    }
+                )
+
             if self.completed_steps % self.config.trainer.eval_interval == 0:
                 step_metrics = self.eval_action_model(step_metrics)
 
+            step_metrics["timing/data"] = t_end_data - t_start_data
+            step_metrics["timing/model"] = t_end_model - t_start_model
+            sample_count = count_batches_samples(batch_vlm) * self.accelerator.num_processes
+            step_metrics.update(
+                build_step_performance_metrics(
+                    data_time=t_end_data - t_start_data,
+                    model_time=t_end_model - t_start_model,
+                    sample_count=sample_count,
+                )
+            )
             self._log_metrics(step_metrics)
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:

--- a/starVLA/training/trainer_utils/throughput.py
+++ b/starVLA/training/trainer_utils/throughput.py
@@ -1,0 +1,72 @@
+"""Lightweight training throughput and memory metric helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import torch
+
+_BYTES_PER_GIB = 1024**3
+
+
+def _tensor_length(value: Any) -> int | None:
+    shape = getattr(value, "shape", None)
+    if shape is None or len(shape) == 0:
+        return None
+    return int(shape[0])
+
+
+def count_batch_samples(batch: Any) -> int:
+    """Infer the number of examples represented by a dataloader batch."""
+    if batch is None:
+        return 0
+    if isinstance(batch, Mapping):
+        attention_mask = batch.get("attention_mask")
+        input_ids = batch.get("input_ids")
+        if attention_mask is not None:
+            attention_length = _tensor_length(attention_mask)
+            input_length = _tensor_length(input_ids)
+            if attention_length is not None and input_length == 1 and getattr(attention_mask, "ndim", 0) == 1:
+                return max(attention_length - 1, 1)
+            if attention_length is not None:
+                return attention_length
+        for value in batch.values():
+            value_length = _tensor_length(value)
+            if value_length is not None:
+                return value_length
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                return len(value)
+        return 1
+    if isinstance(batch, Sequence) and not isinstance(batch, (str, bytes)):
+        return len(batch)
+    tensor_length = _tensor_length(batch)
+    return tensor_length if tensor_length is not None else 1
+
+
+def count_batches_samples(*batches: Any) -> int:
+    """Infer total examples across one or more dataloader batches."""
+    return sum(count_batch_samples(batch) for batch in batches)
+
+
+def build_step_performance_metrics(
+    data_time: float,
+    model_time: float,
+    sample_count: int,
+    cuda: Any = torch.cuda,
+) -> dict[str, float]:
+    """Build grouped timing, throughput, and GPU-memory metrics for one loop iteration."""
+    step_time = data_time + model_time
+    metrics = {
+        "timing/step": step_time,
+        "throughput/samples_per_sec": sample_count / step_time if step_time > 0 else 0.0,
+        "throughput/model_samples_per_sec": sample_count / model_time if model_time > 0 else 0.0,
+        "throughput/data_wait_ratio": data_time / step_time if step_time > 0 else 0.0,
+        "memory/gpu_allocated_gb": 0.0,
+        "memory/gpu_reserved_gb": 0.0,
+    }
+
+    if cuda is not None and cuda.is_available():
+        metrics["memory/gpu_allocated_gb"] = cuda.memory_allocated() / _BYTES_PER_GIB
+        metrics["memory/gpu_reserved_gb"] = cuda.memory_reserved() / _BYTES_PER_GIB
+    return metrics

--- a/tests/test_dataloader_throughput.py
+++ b/tests/test_dataloader_throughput.py
@@ -1,0 +1,176 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader, Dataset
+
+from starVLA.dataloader.dataloader_options import DATALOADER_DEFAULTS, build_dataloader_kwargs
+from starVLA.training.trainer_utils.throughput import (
+    build_step_performance_metrics,
+    count_batch_samples,
+    count_batches_samples,
+)
+
+
+class TinyDataset(Dataset):
+    def __len__(self):
+        return 5
+
+    def __getitem__(self, index):
+        return index
+
+
+class DataloaderOptionsTest(unittest.TestCase):
+    def test_defaults_match_legacy_behavior(self):
+        kwargs = build_dataloader_kwargs({})
+
+        self.assertEqual(kwargs["num_workers"], DATALOADER_DEFAULTS["num_workers"])
+        self.assertEqual(kwargs["prefetch_factor"], DATALOADER_DEFAULTS["prefetch_factor"])
+        self.assertFalse(kwargs["pin_memory"])
+        self.assertFalse(kwargs["persistent_workers"])
+        self.assertFalse(kwargs["drop_last"])
+        self.assertEqual(kwargs["timeout"], 0)
+
+    def test_overrides_accept_dict_and_string_booleans(self):
+        kwargs = build_dataloader_kwargs(
+            {
+                "num_workers": "8",
+                "pin_memory": "true",
+                "persistent_workers": "yes",
+                "prefetch_factor": "3",
+                "drop_last": "on",
+                "timeout": "5",
+            }
+        )
+
+        self.assertEqual(
+            kwargs,
+            {
+                "num_workers": 8,
+                "pin_memory": True,
+                "persistent_workers": True,
+                "prefetch_factor": 3,
+                "drop_last": True,
+                "timeout": 5,
+            },
+        )
+
+    def test_num_workers_zero_omits_prefetch_factor(self):
+        kwargs = build_dataloader_kwargs(SimpleNamespace(num_workers=0, prefetch_factor="ignored"))
+
+        self.assertEqual(kwargs["num_workers"], 0)
+        self.assertNotIn("prefetch_factor", kwargs)
+
+    def test_persistent_workers_requires_positive_num_workers(self):
+        with self.assertRaisesRegex(ValueError, "persistent_workers=True"):
+            build_dataloader_kwargs({"num_workers": 0, "persistent_workers": True})
+
+    def test_invalid_values_raise_clear_errors(self):
+        with self.assertRaisesRegex(ValueError, "num_workers"):
+            build_dataloader_kwargs({"num_workers": -1})
+        with self.assertRaisesRegex(ValueError, "pin_memory"):
+            build_dataloader_kwargs({"pin_memory": "maybe"})
+        with self.assertRaisesRegex(ValueError, "prefetch_factor"):
+            build_dataloader_kwargs({"prefetch_factor": 0})
+
+    def test_real_dataloader_iterates_with_num_workers_zero(self):
+        kwargs = build_dataloader_kwargs({"num_workers": 0, "drop_last": True})
+        loader = DataLoader(TinyDataset(), batch_size=2, **kwargs)
+
+        self.assertEqual([batch.tolist() for batch in loader], [[0, 1], [2, 3]])
+
+    def test_real_dataloader_accepts_worker_overrides(self):
+        kwargs = build_dataloader_kwargs(
+            {
+                "num_workers": 1,
+                "persistent_workers": True,
+                "prefetch_factor": 3,
+                "timeout": 1,
+            }
+        )
+        loader = DataLoader(TinyDataset(), batch_size=2, **kwargs)
+
+        self.assertEqual(loader.num_workers, 1)
+        self.assertTrue(loader.persistent_workers)
+        self.assertEqual(loader.prefetch_factor, 3)
+        self.assertEqual(loader.timeout, 1)
+
+    def test_core_training_configs_expose_default_loader_options(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        config_paths = [
+            repo_root / "starVLA/config/training/starvla_train_adapter.yaml",
+            repo_root / "starVLA/config/training/starvla_cotrain_libero.yaml",
+            repo_root / "starVLA/config/training/starvla_cotrain_oxe.yaml",
+        ]
+        expected = {
+            "num_workers": 4,
+            "pin_memory": False,
+            "persistent_workers": False,
+            "prefetch_factor": 2,
+            "drop_last": False,
+            "timeout": 0,
+        }
+
+        for config_path in config_paths:
+            cfg = OmegaConf.load(config_path)
+            for section_name in ("vla_data", "vlm_data"):
+                if section_name not in cfg.datasets:
+                    continue
+                with self.subTest(config=config_path.name, section=section_name):
+                    kwargs = build_dataloader_kwargs(cfg.datasets[section_name])
+                    self.assertEqual(kwargs, expected)
+
+
+class ThroughputMetricsTest(unittest.TestCase):
+    def test_count_batch_samples_for_vla_and_vlm_batches(self):
+        self.assertEqual(count_batch_samples([{"action": 1}, {"action": 2}]), 2)
+        self.assertEqual(count_batch_samples({"input_ids": torch.zeros(4, 8)}), 4)
+        self.assertEqual(count_batches_samples([1, 2], {"input_ids": torch.zeros(3, 8)}), 5)
+
+    def test_count_batch_samples_for_flattened_vlm_batch(self):
+        batch = {
+            "input_ids": torch.zeros(1, 12),
+            "attention_mask": torch.tensor([0, 3, 7, 12], dtype=torch.int32),
+        }
+
+        self.assertEqual(count_batch_samples(batch), 3)
+
+    def test_metrics_include_timing_throughput_and_no_cuda_memory_keys(self):
+        class NoCuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        metrics = build_step_performance_metrics(data_time=0.25, model_time=0.75, sample_count=4, cuda=NoCuda)
+
+        self.assertEqual(metrics["timing/step"], 1.0)
+        self.assertEqual(metrics["throughput/samples_per_sec"], 4.0)
+        self.assertEqual(metrics["throughput/model_samples_per_sec"], 4 / 0.75)
+        self.assertEqual(metrics["throughput/data_wait_ratio"], 0.25)
+        self.assertEqual(metrics["memory/gpu_allocated_gb"], 0.0)
+        self.assertEqual(metrics["memory/gpu_reserved_gb"], 0.0)
+
+    def test_metrics_report_cuda_memory_in_gb(self):
+        class FakeCuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def memory_allocated():
+                return 2 * 1024**3
+
+            @staticmethod
+            def memory_reserved():
+                return 3 * 1024**3
+
+        metrics = build_step_performance_metrics(data_time=0.0, model_time=2.0, sample_count=4, cuda=FakeCuda)
+
+        self.assertEqual(metrics["memory/gpu_allocated_gb"], 2.0)
+        self.assertEqual(metrics["memory/gpu_reserved_gb"], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes #332

Thanks for the clear guidance in the issue. This PR keeps the scope focused on making DataLoader throughput tunable from config, while keeping the current training behavior unchanged for existing YAML files.

Before this change, VLA/VLM DataLoader options such as worker count were hard-coded in the builders. That made throughput tuning awkward across different machines, storage backends, and datasets, because users had to edit source code for what should be a training configuration choice. The training loop also logged raw data/model timing, but did not group the higher-level throughput and GPU memory signals that make input-pipeline bottlenecks easier to compare.

## Changes

- Added dataset-level DataLoader options for both `datasets.vla_data` and `datasets.vlm_data`:
  - `num_workers`
  - `pin_memory`
  - `persistent_workers`
  - `prefetch_factor`
  - `drop_last`
  - `timeout`
- Preserved the previous hard-coded defaults for backward compatibility:
  - `num_workers: 4`
  - `pin_memory: false`
  - `persistent_workers: false`
  - `prefetch_factor: 2`
  - `drop_last: false`
  - `timeout: 0`
- Added a shared DataLoader options helper used by both VLA and VLM builders.
- Handles `num_workers: 0` safely by omitting `prefetch_factor`.
- Rejects `persistent_workers: true` with `num_workers: 0`, which is an invalid PyTorch combination.
- Added grouped training metrics across VLA-only, VLM-only, and co-training:
  - `timing/step`
  - `throughput/samples_per_sec`
  - `throughput/model_samples_per_sec`
  - `throughput/data_wait_ratio`
  - `memory/gpu_allocated_gb`
  - `memory/gpu_reserved_gb`
- Kept existing `timing/data` and `timing/model` metrics.
- Added VLM-only timing so all three training modes report consistently.
- Added core config defaults and documentation for YAML/CLI overrides.

## Testing

- [x] Ran `black --check` on the touched Python files - passes
- [x] Ran `ruff check` on the touched Python files - passes
- [x] Ran focused unit tests - `Ran 12 tests ... OK`
- [x] Ran `git diff --check` - passes
- [x] Verified touched module imports on Windows Python 3.11
- [x] Verified CUDA memory metric shape on RTX 5070 Laptop GPU
- [x] Verified real DataLoader iteration with `num_workers=1`
- [x] Verified WSL Ubuntu 22.04 training environment:
  - Python 3.10.12
  - CUDA Toolkit 12.8 / `nvcc` 12.8
  - PyTorch 2.7.1+cu128
  - DeepSpeed 0.16.9
  - RTX 5070 Laptop GPU
- [x] Ran real VLA training smoke for 3 steps with Qwen3.5-0.8B + RoboChallenge Table30v2 `shred_paper`
- [x] Ran real VLA training smoke for 3 steps with configured worker throughput options:
  - `num_workers=2`
  - `pin_memory=true`
  - `persistent_workers=true`
  - `prefetch_factor=4`

Commands run:

```bash
D:\Dev\conda-envs\py312\python.exe -m black --check <touched-python-files>
D:\Dev\conda-envs\py312\python.exe -m ruff check <touched-python-files>
D:\Dev\conda-envs\py311\python.exe -m unittest tests.test_dataloader_throughput
git diff --check
```

Real training smoke command shape:

```bash
accelerate launch \
  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
  --num_processes 1 \
  starVLA/training/train_starvla.py \
  --config_yaml ./examples/RoboChallenge_table30v2/train_files/starvla_qwenoft_robochallenge_table30v2.yaml \
  --framework.qwenvl.base_vlm <local-qwen3.5-0.8b> \
  --datasets.vla_data.data_root_dir <local-robochallenge-table30v2> \
  --datasets.vla_data.per_device_batch_size 1 \
  --datasets.vla_data.num_workers 2 \
  --datasets.vla_data.pin_memory true \
  --datasets.vla_data.persistent_workers true \
  --datasets.vla_data.prefetch_factor 4 \
  --trainer.max_train_steps 3 \
  --trainer.freeze_modules qwen_vl_interface.model
```

Observed training log excerpt:

```text
Step 3:
timing/step: 0.2509
throughput/samples_per_sec: 3.9861
throughput/model_samples_per_sec: 3.9886
throughput/data_wait_ratio: 0.0006
memory/gpu_allocated_gb: 1.7419
memory/gpu_reserved_gb: 3.7578
```

## Breaking Changes

None. Existing YAML files remain compatible because missing DataLoader fields fall back to the previous hard-coded behavior.

## Checklist

- [x] Branch is based on latest `starVLA_dev`
- [x] PR targets `starVLA_dev`
- [x] Scope stays focused on DataLoader throughput configuration and training metrics
- [x] Defaults preserve previous behavior
- [x] CLI overrides are documented
- [x] Unit tests cover defaults, overrides, invalid combinations, sample counting, throughput math, and CUDA/no-CUDA memory metric shape
- [x] Real training smoke runs for N steps without errors
- [x] No unrelated refactors or drive-by formatting
- [x] No secrets, API keys, datasets, checkpoints, or generated smoke outputs are committed