### PR TITLE
feat(IndoorUAV): add QwenPI training pipeline for IndoorUAV-Replica

### DIFF
--- a/examples/IndoorUAV/train_files/data_registry/data_config.py
+++ b/examples/IndoorUAV/train_files/data_registry/data_config.py
@@ -1,0 +1,85 @@
+"""IndoorUAV benchmark — data config, embodiment tags, and mixtures.
+
+The IndoorUAV dataset contains short VLA segments extracted from VLN trajectories
+collected in Habitat-Sim across replica / hm3d / gibson / mp3d scenes.
+
+State  (4-dim):  [x, y, z, yaw_deg]  -- absolute drone pose in world frame
+Action (4-dim):  [dx, dy, dz, dyaw_deg]  -- pose delta to the next frame
+Image:           1280x720 monocular front-view RGB, encoded at 10 FPS
+"""
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionToTensor, StateActionTransform
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+
+
+# ---------------------------------------------------------------------------
+# DataConfig
+# ---------------------------------------------------------------------------
+class IndoorUAVDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
+    video_keys = [
+        "video.front",
+    ]
+    state_keys = [
+        "state.x",
+        "state.y",
+        "state.z",
+        "state.yaw",
+    ]
+    action_keys = [
+        "action.x",
+        "action.y",
+        "action.z",
+        "action.yaw",
+    ]
+    language_keys = ["annotation.human.action.task_description"]
+    observation_indices = [0]
+    action_indices = list(range(8))   # predict next 8 frames of action chunk
+    state_indices = [0]
+
+    def modality_config(self):
+        return {
+            "video":    ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
+            "state":    ModalityConfig(delta_indices=self.state_indices,       modality_keys=self.state_keys),
+            "action":   ModalityConfig(delta_indices=self.action_indices,      modality_keys=self.action_keys),
+            "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
+        }
+
+    def transform(self):
+        return ComposedModalityTransform(transforms=[
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={
+                    "action.x":   "min_max",
+                    "action.y":   "min_max",
+                    "action.z":   "min_max",
+                    "action.yaw": "min_max",
+                },
+            ),
+        ])
+
+
+ROBOT_TYPE_CONFIG_MAP = {
+    "indoor_uav": IndoorUAVDataConfig(),
+}
+
+
+# ---------------------------------------------------------------------------
+# Embodiment Tags
+# ---------------------------------------------------------------------------
+ROBOT_TYPE_TO_EMBODIMENT_TAG = {
+    "indoor_uav": EmbodimentTag.NEW_EMBODIMENT,
+}
+
+
+# ---------------------------------------------------------------------------
+# Mixtures
+# ---------------------------------------------------------------------------
+DATASET_NAMED_MIXTURES = {
+    "indoor_uav_replica": [
+        ("indoor_uav_replica_vla_lerobot", 1.0, "indoor_uav"),
+    ],
+}

--- a/examples/IndoorUAV/train_files/launch_train_indoor_uav.sh
+++ b/examples/IndoorUAV/train_files/launch_train_indoor_uav.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Launch QwenPI training on IndoorUAV-Replica with DeepSpeed ZeRO-2.
+#
+# Usage:
+#   bash examples/IndoorUAV/train_files/launch_train_indoor_uav.sh
+#   NUM_GPUS=4 GPU_IDS=4,5,6,7 bash examples/IndoorUAV/train_files/launch_train_indoor_uav.sh
+#   ZERO_STAGE=3 GRAD_ACCUM=16 bash examples/IndoorUAV/train_files/launch_train_indoor_uav.sh
+#
+# Environment overrides:
+#   NUM_GPUS      - default 4
+#   GPU_IDS       - default 4,5,6,7  (CUDA_VISIBLE_DEVICES)
+#   ZERO_STAGE    - default 2 (use 3 if even ZeRO-2 OOMs)
+#   GRAD_ACCUM    - default 8
+#   PER_DEVICE_BS - default 2
+#   MAX_STEPS     - default 5000
+#   RUN_ID        - default auto
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+cd "${PROJECT_DIR}"
+export PYTHONPATH="${PROJECT_DIR}:${PROJECT_DIR}/starVLA"
+
+NUM_GPUS="${NUM_GPUS:-4}"
+GPU_IDS="${GPU_IDS:-4,5,6,7}"
+ZERO_STAGE="${ZERO_STAGE:-2}"
+GRAD_ACCUM="${GRAD_ACCUM:-8}"
+PER_DEVICE_BS="${PER_DEVICE_BS:-2}"
+MAX_STEPS="${MAX_STEPS:-5000}"
+RUN_ID="${RUN_ID:-indoor_uav_qwenpi_$(date +%Y%m%d_%H%M%S)}"
+
+CONFIG_YAML="examples/IndoorUAV/train_files/starvla_train_indoor_uav.yaml"
+RUN_ROOT_DIR="${RUN_ROOT_DIR:-playground/Checkpoints}"
+mkdir -p "${RUN_ROOT_DIR}/${RUN_ID}" logs
+cp "$0" "${RUN_ROOT_DIR}/${RUN_ID}/" || true
+
+# NCCL / CUDA env
+export CUDA_VISIBLE_DEVICES="${GPU_IDS}"
+export NCCL_BLOCKING_WAIT=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_TIMEOUT=10000
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Generate accelerate + DeepSpeed config (reuses Gemma4 helper)
+ACCEL_CONFIG=$(python3 examples/Gemma4/_make_accelerate_config.py \
+    --grad-accum "${GRAD_ACCUM}" \
+    --num-processes "${NUM_GPUS}" \
+    --zero-stage "${ZERO_STAGE}")
+echo "[indoor-uav] generated accelerate config: ${ACCEL_CONFIG}"
+
+echo "[indoor-uav] GPU_IDS=${GPU_IDS}  NUM_GPUS=${NUM_GPUS}  ZERO_STAGE=${ZERO_STAGE}"
+echo "[indoor-uav] PER_DEVICE_BS=${PER_DEVICE_BS}  GRAD_ACCUM=${GRAD_ACCUM}"
+echo "[indoor-uav] effective BS = ${PER_DEVICE_BS} × ${NUM_GPUS} × ${GRAD_ACCUM} = $((PER_DEVICE_BS * NUM_GPUS * GRAD_ACCUM))"
+echo "[indoor-uav] MAX_STEPS=${MAX_STEPS}  RUN_ID=${RUN_ID}"
+
+accelerate launch \
+  --config_file "${ACCEL_CONFIG}" \
+  --num_processes "${NUM_GPUS}" \
+  --num_machines 1 \
+  starVLA/training/train_starvla.py \
+  --config_yaml "${CONFIG_YAML}" \
+  --datasets.vla_data.per_device_batch_size "${PER_DEVICE_BS}" \
+  --trainer.gradient_accumulation_steps "${GRAD_ACCUM}" \
+  --trainer.max_train_steps "${MAX_STEPS}" \
+  --trainer.save_interval 1000 \
+  --trainer.logging_frequency 10 \
+  --trainer.eval_interval 1000 \
+  --run_root_dir "${RUN_ROOT_DIR}" \
+  --run_id "${RUN_ID}"

