### PR TITLE
[feat] add Ascend NPU support with minimal code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In StarVLA (also a pun on "start VLA" ),  each functional component (model, data
 
 > **💡 Tip:** Files under any `**/bar/` directory are git-ignored, so you can place your custom scripts there (e.g., `examples/LIBERO/train_files/bar/my_train.sh`) without polluting the repo.
 
-
+**[2026/05/30]** 🔥 StarVLA now supports [VLA training with **Qwen-series backbones** on **Ascend NPU**](https://github.com/starVLA/starVLA/pull/336). See the [related discussion](https://github.com/starVLA/starVLA/issues/341) for details and feedback.
 
 **[2026/04/09]** 🚀 unified **multi-benchmark co-training** example (combining LIBERO, SimplerEnv, RoboTwin, VLA-Arena, etc.) is coming soon. Stay tuned!
 

--- a/starVLA/model/modules/vlm/QWen2_5.py
+++ b/starVLA/model/modules/vlm/QWen2_5.py
@@ -5,6 +5,7 @@
 from typing import List, Optional
 
 import torch
+from starVLA.model.tools import has_flash_attn  # unified flash-attn detection (GPU / NPU)
 from starVLA.training.trainer_utils import initialize_overwatch
 from qwen_vl_utils import process_vision_info
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
@@ -82,9 +83,7 @@ class _QWen_VL_Interface(nn.Module):
 
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
-            try:
-                import flash_attn  # noqa: F401
-            except ImportError:
+            if not has_flash_attn():
                 print("[WARNING] flash_attn not installed, falling back to sdpa")
                 attn_implementation = "sdpa"
 

--- a/starVLA/model/modules/vlm/QWen3.py
+++ b/starVLA/model/modules/vlm/QWen3.py
@@ -5,6 +5,7 @@
 from typing import Optional
 
 import torch
+from starVLA.model.tools import has_flash_attn  # unified flash-attn detection (GPU / NPU)
 from starVLA.training.trainer_utils import initialize_overwatch
 from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
 from transformers.modeling_outputs import CausalLMOutputWithPast
@@ -52,9 +53,7 @@ class _QWen3_VL_Interface(nn.Module):
         attn_implementation = "sdpa"
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
-            try:
-                import flash_attn  # noqa: F401
-            except ImportError:
+            if not has_flash_attn():
                 print("[WARNING] flash_attn not installed, falling back to sdpa")
                 attn_implementation = "sdpa"
 

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -6,6 +6,7 @@
 from typing import Optional
 
 import torch
+from starVLA.model.tools import has_flash_attn  # unified flash-attn detection (GPU / NPU)
 from starVLA.training.trainer_utils import initialize_overwatch
 from transformers import AutoProcessor
 from transformers.modeling_outputs import CausalLMOutputWithPast
@@ -61,9 +62,7 @@ class _QWen3_5_VL_Interface(nn.Module):
         attn_implementation = "sdpa"
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
-            try:
-                import flash_attn  # noqa: F401
-            except ImportError:
+            if not has_flash_attn():
                 print("[WARNING] flash_attn not installed, falling back to sdpa")
                 attn_implementation = "sdpa"
 

--- a/starVLA/model/tools.py
+++ b/starVLA/model/tools.py
@@ -1,3 +1,22 @@
+def has_flash_attn():
+    """Check whether a flash-attention backend is available.
+
+    Returns True if either ``torch_npu`` (Ascend NPU) or ``flash_attn`` (GPU)
+    can be imported, otherwise False.  This allows VLM modules to gracefully
+    fall back to SDPA when no compatible flash-attention implementation is found.
+    """
+    try:
+        import torch_npu  # NPU flash-attention backend
+        return True
+    except ImportError:
+        pass
+    try:
+        import flash_attn  # GPU flash-attention backend
+        return True
+    except ImportError:
+        return False
+
+
 def auto_get_module_keys(module, max_depth=0, prefix_list=None, current_depth=0, current_prefix=""):
     """
     get all submodule keys of a module, support setting recursion depth and prefix list.

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -22,6 +22,15 @@ from typing import Tuple
 import numpy as np
 import torch
 import torch.distributed as dist
+
+# NPU support: import torch_npu and enable automatic CUDA→NPU mapping.
+# On GPU-only environments this is a no-op (ImportError is silently ignored).
+try:
+    import torch_npu
+    from torch_npu.contrib import transfer_to_npu
+except ImportError:
+    pass
+
 import wandb
 from accelerate import Accelerator, DeepSpeedPlugin
 from accelerate.logging import get_logger


### PR DESCRIPTION
## Description
Add Ascend NPU (华为昇腾) support to starVLA with minimal code changes, enabling training on both GPU and NPU hardware.

## Motivation
Currently starVLA only supports NVIDIA GPU. This PR adds native NPU support so users with Ascend hardware can train without maintaining a separate fork.

## Changes
- Add `has_flash_attn()` to `starVLA/model/tools.py` — unified flash-attention detection for both GPU (`flash_attn`) and NPU (`torch_npu`) backends
- Add optional `torch_npu` + `transfer_to_npu` import in `train_starvla.py` for automatic CUDA→NPU mapping
- Replace inline `try: import flash_attn` blocks in Qwen-series VLM backbones (QWen2_5, QWen3, QWen3_5) with `has_flash_attn()` for consistent fallback behavior
- No changes to autocast/device logic; `torch_npu.contrib.transfer_to_npu` handles CUDA API remapping transparently

## Testing
- [x] Verified on Atlas 800T A3 for 150,000 training steps without any errors (script: starVLA/examples/Robotwin/train_files/run_robotwin_train.sh)

## Type of Change
- [x] New feature (non-breaking)

## Checklist
- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] No modifications to shared dataloader/config modules — only training entries and VLM model wrappers