--- a/examples/IndoorUAV/train_files/starvla_train_indoor_uav.yaml
+++ b/examples/IndoorUAV/train_files/starvla_train_indoor_uav.yaml
@@ -1,0 +1,61 @@
+run_id: starvla_indoor_uav_replica
+run_root_dir: playground/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_IndoorUAV
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: QwenPI
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  action_model:
+    action_dim: 4          # [dx, dy, dz, dyaw_deg]
+    state_dim: 4           # [x, y, z, yaw_deg]
+    action_horizon: 8
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    include_state: true
+    data_root_dir: playground/Datasets/IndoorUAV
+    data_mix: indoor_uav_replica
+    action_type: delta_qpos      # pose delta as action
+    action_mode: abs
+    sequential_step_sampling: false
+    per_device_batch_size: 4
+    load_all_data_for_training: true
+    obs_image_size: [224, 224]
+    video_backend: torchvision_av
+    lerobot_version: "v2.0"
+
+trainer:
+  max_train_steps: 100
+  num_warmup_steps: 10
+  save_interval: 100
+  eval_interval: 100
+  learning_rate:
+    base: 2.5e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 1.0e-06
+  freeze_modules: 'qwen_vl_interface'
+  loss_scale:
+    vla: 1.0
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 1
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08

--- a/scripts/convert_indoor_uav_to_lerobot.py
+++ b/scripts/convert_indoor_uav_to_lerobot.py
@@ -1,0 +1,313 @@
+"""Convert IndoorUAV VLA subset (Replica scenes) to starVLA LeRobot-v2.0 format.
+
+Self-contained: only needs numpy / pyarrow / pillow / ffmpeg. No `lerobot` lib.
+
+Input layout (under --raw_root):
+  extracted/vla_ins/vla_ins/<scene_group>/<scene>/<traj>/vla_ins_<N>.json
+      {"instruction": str, "source": [start_1based, end_1based]}
+  replica_extracted/<scene_group>/<scene>/<traj>/
+      posture.json:   list[[x, y, z, yaw_deg]]
+      screenshots/<frame_1based>.png  (1280x720 RGBA)
+
+Output (under --out_dir):
+  meta/info.json
+  meta/episodes.jsonl
+  meta/tasks.jsonl
+  meta/modality.json
+  data/chunk-000/episode_{idx:06d}.parquet
+  videos/chunk-000/observation.images.front/episode_{idx:06d}.mp4
+
+State  = pose[t]                       (4 dims: x, y, z, yaw_deg)
+Action = pose[t+1] - pose[t]           (yaw wrapped to (-180, 180])
+         terminal frame action = 0
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+# ----------------------------- helpers -----------------------------
+
+def safe_load_json(p: Path):
+    for enc in ("utf-8", "latin-1", "gbk"):
+        try:
+            with open(p, encoding=enc) as f:
+                return json.load(f)
+        except UnicodeDecodeError:
+            continue
+    raise RuntimeError(f"Cannot decode {p}")
+
+
+def yaw_delta_deg(yaw_next: float, yaw_curr: float) -> float:
+    d = (yaw_next - yaw_curr) % 360.0
+    if d > 180.0:
+        d -= 360.0
+    return d
+
+
+def encode_video_ffmpeg(frame_paths: list[Path], out_path: Path, fps: int):
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    list_file = out_path.with_suffix(".concat.txt")
+    with open(list_file, "w") as f:
+        for p in frame_paths:
+            f.write(f"file '{p.resolve()}'\n")
+            f.write(f"duration {1.0/fps}\n")
+        f.write(f"file '{frame_paths[-1].resolve()}'\n")  # ffmpeg concat quirk
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-f", "concat", "-safe", "0", "-i", str(list_file),
+        "-fps_mode", "cfr", "-r", str(fps),
+        "-c:v", "libx264", "-pix_fmt", "yuv420p",
+        "-preset", "fast", "-crf", "23",
+        "-vf", "scale='trunc(iw/2)*2':'trunc(ih/2)*2'",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+    list_file.unlink()
+
+
+def build_episode(vla_path: Path, scene_group: str, raw_root: Path) -> dict | None:
+    """Read one VLA json + its traj metadata, return episode dict or None on error."""
+    vla = safe_load_json(vla_path)
+    instruction = vla["instruction"]
+    s, e = vla["source"]  # both 1-based inclusive
+    # vla_path: .../vla_ins/<group>/<scene>/<traj>/vla_ins_N.json
+    traj_rel = vla_path.parent.relative_to(
+        raw_root / "extracted" / "vla_ins" / "vla_ins" / scene_group
+    )
+    img_dir = raw_root / "replica_extracted" / scene_group / traj_rel / "screenshots"
+    posture_path = raw_root / "replica_extracted" / scene_group / traj_rel / "posture.json"
+
+    if not posture_path.exists():
+        print(f"  SKIP missing posture: {posture_path}")
+        return None
+
+    posture = safe_load_json(posture_path)  # list of [x, y, z, yaw]
+    n_total = len(posture)
+    if e > n_total or s < 1:
+        print(f"  SKIP out-of-range {vla_path}: [{s},{e}] vs {n_total} frames")
+        return None
+
+    # State and action sequences. We need actions for frames s..e (1-based inclusive)
+    # Action[t] = pose[t+1] - pose[t]. Terminal action (t=e) uses zeros.
+    frame_paths: list[Path] = []
+    states: list[list[float]] = []
+    actions: list[list[float]] = []
+    for f1 in range(s, e + 1):  # 1-based
+        idx = f1 - 1
+        pose = posture[idx]
+        states.append([float(pose[0]), float(pose[1]), float(pose[2]), float(pose[3])])
+        if f1 < e and (idx + 1) < n_total:
+            nxt = posture[idx + 1]
+            dx = float(nxt[0]) - float(pose[0])
+            dy = float(nxt[1]) - float(pose[1])
+            dz = float(nxt[2]) - float(pose[2])
+            dyaw = yaw_delta_deg(float(nxt[3]), float(pose[3]))
+            actions.append([dx, dy, dz, dyaw])
+        else:
+            actions.append([0.0, 0.0, 0.0, 0.0])
+        img_path = img_dir / f"{f1}.png"
+        if not img_path.exists():
+            print(f"  SKIP missing image: {img_path}")
+            return None
+        frame_paths.append(img_path)
+
+    return {
+        "instruction": instruction,
+        "states": np.asarray(states, dtype=np.float32),
+        "actions": np.asarray(actions, dtype=np.float32),
+        "frame_paths": frame_paths,
+        "traj_rel": str(traj_rel),
+        "vla_name": vla_path.stem,
+    }
+
+
+# ----------------------------- main -----------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw_root", required=True)
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--scene_group", default="replica")
+    ap.add_argument("--fps", type=int, default=10)
+    ap.add_argument("--chunk_size", type=int, default=1000)
+    ap.add_argument("--max_episodes", type=int, default=None)
+    args = ap.parse_args()
+
+    raw_root = Path(args.raw_root).resolve()
+    out_dir = Path(args.out_dir).resolve()
+    vla_root = raw_root / "extracted" / "vla_ins" / "vla_ins" / args.scene_group
+
+    vla_files = sorted(vla_root.glob("*/traj_*/vla_ins_*.json"))
+    print(f"Found {len(vla_files)} VLA instances in {vla_root}")
+    if args.max_episodes:
+        vla_files = vla_files[: args.max_episodes]
+        print(f"Truncated to first {len(vla_files)} for debug")
+
+    meta_dir = out_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = out_dir / "data" / "chunk-000"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    video_dir = out_dir / "videos" / "chunk-000" / "observation.images.front"
+    video_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pass 1: build episodes, dedupe instructions → task_index
+    episodes = []
+    task_to_index: dict[str, int] = {}
+    for i, vla_path in enumerate(vla_files):
+        print(f"[{i+1}/{len(vla_files)}] {vla_path.relative_to(vla_root)}")
+        ep = build_episode(vla_path, args.scene_group, raw_root)
+        if ep is None:
+            continue
+        if ep["instruction"] not in task_to_index:
+            task_to_index[ep["instruction"]] = len(task_to_index)
+        ep["task_index"] = task_to_index[ep["instruction"]]
+        ep["episode_index"] = len(episodes)
+        episodes.append(ep)
+
+    print(f"\nValid episodes: {len(episodes)} | unique tasks: {len(task_to_index)}")
+
+    # Pass 2: write parquet + mp4 per episode
+    total_frames = 0
+    h_w_c = None
+    episodes_jsonl = []
+    for ep in episodes:
+        idx = ep["episode_index"]
+        ep_len = len(ep["states"])
+        global_indices = np.arange(total_frames, total_frames + ep_len, dtype=np.int64)
+
+        # parquet: rows are timesteps. Columns: observation.state, action,
+        # episode_index, frame_index, timestamp, index, task_index
+        table = pa.table({
+            "observation.state": pa.array(
+                [list(map(float, row)) for row in ep["states"]],
+                type=pa.list_(pa.float32(), 4),
+            ),
+            "action": pa.array(
+                [list(map(float, row)) for row in ep["actions"]],
+                type=pa.list_(pa.float32(), 4),
+            ),
+            "episode_index": pa.array([idx] * ep_len, type=pa.int64()),
+            "frame_index": pa.array(np.arange(ep_len, dtype=np.int64)),
+            "timestamp": pa.array(
+                (np.arange(ep_len, dtype=np.float32) / args.fps).tolist(),
+                type=pa.float32(),
+            ),
+            "index": pa.array(global_indices),
+            "task_index": pa.array([ep["task_index"]] * ep_len, type=pa.int64()),
+        })
+        pq.write_table(table, data_dir / f"episode_{idx:06d}.parquet")
+
+        # mp4
+        video_path = video_dir / f"episode_{idx:06d}.mp4"
+        encode_video_ffmpeg(ep["frame_paths"], video_path, args.fps)
+
+        # peek size from first image once
+        if h_w_c is None:
+            from PIL import Image
+            with Image.open(ep["frame_paths"][0]) as im:
+                w, h = im.size
+            h_w_c = (h, w, 3)
+
+        episodes_jsonl.append({
+            "episode_index": idx,
+            "tasks": [ep["instruction"]],
+            "length": ep_len,
+        })
+        total_frames += ep_len
+
+    # episodes.jsonl
+    with open(meta_dir / "episodes.jsonl", "w") as f:
+        for r in episodes_jsonl:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    # tasks.jsonl
+    with open(meta_dir / "tasks.jsonl", "w") as f:
+        for task, ti in sorted(task_to_index.items(), key=lambda kv: kv[1]):
+            f.write(json.dumps({"task_index": ti, "task": task}, ensure_ascii=False) + "\n")
+
+    # modality.json
+    modality = {
+        "state": {
+            "x":   {"start": 0, "end": 1},
+            "y":   {"start": 1, "end": 2},
+            "z":   {"start": 2, "end": 3},
+            "yaw": {"start": 3, "end": 4},
+        },
+        "action": {
+            "x":   {"start": 0, "end": 1},
+            "y":   {"start": 1, "end": 2},
+            "z":   {"start": 2, "end": 3},
+            "yaw": {"start": 3, "end": 4},
+        },
+        "video": {
+            "front": {"original_key": "observation.images.front"},
+        },
+        "annotation": {
+            "human.action.task_description": {"original_key": "task_index"},
+        },
+    }
+    with open(meta_dir / "modality.json", "w") as f:
+        json.dump(modality, f, indent=2, ensure_ascii=False)
+
+    # info.json (LeRobot v2.0)
+    info = {
+        "codebase_version": "v2.0",
+        "robot_type": "indoor_uav",
+        "total_episodes": len(episodes),
+        "total_frames": int(total_frames),
+        "total_tasks": len(task_to_index),
+        "total_videos": len(episodes),
+        "total_chunks": 1,
+        "chunks_size": args.chunk_size,
+        "fps": args.fps,
+        "splits": {"train": f"0:{len(episodes)}"},
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+        "features": {
+            "observation.state": {
+                "dtype": "float32",
+                "shape": [4],
+                "names": ["x", "y", "z", "yaw"],
+            },
+            "action": {
+                "dtype": "float32",
+                "shape": [4],
+                "names": ["x", "y", "z", "yaw"],
+            },
+            "observation.images.front": {
+                "dtype": "video",
+                "shape": [h_w_c[0], h_w_c[1], h_w_c[2]],
+                "names": ["height", "width", "channel"],
+                "video_info": {
+                    "video.fps": float(args.fps),
+                    "video.codec": "h264",
+                    "video.pix_fmt": "yuv420p",
+                    "video.is_depth_map": False,
+                    "has_audio": False,
+                },
+            },
+            "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+            "frame_index":   {"dtype": "int64", "shape": [1], "names": None},
+            "timestamp":     {"dtype": "float32", "shape": [1], "names": None},
+            "index":         {"dtype": "int64", "shape": [1], "names": None},
+            "task_index":    {"dtype": "int64", "shape": [1], "names": None},
+        },
+    }
+    with open(meta_dir / "info.json", "w") as f:
+        json.dump(info, f, indent=2)
+
+    print(f"\n✅ Done. Wrote {len(episodes)} episodes / {total_frames} frames to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_train_indoor_uav.py
+++ b/scripts/smoke_train_indoor_uav.py
@@ -1,0 +1,82 @@
+"""Single-GPU training smoke test for IndoorUAV × QwenPI.
+
+Verifies the full closed loop: dataset -> model.forward -> backward ->
+gradient clipping -> optimizer.step. Uses bitsandbytes 8-bit AdamW to fit
+3.3B trainable parameters into a single ~50GB-free GPU.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=<id> python scripts/smoke_train_indoor_uav.py [--steps 5]
+
+Pre-requisites:
+    pip install bitsandbytes
+    Dataset already converted to:
+        playground/Datasets/IndoorUAV/indoor_uav_replica_vla_lerobot/
+"""
+
+from __future__ import annotations
+import argparse
+import os
+
+import torch
+import bitsandbytes as bnb
+from omegaconf import OmegaConf
+
+from starVLA.dataloader.lerobot_datasets import get_vla_dataset
+from starVLA.model.framework.VLM4A.QwenPI import Qwen_PI
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="examples/IndoorUAV/train_files/starvla_train_indoor_uav.yaml")
+    ap.add_argument("--steps", type=int, default=5)
+    ap.add_argument("--batch_size", type=int, default=2)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--clip", type=float, default=1.0)
+    args = ap.parse_args()
+
+    os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+    cfg = OmegaConf.load(args.config)
+    print(f"--- Loading dataset (mix={cfg.datasets.vla_data.data_mix}) ---")
+    ds = get_vla_dataset(cfg.datasets.vla_data, mode="train")
+    print(f"Dataset size: {len(ds)}")
+
+    print("--- Building QwenPI ---")
+    model = Qwen_PI(cfg).cuda()
+
+    # Honor `freeze_modules: qwen_vl_interface` from the yaml
+    freeze_prefix = str(cfg.trainer.get("freeze_modules", ""))
+    if freeze_prefix:
+        for name, p in model.named_parameters():
+            if name.startswith(freeze_prefix):
+                p.requires_grad = False
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    n_trainable = sum(p.numel() for p in trainable) / 1e6
+    n_total = sum(p.numel() for p in model.parameters()) / 1e9
+    print(f"Trainable: {n_trainable:.1f}M  /  Total: {n_total:.2f}B")
+
+    opt = bnb.optim.AdamW8bit(
+        trainable, lr=args.lr, betas=(0.9, 0.95), eps=1e-8, weight_decay=1e-8,
+    )
+
+    print(f"\n--- Running {args.steps} train steps (batch={args.batch_size}) ---")
+    losses = []
+    for step in range(args.steps):
+        batch = [ds[(step * args.batch_size + i) % len(ds)] for i in range(args.batch_size)]
+        out = model(batch)
+        loss = out["action_loss"]
+        opt.zero_grad()
+        loss.backward()
+        gn = torch.nn.utils.clip_grad_norm_(trainable, max_norm=args.clip)
+        opt.step()
+        losses.append(loss.item())
+        peak = torch.cuda.max_memory_allocated() / 1e9
+        print(f"  step={step:>2}  loss={loss.item():>10.4f}  grad_norm={gn.item():>8.4f}  peak_mem={peak:.2f}GB")
+        torch.cuda.reset_peak_memory_stats()
+
+    print(f"\nloss trace: {[f'{l:.2f}' for l in losses]}")
+    print("Full train step closed-loop OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/周报-第1周.md
+++ b/周报-第1周.md
@@ -1,0 +1,300 @@
+# 研究周报（第 1 周）—— VLA 文献调研
+
+> 周期：5.14–5.17
+> 学生：张权德
+> 主题：VLA / VLN 发展脉络、前沿成果，及其与具身安全的潜在结合
+> 主阅文献：*Vision-Language-Action Models for Robotics: A Review Towards Real-World Applications* (Kawaharazuka, Oh, Yamada, Posner, Zhu)
+
+---
+
+## 一、本周工作概述
+
+本周按考核要求开展 **文献调研** 部分的工作。围绕 *Vision-Language-Action Models for Robotics: A Review Towards Real-World Applications* 这篇全栈式综述展开精读，并对其中出现的关键概念（分箱动作离散化、VLM 主干、扩散策略、流匹配、潜在动作、分层策略、世界模型、Affordance、梯度隔离、弱监督、ECoT 等）做了原理性拆解。
+
+下文为对综述阅读结论与关键技术细节的整理，并在末尾附 **VLA 记忆方向** 与 **具身安全方向** 的延伸思考与下周计划。
+
+---
+
+## 二、VLA 的发展脉络与前沿格局
+
+### 2.1 定义与边界（Def. I.1）
+综述将 VLA 严格定义为：**以视觉观察 + 自然语言指令为必要输入，直接生成控制命令（control command）的系统**。仅用 VLM 做 high-level 任务规划、再从预定义技能库里选 index 的方法被排除在 VLA 的定义之外。这一定义把"端到端可微的动作生成"作为 VLA 的本质特征，奠定了综述的"全栈"视角。
+
+### 2.2 架构演变（Section III）
+综述将 VLA 的代际演化梳理为如下时间线：
+
+| 代际 | 代表模型 | 关键特征 |
+|---|---|---|
+| 早期 CNN 端到端 | CLIPort | CLIP 特征 + Transporter Network；多模态融合能力受限 |
+| Transformer 序列模型 | Gato、VIMA | 单一 Transformer 处理多任务；技能仍较窄 |
+| 真实世界统一策略 + 预训练 VLM | RT-1、RT-2、RT-X、OpenVLA | VLM 作为 backbone，离散动作 Token；OXE 多机训练 |
+| 分层策略雏形 | RT-H | 引入"language motion"中间层，high-/low-level 切换 |
+| 扩散策略 | Octo、NoMAD | 在 Transformer 后接 Diffusion Action Head，连续动作 |
+| 扩散 Transformer | RDT-1B、LBM | 把 diffusion 直接放进 backbone（DiT），交替条件注入 |
+| 流匹配策略 | π0 | 基于 PaliGemma 的 action expert，50Hz 实时控制；并行输出 action chunk |
+| 视频学习潜在动作 | LAPA | VQ-VAE 在 (x_t, x_{t+H}) 差值上离散化潜在动作，可用人类视频预训练 |
+| 多代融合的分层架构 | π0.5、GR00T N1、GR-3 | 把 latent action / FAST tokens / flow matching / DiT 多组件统一在多阶段策略里 |
+
+**结论**：当前 SOTA 已收敛到 "**预训练 VLM backbone + 连续动作生成（Diffusion / Flow Matching）+ 分层策略（System 2 / System 1）**" 的范式，并普遍利用人类视频与跨具身数据扩展预训练。
+
+### 2.3 架构构件（Section IV-A）
+综述给出感觉运动模型的 7 类组合（Fig. 4）：
+
+1. Transformer + Discrete Action Token（Gato / VIMA / RT-1）
+2. Transformer + Diffusion Action Head（Octo / NoMAD）
+3. Diffusion Transformer（RDT-1B / LBM / Dita）
+4. **VLM + Discrete Action Token**（RT-2 / OpenVLA / RT-H / 3D-VLA）
+5. **VLM + Diffusion Action Head**（DexVLA / GO-1 / CogACT 系）
+6. **VLM + Flow Matching Action Head**（π0 / GraspVLA / Hume）
+7. **VLM + Diffusion Transformer**（GR00T N1 / TrackVLA / SmolVLA）
+
+可以看到 (4)(5)(6)(7) 都建立在 VLM backbone 之上，差别主要在动作头形式与是否分层。
+
+此外还有 **World Model 路径**（UniPi / Dreamitate / SuSIE / MinD / PPI）与 **Affordance 路径**（VoxPoser / RoboPoint / Chain-of-Affordance）作为正交分支。世界模型的"先生成未来观察、再用 IDM 解码动作"以及 Affordance 的"先预测可操作位置 / 接触点"，本质都是引入 **结构化中间表示** 来缓解长程任务的规划难度。
+
+### 2.4 训练范式与数据（Section V–VI）
+- **监督学习**主导：next-token prediction + 动作头损失（L1 / L2 / BCE / Diffusion / Flow）。
+- **自监督**：视觉表示（MAE / CLIP / DINOv2）、潜在动作（LAPA / UniVLA / UniSkill）。
+- **强化学习**：样本效率与安全限制使其多停留在仿真或受限实机。
+- **数据**：Ego4D / EPIC-KITCHENS / HOI4D / Aria 等第一人称人类数据 + RT-1 / BridgeData V2 / DROID / RoboMIND / **AgiBot World (1M trajectories)** / **Open-X Embodiment** 等真实机器人数据，二者融合是当前主流。
+- **数据增强**：CACTI / GenAug / ROSIE / DreamGen 用扩散模型做 embodiment-aware 视觉增强；DIAL 用 LLM 做指令释义；DAgger / CCIL 做交互式动作增强。
+
+### 2.5 三大根本性挑战（Section II）
+1. **数据稀缺**：三模态对齐数据规模 / 多样性都不够；teleop 收集成本高；模态越多越严重。
+2. **具身迁移**：动作空间、关节构型、传感器各异；人类动作 → 机器人动作语义鸿沟。
+3. **算力与训练成本**：Transformer 对长序列、高分辨率、高维多模态扩展性差；推理在受限平台上有显著延迟与显存问题。
+
+### 2.6 实践建议（Section VIII，作者总结）
+- 数据多样且高质量优先；
+- 倾向于用 **Diffusion / Flow Matching** 生成连续动作；
+- 预训练时使用 **Gradient Insulation / 冻结 backbone** 防止灾难性遗忘；
+- 资源受限时先 fine-tune action head，或使用 LoRA；
+- 引入 **世界模型 + 潜在动作** 利用人类视频；
+- 引入 affordance / keypoint / 未来状态预测等 **辅助多任务**，让表示更贴近控制需求。
+
+---
+
+## 三、技术细节
+
+> 本节把对综述中若干高密度概念的拆解笔记浓缩在一起，作为后续阅读论文与读 codebase 的"工具箱"。
+
+### 3.1 动作离散化：分箱 (Binning) 与动作 Token
+- **核心思想**：把每个关节的连续物理量在训练前 **划成 256 个等距区间（bin）**，每个 bin 永远绑定一个固定的物理含义（例如 X 轴 89 号 bin = `8.8~8.9 cm`）。LLM 字典里恰好生僻字够用、1 字节 = 256，与计算机底层契合，4 mm 量级的精度也足够日常操作。
+- **千变万化从何而来**：单一关节虽然只有 256 个动作，但 (i) **多自由度组合**——RT-1 一次输出 11 个动作 token，仅 X/Y/Z 三轴就有 256³ ≈ 1.6 × 10⁷ 个空间目标；(ii) **时间高频接力**——20–50 Hz 控制率下，2 秒任务会产生 40–100 个 token 序列，组合出几乎连续的轨迹。
+- **缺陷**：bin 内统一落到中心点，存在精度损失；并且离散 token 缺乏实时平滑性，这正是 Diffusion / Flow Matching 路线要解决的问题。
+
+### 3.2 词元 → 连续动作的解码模块
+综述总结的几种"翻译官"：
+- **MLP（基础）**：把 Transformer 输出的 token / readout 向量直接回归成连续物理量；常用损失：**L2**（对离群点惩罚大）、**L1**（OpenVLA-OFT 指出更鲁棒，动作更稳）、**BCE**（夹爪开/闭这种二元输出）。
+- **LSTM**：在解码端引入时间记忆，确保前后动作连贯，避免抖动。
+- **GMM（高斯混合）**：处理多峰动作分布（如左/右两种合理抓法），避免被平均成"中间撞上去"的错误轨迹。
+- **加入本体感觉 / 力信号**：把关节角度、力矩接入解码端，实现"轻拿轻放"。
+- **非自回归压缩（RoboFlamingo）**：用 average / max pooling 把 Transformer 内部的一长串思考 token 压成单一向量，**只输出当前 1 步动作**（压的是"思考过程"，不是时间步）。
+- **Action Chunking（OpenVLA-OFT / ACT）**：一次输出未来多步动作块，**压的是"时间维度"**，得到时间上更平滑的轨迹。两者经常被混淆，需要明确区分。
+
+### 3.3 分层策略：从 RT-H 到 GR00T N1
+- **RT-H** 用 **同一个 RT-2 backbone**，通过修改 prompt 在两种角色间切换：
+  - *High-level*：从 (image, instruction) 预测 **language motion**（如 "move arm forward"），作为可读的中间动作语义；
+  - *Low-level*：以 language motion 为条件再预测离散动作 token。
+- **收益**：(i) 中间符号化让错误可检测、可纠正；(ii) 高低层共享表示，迁移与组合更自然。
+- **后续演进**：π0.5 把高层换成 **FAST tokens（离散）**、低层换成 **Flow Matching（连续）**；GR00T N1 推广为 **VLM (System 2) + DiT/Flow (System 1)**。
+- **隐式分层**：FiS-VLA / OpenHelix / DP-VLA 让高低层在 **潜在空间直连**，不再显式输出人类可读的子任务；Tri-VLA 则把 VLM + Stable Video Diffusion + 扩散 Transformer 三者用交叉注意力串成一条流水线。
+
+### 3.4 模态扩展
+- **音频**：把声音转成 **梅尔频谱图**（"声音的 X 光片"）→ ResNet / ViT-VQGAN 词元化；或直接用 Whisper / AST / SpeechTokenizer 提取保留语气、环境声、碰撞声等"文本无法转写"的信息。RoboNurse-VLA 走 ASR → 文本的偷懒路线，丢失情境声。
+- **3D（体素 / TSDF）**：体素 = "3D 像素"（Minecraft 方块），与 3D U-Net / 卷积天然兼容。
+  - OccLLaMA / OpenDriveVLA：把 3D 占用栅格 **踩扁成 BEV** 再用 VQ-VAE 词元化，省算力；
+  - iManip：直接在 3D 体素上跑 3D U-Net，精度高、算力贵；
+  - VidBot：用 **TSDF（截断符号距离场）** 让每个 voxel 记"到最近表面的有符号距离"，从而平滑出零等值面，避免马赛克锯齿。
+- **运动模态**：ARM4R 接入 3D 跟踪；SOLAMI 用 VQ-VAE 把 **SMPL-X 关节角度**离散成"骨骼动作密码"；PPL / LangToMo 用 RAFT 估计光流捕捉像素流速场，做细粒度时间推理。
+
+### 3.5 推理加速与 ECoT
+**问题**：标准 ECoT（Embodied Chain-of-Thought）逼模型在动作前先输出几百个推理 token，自回归生成造成显著延迟。
+- **ECoT-Lite**：训练时使用 **Reasoning Dropout**，强迫网络把中间推理 **内化进权重**；推理时跳过文本输出直接给动作，省掉生成 token 的开销。
+- **Fast ECoT**：两招组合 —— (i) **Thoughts Reuse / 缓存**：宏观计划只想一次，重复使用；(ii) **并行/异步生成**：前台立刻输出动作、后台异步推演长远逻辑，整体提速可达 ~7.5×。
+
+### 3.6 上下文学习（ICL）与 ICRT
+- ICL 让 VLA 在 **不修改参数** 的前提下，仅依靠测试时提供的 1–3 条遥操作轨迹作为 prompt，就能 zero-shot 生成新任务动作（ICRT 框架）。
+- 这与 LLM 中 "给几个 in-context 示例就能学会规律" 同源；瓶颈在于上下文窗口长度和样例选取策略。
+
+### 3.7 弱监督（GR00T N1 的辅助 BBox 损失）
+- 让 VLA 在输出动作的同时预测物体边界框，强化空间定位与 affordance 检测。
+- "标准答案" 不靠人工标注，而是用另一个 AI（**OWL-ViT**）自动生成 → **弱监督**。便宜、海量，依赖大数定律抹平标注噪声，但若教师 AI 对某类物体（如透明玻璃）盲区会传导给学生。
+
+### 3.8 梯度隔离与灾难性遗忘
+- **痛点**：随机初始化的动作头会向预训练 VLM 主干回传巨大梯度 → 把预训练好的视觉/语言常识冲垮（**catastrophic forgetting**）。
+- **梯度隔离 (Gradient Insulation)**：在动作头与主干之间砌"单向防火墙"，惩罚只更新动作头。
+- **极端做法**：GR00T N1.5 **完全冻结 VLA**；RevLA 借鉴 model merging，**逐步反转主干权重** 回到预训练状态来缓解遗忘。
+- **配套手段**：LoRA / 仅 fine-tune action head，是资源受限场景的首选。
+
+---
+
+## 四、关键对比速查（来自阅读词汇积累）
+
+**扩散 vs 流匹配（生成路径与适用角色）**
+
+| 维度 | Diffusion / RDT-1B | Flow Matching / π0 |
+|---|---|---|
+| 生成路径 | 弯曲、随机、不断摸索修正 | 直线 / 平滑曲线、目标明确 |
+| 生成速度 | 较慢（多步去噪） | 极快（步骤极少） |
+| 动作连贯性 | 好，但过程复杂 | 极佳，天生适合连续流动控制 |
+| 数学本质 | SDE / 分数匹配 | ODE / 向量场回归 |
+| 角色定位 | 适合"大局观生成" | 适合低级实时控制器 |
+
+**Octo vs NoMAD（任务指定方式 & 信息聚合）**
+
+| 维度 | Octo | NoMAD |
+|---|---|---|
+| 任务输入 | 画面 + **文字指令** | 画面 + **目标画面**（无文字） |
+| 信息聚合 | 提取唯一 **Readout token** | 所有 token 做 **Average Pooling** |
+| 动作生成器 | Diffusion | Diffusion |
+
+**VLM + 离散 Token vs VLM + 扩散动作头**
+
+| 维度 | (4) VLM + Discrete Token（RT-2） | (5) VLM + Diffusion Head |
+|---|---|---|
+| 主干 | 大型 VLM（带人类常识） | 同左 |
+| 输出格式 | **离散**动作 token | **连续**动作轨迹 |
+| 动作生成器 | VLM 自身自回归 | 外挂 Diffusion 模型 |
+| 哲学 | 万物皆 token | 认知归认知、控制归控制 |
+
+**连续嵌入 vs 离散词元**
+
+| 维度 | 连续嵌入（ViT / CLIP） | 离散词元（VQ-GAN / VQ-VAE） |
+|---|---|---|
+| 数据形态 | 高维浮点向量 | 字典中的固定整数 ID |
+| 与 LLM 兼容性 | 较差 | 极好 |
+
+**粗粒度 vs 细粒度**
+
+| 维度 | 粗粒度 | 细粒度 |
+|---|---|---|
+| 视角 | 宏观、鸟瞰 | 微观、局部 |
+| 信息量 | 少（被压缩） | 大（保留原始特征） |
+| 算力成本 | 低 | 高 |
+| 适用场景 | 高层规划、整体趋势 | 精准定位、安全审计 |
+
+---
+
+## 五、延伸方向一：VLA 的"记忆"问题
+
+综述 Section IX-B (*Reasoning*) 明确把 **memory** 列为 VLA 走向 long-horizon 的关键瓶颈：
+
+> "effective reasoning requires the ability to retain relevant information over time and retrieve it when needed … e.g., locate a shelf, navigate elsewhere to pick up a cup, then return to place it on the shelf."
+
+观察到的几条与记忆相关的研究线索：
+
+1. **隐式记忆（上下文窗口里的历史 token）**：RT-1 / RT-2 / OpenVLA 仅靠最近若干帧的视觉 token，受 Transformer 上下文长度限制，无法跨数十秒以上保留语义。
+2. **世界模型作为外部记忆**：MinD / FLARE / UVA 通过预测未来观察隐式编码"环境状态"，但仍是短时滚动窗口。
+3. **潜在动作 + 结构化中间表示**：LAPA / UniVLA / Chain-of-Affordance / PPI 把任务关键节点（关键帧、抓取点、Pointflow）作为可检索的"中间 anchor"，类似事件记忆。
+4. **分层策略的高层 plan 缓存**：π0.5 / GR00T N1 / LoHoVLA 在高层 sub-task 出错时回溯重规划，本质是轻量的 episodic memory + replanning。
+5. **显式外置记忆库**：综述指出这正是 *open challenge*——引入 key-value memory / 检索增强 VLA / 向量数据库等实现跨 episode 信息保留尚属空白。
+
+**初步判断**：VLA 记忆方向有几条可切入的小问题：
+
+- **跨 episode 检索增强 VLA（RAG-VLA）**：把过去成功轨迹片段向量化检索，作为高层 prompt 的一部分；
+- **时间抽象 + 关键帧记忆**：仿照 PPI 把 keyframe 的视觉 / 动作摘要塞入显式 memory；
+- **世界模型作为可写记忆**：让 VLA 不仅"读"世界模型预测，还把交互结果"写回"潜在状态做长时序一致性建模。
+
+下周计划在此基础上做一轮专门的 *VLA + Memory* 论文调研。
+
+---
+
+## 六、延伸方向二：VLA / VLN 与具身安全（Embodied Safety）
+
+综述 Section IX-E (*Safety*) 与 IX-F (*Failure Detection and Recovery*) 系统指出当前不足：
+
+> "Current systems often lack mechanisms to detect and avoid unexpected human presence in the workspace … improving safety requires hybrid architectures combining learned policies with the reliability of model-based controllers."
+>
+> "Failures are typically treated as terminal events, with no recovery or re-planning strategies in place."
+
+综述列举的早期工作：
+
+- **SAFE**：用 VLA 内部中间表示在线检测失败事件；
+- **Agentic Robot**：用 VLM 检测失败 → 触发预设恢复行为 → 重新规划；
+- **LoHoVLA**：分层架构下，反复失败时回退到上层 sub-task 重新生成；
+- **FOREWARN**：从策略采样大量动作序列、聚类为 6 种行为模式，用 DreamerV3 世界模型仿真未来状态再选最优。
+
+**对"VLN / VLA 如何向具身安全靠拢"的初步思考**：
+
+1. **失败可检测性**：让 VLA 同时输出 *action* 与 *confidence / affordance score*，低置信度时降级到 MPC。
+2. **混合架构（learned + model-based）**：在 low-level 加入 CBF / MPC shielding，把 VLA 输出的 chunk 投影到安全集合，这与 π0 / GR00T N1 的 System 1 接口天然兼容。
+3. **世界模型驱动的预演（Imagined Rollout）**：执行前先用世界模型 rollout 若干候选 chunk，剔除会碰撞 / 误抓 / 越界的方案（FOREWARN 思路在 VLN 上尤其值得尝试）。
+4. **VLN 中的安全导航**：四足 / 人形 + VLN 的部署场景（NaVILA、TrackVLA、Cross-Former）天然存在动态人-机共存问题，可把"可达性 + 可见人类位置 + 不确定性估计"作为额外感知通道融入语言条件策略。
+5. **持续学习中的安全约束**：综述 IX-C 强调在线 / 持续学习必经之路，但带来 catastrophic forgetting 与 unsafe exploration；可结合 RLHF + 安全 critic 作为约束信号，避免在线更新破坏既有安全策略。
+6. **数据侧的安全增强**：在 GenAug / ROSIE 等增强管线中显式插入"危险情境"（人类闯入、地形塌陷、目标缺失），让 VLA 见过这些 edge case。
+
+这一方向恰好与综述 Section IX-E、IX-F 的 *open challenge* 重合，值得作为后续的研究切入点之一。
+
+---
+
+## 七、本周收获与反思
+
+1. **建立了 VLA 全景图**：从 CNN 时代到 hierarchical VLM + Flow Matching，能对当前主流模型（RT-2 / OpenVLA / Octo / RDT-1B / π0 / π0.5 / GR00T N1）的架构差异说出关键不同点。
+2. **澄清了若干常见混淆点**：
+   - 分箱 (Binning) 下"一个 bin = 一个固定区间"，多自由度组合 + 高频率 → 千万种轨迹；
+   - 非自回归压缩（RoboFlamingo）≠ Action Chunking（OpenVLA-OFT）：前者压"思考过程"输出 1 步，后者压"时间维度"输出未来多步；
+   - Diffusion vs Flow Matching：前者偏"大局观生成"，后者偏"低级实时控制"；
+   - ECoT-Lite 用 Reasoning Dropout 内化推理，Fast ECoT 用缓存 + 异步并行加速；
+   - 梯度隔离 / LoRA / 冻结 backbone 是抵御 catastrophic forgetting 的三种常见策略。
+3. **意识到自己的薄弱点**：扩散 / 流匹配的数学细节（SDE / ODE、score matching、CFM）只有概念层理解；VLN 线（NaVILA / TrackVLA / CrossFormer）掌握尚浅；具身安全文献（CBF / MPC shielding / FOREWARN / SAFE）只读到综述级别。
+
+---
+
+## 八、Coding 进展
+
+与文献调研并行，本周也启动了考核任务的 coding 部分：在 `starVLA` codebase 中选用 **QwenPI 架构 + Qwen3-VL-4B-Instruct backbone**，目标是用 IndoorUAV 数据集跑通 VLN 导航的 smoke test。当前进度如下：
+
+### 8.1 环境与 codebase 准备（已完成）
+- **运行环境**：在 Linux 服务器上配置好 conda env `starVLA`（Python 3.10），按 `requirements.txt` 安装 PyTorch 2.7 + CUDA 12.8、`transformers`、`accelerate`、`deepspeed` 等依赖；额外编译安装 `flash-attn 2.8.3` 以适配本机 Blackwell 架构（sm_120）的 GPU。
+- **Backbone 下载**：从 HuggingFace 拉取 `Qwen/Qwen3-VL-4B-Instruct` 到 `playground/Pretrained_models/`，并通过 `from_pretrained` 成功加载。
+- **codebase 走读**：阅读 starVLA 的整体结构，明确以下关键模块的关系——
+  - `starVLA.model.framework.VLM4A.QwenPI`：QwenPI 框架的训练入口（VLM 主干 + 流匹配动作头）；
+  - `starVLA.dataloader.gr00t_lerobot`：LeRobot v2.0 格式的数据加载与统计、模态注册；
+  - `starVLA.dataloader.gr00t_lerobot.registry`：自动扫描 `examples/*/train_files/data_registry/`，将各 benchmark 的 `data_config.py` 注册进全局表；
+  - `examples/LIBERO/`、`examples/DOMINO/`：作为 yaml + data_config 的样板参考。
+- **QwenPI smoke（随机数据）**：用一个 fake batch（随机 image / action / state / instruction）跑通 QwenPI 的 forward，确认权重加载、flash-attn kernel、动作头维度配置全部对得上，得到合理的 flow-matching loss。
+
+### 8.2 IndoorUAV 数据集获取与解析（已完成）
+- IndoorUAV 完整数据集体量较大（多场景组共 ~34925 条 VLA 实例），按考核要求**先只下载 `replica` 场景组 + `vla_ins` 索引 + `without_screenshot` metadata** 用于 smoke。
+- 解压后梳理出三个 zip 的角色分工：
+  - `replica.zip` → 提供 `screenshots/*.png`（1280×720 第一视角图像）；
+  - `without_screenshot.zip` → 提供 `posture.json`（每帧 [x, y, z, yaw°]）、`real_action.json`（每帧离散动作 + magnitude）、`instruction.json` 等 metadata；
+  - `vla_ins.zip` → 把 VLN 长轨迹切成短 VLA 子段的 `{instruction, source: [start, end]}` 索引。
+- 校验通过：replica 共 32 条 traj、110 个 VLA 子段，索引帧号与 posture / screenshots 完全对齐；并验证了 `posture` 相邻帧差分与 `real_action` 的语义完全一致（如 [0, 0, 0.07, 0] ↔ `fly_up: 0.07`），可放心用 pose 差分作为连续动作表示。
+
+### 8.3 数据转换脚本（**进行中**）
+当前目标是把 IndoorUAV 转成 starVLA dataloader 直接可读的 **LeRobot v2.0 格式**：
+
+```
+meta/{info.json, episodes.jsonl, tasks.jsonl, modality.json}
+data/chunk-000/episode_XXXXXX.parquet      # state / action / index 等
+videos/chunk-000/observation.images.front/episode_XXXXXX.mp4
+```
+
+设计方案已锁定：
+- **状态** 4 维 `[x, y, z, yaw°]`、**动作** 4 维 `[dx, dy, dz, dyaw°]`（yaw 差分包到 (-180°, 180°]）；
+- 每个 VLA 子段 → 一个 episode；
+- Embodiment tag 复用 `NEW_EMBODIMENT`；
+- 通过新增 `examples/IndoorUAV/train_files/data_registry/data_config.py` 让 registry 自动发现。
+
+当前正在写 `scripts/convert_indoor_uav_to_lerobot.py`，主要进度：
+- ✅ 已实现 metadata pipeline（解析 vla_ins / posture / instruction，处理编码异常）；
+- ✅ 已实现 parquet 写入（state / action / timestamp / index 等列）；
+- ⏳ 视频编码部分仍在调通（用 ffmpeg concat 把每个 episode 的 PNG 序列编码为 H.264 mp4，目前在解决 ffmpeg 8 新版的 `-r / -vsync` 参数兼容问题）；
+- ⏳ 完成转换器后，还需要写 `data_config.py`、`modality.json`、训练 yaml，并通过 dataloader 端到端跑一遍验证。
+
+### 8.4 下一步
+1. 把 convert 脚本调通，跑出 replica 子集（110 episodes）的 LeRobot 数据；
+2. 编写 IndoorUAV 的 `data_config.py` + 训练 yaml；
+3. 在 GPU 上跑一次 micro-batch 训练 step，闭环验证 forward + backward + optimizer step；
+4. 视显存情况决定是否上 DeepSpeed ZeRO，并补一些更多场景包做正式训练。
+
+---
+
+## 九、下周计划
+
+1. **VLA 记忆方向专项调研**：精读 PPI、UniVLA、UniSkill、FLARE、MinD 等强调中间表示与世界模型的工作，并扫一轮 RAG-style 的 VLA / agent memory 论文。
+2. **VLN 专项调研**：以 NaVILA、TrackVLA、CrossFormer、NaVid、VLN-CE 为线索梳理 VLN 当前 SOTA。
+3. **具身安全文献调研**：精读 SAFE、Agentic Robot、LoHoVLA、FOREWARN，并外延到 CBF / Safety-critic / RLHF for robotics。
+4. **Coding 收尾**：把 IndoorUAV 转换器写完，跑通 dataloader + QwenPI 端到端训练 smoke，并在 replica 子集上初步训练几个 step 观察 loss 趋势。


### PR DESCRIPTION
- scripts/convert_indoor_uav_to_lerobot.py: convert raw VLA segments to LeRobot v2.0
- scripts/smoke_train_indoor_uav.py: single-GPU 8-bit AdamW smoke test
- examples/IndoorUAV/train_files/data_registry/data_config.py: register indoor_uav embodiment
- examples/IndoorUAV/train_files/starvla_train_indoor_uav.yaml: QwenPI 4-dim state/action config
- examples/IndoorUAV/train_files/launch_train_indoor_uav.sh: DeepSpeed ZeRO-2 multi-GPU launcher
- 周报-第1周.md: weekly research report

## Description
<!-- Briefly describe what this PR does -->


## Motivation
<!-- Why is this change needed? Please link the related Issue -->
Closes #

## Changes
<!-- List the key changes -->
-
-

## Testing
<!-- How was this verified? Check at least one -->
<!-- - [ ] `make check` passes  TODO: enable later -->
- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
|           |        |        |

- **Checkpoint**: <!-- Required for framework/benchmark changes: public HF link -->
- **Config**: <!-- Config path under examples/ -->
- **Reproduce**: <!-- Reproduction command -->

## Type of Change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [ ] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [ ] No secrets, API keys, or large binaries committed
- [ ] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [ ] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

## Screenshots / Logs (optional)
<!-- Training curves, evaluation result screenshots, relevant logs -->
