### PR TITLE
[feat]: add QwenDiscreteDiffusion + RTC predict_action_realtime

### DIFF
--- a/examples/modelExtensions/DiscreteDiffusion/README.md
+++ b/examples/modelExtensions/DiscreteDiffusion/README.md
@@ -1,0 +1,202 @@
+# Discrete Diffusion Action Head (MaskGIT-style)
+
+A new framework for starVLA: `QwenDiscreteDiffusion`. The VLM backbone is the
+same Qwen2.5-VL stack used by `QwenPI`, but the action head replaces continuous
+flow-matching with **MaskGIT-style discrete diffusion** over a uniform action
+binning. The head also exposes a **real-time chunking (RTC)** decode that
+conditions on the previous chunk's un-executed actions as a known prefix,
+enabling smooth closed-loop control under inference latency.
+
+## What's added
+
+| Component | Path |
+|---|---|
+| Framework | `starVLA/model/framework/VLM4A/QwenDiscreteDiffusion.py` |
+| Action head | `starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py` |
+| Binning + MaskGIT helpers | `starVLA/model/modules/action_model/discrete_diffusion/` |
+| Sim config (RoboTwin, 14D) | `starVLA/config/training/starvla_train_discrete_diffusion.yaml` |
+| Real config (FastUMI, 10D) | `starVLA/config/training/starvla_train_discrete_diffusion_real.yaml` |
+
+### Architecture
+
+`LayerwiseDiscreteDiffusionActionHead` mirrors the QwenPI flow-matching head:
+the same DiT block stack, the same layer-wise cross-attention against the
+Qwen-VL hidden states (`vl_embs_list`), the same future-token / state /
+position-embedding inputs. Two things change:
+
+1. **Tokens, not noise.** Each continuous action `a ∈ [low, high]^D` is encoded
+   into discrete bins (`continuous_to_bins`, default `num_bins=256`). The head
+   predicts logits over bins per (timestep, action-dim) position, and decodes
+   back to bin centers (`ActionBinning.decode`). Two representations are
+   supported:
+   - `bin` — output `num_bins` logits per position, cross-entropy loss.
+   - `bit` — output 8 sigmoid-bit logits per position, BCE loss; 8 bits
+     simulate 256 bins. Useful when the vocab is large.
+2. **MaskGIT decode replaces Euler integration.** Training masks a
+   schedule-controlled fraction of positions and asks the model to fill them
+   in (`apply_mask` + cross-entropy). Inference iteratively unmasks the
+   highest-confidence positions over `num_inference_steps` rounds
+   (`predict_action`). An auxiliary L1 loss on the decoded continuous
+   prediction (`l1_loss_weight=0.1`) keeps bin centers calibrated.
+
+### Real-time chunking decode
+
+`predict_action_realtime(vl_embs_list, state, prev_action_chunk, inference_delay,
+execution_horizon, …)` is the RTC entry point. The previous chunk's tail is
+encoded into bins and pinned as a known prefix; only the trailing
+`execution_horizon` positions are masked and resampled. The number of decode
+steps scales with the masked fraction (or is held fixed via `fixed_steps=True`),
+and `early_stop=True` exits as soon as every non-prefix slot is unmasked.
+
+| Argument | Effect |
+|---|---|
+| `prev_action_chunk` | `(B, T, action_dim)` continuous actions from the previous prediction. |
+| `inference_delay` | Fallback for `execution_horizon` if the latter is unset; sets prefix length under `hard_mask=True`. |
+| `execution_horizon` | Number of trailing positions to regenerate. Defaults to `inference_delay`. |
+| `hard_mask` | If `True`, prefix length is `inference_delay` (legacy). If `False` (default), prefix length is `action_horizon - execution_horizon`. |
+| `fixed_steps` | Always run `num_inference_steps`, otherwise scale by mask fraction. |
+| `choice_temperature` / `decode_temperature` | Top-k Gumbel temperature for which positions stay masked / per-step softmax temperature. |
+| `early_stop` | Exit early once every non-prefix slot is unmasked. |
+
+The flow-matching counterpart `LayerwiseFlowmatchingActionHead.predict_action_realtime`
+exposes the same `prev_action_chunk` interface but uses ΠGDM (pseudo-inverse
+guided diffusion) by default; pass `mode="simulated_delay"` for the naive
+replace-and-denoise variant. They are interchangeable from the deployment
+client's perspective (same `examples`, `prev_action_chunk_normalized`,
+`inference_delay` API on the framework wrapper).
+
+## Configs at a glance
+
+Discrete-diffusion-specific keys under `framework.action_model` (see the YAMLs
+for the full set):
+
+```yaml
+representation: bin           # "bin" or "bit"
+num_bins: 256                 # 256 bins → 8-bit "bit" mode also works
+action_low: -1.0
+action_high: 1.0
+
+num_inference_steps: 8        # MaskGIT decode rounds
+train_mask_schedule: cosine   # "cosine" or "linear"
+decode_schedule: cosine
+no_mask_token_prob: 0.0       # leak some unmasked tokens during training
+l1_loss_weight: 0.1           # auxiliary L1 on decoded continuous values
+use_simple_max: false         # if true: single forward + argmax (no iteration)
+```
+
+`action_dim`, `state_dim`, `future_action_window_size`, and the DiT block
+shape (`num_layers`, `attention_head_dim`, `num_attention_heads`) are inherited
+from the same conventions as QwenPI; the head overrides DiT layer count and
+hidden dim from `framework.qwenvl` at construction time so the action head
+matches the VLM size automatically.
+
+## Training
+
+The training entrypoint is unchanged — `starVLA/training/train_starvla.py`.
+Pick the discrete-diffusion config and set `framework.name=QwenDiscreteDiffusion`.
+
+### Sim / RoboTwin (14D, dual-arm)
+
+```bash
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes 8 \
+  starVLA/training/train_starvla.py \
+  --config_yaml starVLA/config/training/starvla_train_discrete_diffusion.yaml \
+  --framework.name QwenDiscreteDiffusion \
+  --framework.qwenvl.base_vlm playground/Pretrained_models/Qwen2.5-VL-3B-Instruct \
+  --framework.qwenvl.attn_implementation flash_attention_2 \
+  --datasets.vla_data.data_root_dir playground/Datasets/RoboTwin \
+  --datasets.vla_data.data_mix robotwin \
+  --datasets.vla_data.per_device_batch_size 16 \
+  --trainer.max_train_steps 100000 \
+  --trainer.save_interval 5000 \
+  --run_id qwendd_robotwin
+```
+
+### Real / FastUMI pick-and-place (10D, single-arm)
+
+```bash
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes 4 \
+  starVLA/training/train_starvla.py \
+  --config_yaml starVLA/config/training/starvla_train_discrete_diffusion_real.yaml \
+  --framework.name QwenDiscreteDiffusion \
+  --framework.qwenvl.base_vlm playground/Pretrained_models/Qwen2.5-VL-3B-Instruct-Action \
+  --framework.qwenvl.attn_implementation flash_attention_2 \
+  --datasets.vla_data.data_root_dir playground/Datasets/FastUMI \
+  --datasets.vla_data.data_mix fastumi_pickandplace_real_0307 \
+  --datasets.vla_data.per_device_batch_size 8 \
+  --trainer.max_train_steps 30000 \
+  --trainer.save_interval 5000 \
+  --run_id qwendd_fastumi_real
+```
+
+Either command can be wrapped into a slurm/launch script following the
+template in `0130-train-libero.sh` (just swap `Framework_name` and
+`config_yaml`). Override any YAML key from the CLI with the
+`--<group>.<subgroup>.<key> <value>` syntax used above.
+
+## Inference
+
+In-process Python use:
+
+```python
+from starVLA.model.framework import build_framework
+from starVLA.model.framework.share_tools import read_mode_config, dict_to_namespace
+
+model_config, norm_stats = read_mode_config("path/to/checkpoint.pt")
+config = dict_to_namespace(model_config)
+config.trainer.pretrained_checkpoint = None
+model = build_framework(cfg=config).cuda().eval()
+model.load_state_dict(torch.load("path/to/checkpoint.pt", map_location="cpu"), strict=True)
+model.norm_stats = norm_stats
+
+# Single shot
+out = model.predict_action(examples=[{"image": [...], "lang": "...", "state": ...}])
+normalized_actions = out["normalized_actions"]   # (B, action_horizon, action_dim)
+
+# RTC-aware (continuous prefix from the previous chunk)
+out = model.predict_action_realtime(
+    examples=[...],
+    prev_action_chunk_normalized=prev_chunk,     # (B, action_horizon, action_dim)
+    inference_delay=5,
+    execution_horizon=5,
+    hard_mask=False,
+    fixed_steps=False,
+    early_stop=False,
+    decode_temperature=0.1,
+    choice_temperature=0.1,
+)
+```
+
+## Real-world deployment
+
+Deployment scripts (server/client split with `inference_server.py`,
+`closedloop_rtc_*.py`, `closedloop_sync.py`, `openloop_eval.py`) live in
+the author's fork and are kept out of this PR to keep the surface minimal.
+The framework wrapper's `predict_action_realtime(...)` is the integration
+point — anything that calls it the way `predict_action(...)` is called can
+drive a real-time RTC loop. The flow-matching counterpart
+`LayerwiseFlowmatchingActionHead.predict_action_realtime` exposes the same
+`prev_action_chunk` / `inference_delay` / `execution_horizon` interface, so
+the two heads are interchangeable from the deployment client's perspective.
+
+## File map
+
+```
+examples/modelExtensions/DiscreteDiffusion/
+└── README.md                                # this file
+starVLA/config/training/
+├── starvla_train_discrete_diffusion.yaml      # sim (14D)
+└── starvla_train_discrete_diffusion_real.yaml # real (10D)
+starVLA/model/framework/VLM4A/
+└── QwenDiscreteDiffusion.py                 # framework wrapper (forward + predict_action[_realtime])
+starVLA/model/modules/action_model/
+├── LayerwiseDiscreteDiffusion_ActionHeader.py
+└── discrete_diffusion/
+    ├── action_binning.py                    # continuous ↔ bin index, logits → indices
+    ├── mask_git_schedule.py                 # train/decode schedules, top-k mask helpers
+    └── __init__.py
+```

--- a/starVLA/config/training/starvla_train_discrete_diffusion.yaml
+++ b/starVLA/config/training/starvla_train_discrete_diffusion.yaml
@@ -1,0 +1,125 @@
+# Discrete Diffusion Policy (MaskGIT-style) - aligned with starvla_cotrain_robotwin
+# Same datasets/trainer as robotwin; uses discrete diffusion action head instead of QwenOFT
+
+run_id: qwenact
+run_root_dir: results/Checkpoints
+seed: 42
+trackers: [jsonl, wandb]
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+
+framework:
+  name: QwenDiscreteDiffusion
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  dino:
+    dino_backbone: dinov2_vits14
+
+  action_model:
+    # Discrete diffusion (MaskGIT-style). QwenPI-style: layer-wise cross-attention with vl_embs_list.
+    action_model_type: DiT-B
+    hidden_size: 1024
+    add_pos_embed: true
+    max_seq_len: 1024
+    action_dim: 14
+    state_dim: 14
+    future_action_window_size: 15
+    action_horizon: 16
+    past_action_window_size: 0
+    repeated_diffusion_steps: 4
+
+
+
+    # Binning: "bin" (B,T,D,num_bins) or "bit" (B,T,D,8) - 8 bits simulate 256 bins
+    representation: bin  # bin | bit
+    num_bins: 256
+    action_low: -1.0
+    action_high: 1.0
+
+    # MaskGIT schedule
+    use_simple_max: false   # if true: single forward + argmax, no iterative decode
+    num_inference_steps: 8
+    train_mask_schedule: cosine  # cosine or linear
+    decode_schedule: cosine
+    no_mask_token_prob: 0.0
+    l1_loss_weight: 0.1  # Auxiliary L1 on continuous predictions
+    inpainting_mask: false
+    inpainting_d_schedule: linear_decay
+
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:
+      cross_attention_dim: 2048
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: "ada_norm"
+      num_layers: 12
+      attention_head_dim: 64
+      num_attention_heads: 32
+      output_dim: 256  # overridden by binning.logits_dim at runtime
+      positional_embeddings: "sinusoidal"
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: asv2_conversation_en,asv2_detailed_description_en,asv2_region_captioning_en,coco_internvl_longcap_en,coco_karpathy_train_567_en,coco_negative_gpt4o_en,coco_poetry_zh,coco_rem_en_zh,cocorem_exist_yorn_en,cocotextv2_en,cocotextv2_gpt4o_en,okvqa_en,refcoco_grounding_aug_en,refcoco_grounding_en,tallyqa_coco_en,toloka_grounding_aug_en,vqav2_en,vsr_en
+    eval_dataset: aokvqa_cauldron_llava_format
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 50176
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: playground/Datasets/RoboTwin
+    data_mix: robotwin  # bridge_rt_1
+    action_type: abs_qpos
+    default_image_resolution: [3, 224, 224]
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs: ["image_0"]
+    image_size: [224, 224]
+    video_backend: torchvision_av
+
+trainer:
+  epochs: 100
+  max_train_steps: 1000000
+  num_warmup_steps: 5000
+  save_interval: 5000
+  eval_interval: 100
+  learning_rate:
+    base: 1.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  repeated_diffusion_steps: 4
+  max_grad_norm: 1.0
+  warmup_ratio: 0.1
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+  save_format: pt
+  is_resume: false
+  resume_epoch: null
+  resume_step: null
+  enable_gradient_checkpointing: true
+  enable_mixed_precision_training: true

--- a/starVLA/config/training/starvla_train_discrete_diffusion_real.yaml
+++ b/starVLA/config/training/starvla_train_discrete_diffusion_real.yaml
@@ -1,0 +1,114 @@
+# Discrete Diffusion Policy (MaskGIT-style) - FastUMI real pick-and-place
+# Aligned with FastUMI: pickandplace-real-0307, 10D actions, action_mode=abs.
+
+run_id: fastumi_discrete_diffusion_real
+run_root_dir: results/Checkpoints
+seed: 42
+trackers: [jsonl, wandb]
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_FastUMI
+is_debug: false
+
+framework:
+  name: QwenDiscreteDiffusion
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct-Action
+    attn_implementation: flash_attention_2
+    vl_hidden_dim: 2048
+  dino:
+    dino_backbone: dinov2_vits14
+
+  action_model:
+    # Discrete diffusion (MaskGIT-style). QwenPI-style: layer-wise cross-attention with vl_embs_list.
+    action_model_type: DiT-B
+    hidden_size: 1024
+    add_pos_embed: true
+    max_seq_len: 1024
+    # FastUMI action/state are 10D: [dx,dy,dz, rot6d(6), gripper]
+    action_dim: 10
+    state_dim: 10
+    future_action_window_size: 15
+    action_horizon: 16
+    past_action_window_size: 0
+    repeated_diffusion_steps: 4
+    num_inference_timesteps: 8
+
+    # Binning: "bin" (B,T,D,num_bins) or "bit" (B,T,D,8) - 8 bits simulate 256 bins
+    representation: bin  # bin | bit
+    num_bins: 256
+    action_low: -1.0
+    action_high: 1.0
+
+    # MaskGIT schedule
+    use_simple_max: false   # if true: single forward + argmax, no iterative decode
+    num_inference_steps: 8
+    train_mask_schedule: cosine  # cosine or linear
+    decode_schedule: cosine
+    no_mask_token_prob: 0.0
+    l1_loss_weight: 0.1  # Auxiliary L1 on continuous predictions
+    inpainting_mask: false
+    inpainting_d_schedule: linear_decay
+
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:
+      cross_attention_dim: 2048
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: "ada_norm"
+      num_layers: 12
+      attention_head_dim: 64
+      num_attention_heads: 32
+      output_dim: 256  # overridden by binning.logits_dim at runtime
+      positional_embeddings: "sinusoidal"
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: playground/Datasets/FastUMI
+    data_mix: fastumi_pickandplace_real_0307
+    # FastUMI: actions are pre-computed relative; action_mode=abs (no further delta).
+    action_mode: abs
+    default_image_resolution: [3, 224, 224]
+    per_device_batch_size: 8
+    load_all_data_for_training: true
+    obs: ["image_0"]  # compatibility; FastUMIDataConfig uses video.wrist
+    image_size: [224, 224]
+    video_backend: torchvision_av
+    # num_workers: 0  # uncomment to avoid distributed deadlocks during debug
+
+trainer:
+  epochs: 100
+  max_train_steps: 30000
+  num_warmup_steps: 5000
+  save_interval: 5000
+  eval_interval: 100
+  learning_rate:
+    base: 1.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  repeated_diffusion_steps: 4
+  max_grad_norm: 1.0
+  warmup_ratio: 0.1
+  weight_decay: 0.0
+  logging_frequency: 50
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+  save_format: pt
+  is_resume: false
+  resume_epoch: null
+  resume_step: null
+  enable_gradient_checkpointing: true
+  enable_mixed_precision_training: true

--- a/starVLA/model/framework/VLM4A/QwenDiscreteDiffusion.py
+++ b/starVLA/model/framework/VLM4A/QwenDiscreteDiffusion.py
@@ -1,0 +1,352 @@
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License, Version 1.0 (the "License").
+"""
+QwenDiscreteDiffusion Framework
+Qwen2.5-VL backbone + MaskGIT-style discrete-diffusion action head.
+
+Layer-wise cross-attention over multi-layer VLM hidden states, same shape
+as QwenPI, but the continuous flow-matching head is replaced by a
+discrete-diffusion head that predicts logits over a uniform action binning.
+
+The same wrapper exposes:
+  - forward(...) for training
+  - predict_action(...) for single-shot MaskGIT decode
+  - predict_action_realtime(...) for real-time chunking (RTC): pin the
+    un-executed tail of the previous chunk as a known prefix and only
+    decode the trailing execution_horizon positions.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+import torch
+
+from deployment.model_server.tools.image_tools import to_pil_preserve
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.framework.share_tools import (
+    merge_framework_config,
+    populate_layerwise_dit_cfg,
+)
+from starVLA.model.modules.action_model.LayerwiseDiscreteDiffusion_ActionHeader import (
+    LayerwiseDiscreteDiffusionActionHead,
+    get_action_model,
+)
+from starVLA.model.modules.vlm import get_vlm_model
+from starVLA.model.tools import FRAMEWORK_REGISTRY
+from starVLA.training.trainer_utils import initialize_overwatch
+from starVLA.training.trainer_utils.trainer_tools import resize_images
+
+logger = initialize_overwatch(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Default Config for QwenDiscreteDiffusion
+#  - Documents every framework-level parameter with type + description
+#  - YAML values override these defaults; extra YAML keys are preserved
+# ──────────────────────────────────────────────────────────────────────
+@dataclass
+class QwenDiscreteDiffusionDefaultConfig:
+    """QwenDiscreteDiffusion framework default parameters.
+
+    Layer-wise cross-DiT discrete-diffusion (MaskGIT-style) action prediction
+    conditioned on multi-layer VLM hidden states. All fields can be overridden
+    by the corresponding key in the YAML ``framework:`` section.
+    """
+
+    # --- Registry identifier (must match @FRAMEWORK_REGISTRY.register) ---
+    name: str = "QwenDiscreteDiffusion"
+
+    # === VLM backbone (Qwen2.5-VL / Qwen3-VL) ===
+    qwenvl: dict = field(
+        default_factory=lambda: {
+            "base_vlm": "./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct",
+            "attn_implementation": "flash_attention_2",
+            # Auto-set at runtime from VLM HF config.
+            "vl_hidden_dim": 2048,
+            "num_vl_layers": 36,
+        }
+    )
+
+    # === Action head (Layer-wise cross-DiT discrete diffusion) ===
+    action_model: dict = field(
+        default_factory=lambda: {
+            "action_model_type": "LayerwiseDD",
+            # Action / state dims and chunk length.
+            "action_dim": 7,
+            "state_dim": 7,
+            # Canonical chunk length. Legacy YAMLs may use
+            # future_action_window_size = action_horizon - 1; apply_config_compat
+            # normalises both directions.
+            "action_horizon": 16,
+            # Repeat factor used during training (matches QwenPI).
+            "repeated_diffusion_steps": 2,
+            "add_pos_embed": True,
+            "max_seq_len": 1024,
+            "num_target_vision_tokens": 32,
+            # --- Discrete-diffusion specific ---
+            # "bin": num_bins logits per (T, D) position, CE loss.
+            # "bit": num_bits=8 sigmoid bits per position, BCE loss; 8 bits
+            #        simulate 256 bins. Requires num_bins == 256.
+            "representation": "bin",
+            "num_bins": 256,
+            "action_low": -1.0,
+            "action_high": 1.0,
+            # MaskGIT decode rounds (used by predict_action and as the basis
+            # for predict_action_realtime's scaled-step heuristic).
+            "num_inference_steps": 8,
+            "train_mask_schedule": "cosine",  # "cosine" | "linear"
+            "decode_schedule": "cosine",
+            "no_mask_token_prob": 0.0,
+            # Auxiliary L1 on the decoded continuous prediction, keeps bin
+            # centers calibrated.
+            "l1_loss_weight": 0.1,
+            # If True, replace iterative decode with a single forward + argmax.
+            "use_simple_max": False,
+            # DiT architecture settings — shape fields (num_layers,
+            # input_embedding_dim, cross_attention_dim, num_attention_heads)
+            # are auto-populated by populate_layerwise_dit_cfg at runtime.
+            "diffusion_model_cfg": {
+                "dropout": 0.2,
+                "final_dropout": True,
+                "interleave_self_attention": True,
+                "norm_type": "ada_norm",
+                "positional_embeddings": "sinusoidal",
+                "attention_head_dim": 64,
+            },
+        }
+    )
+
+
+@FRAMEWORK_REGISTRY.register("QwenDiscreteDiffusion")
+class Qwen_DiscreteDiffusion(baseframework):
+    """
+    VLA with MaskGIT-style discrete-diffusion action head.
+    Layer-wise cross-attention over multi-layer VLM hidden states (QwenPI shape).
+    """
+
+    def __init__(
+        self,
+        config: Optional[dict] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        # Merge framework defaults with YAML config (YAML wins on conflicts).
+        self.config = merge_framework_config(QwenDiscreteDiffusionDefaultConfig, config)
+        self.qwen_vl_interface = get_vlm_model(config=self.config)
+
+        # Read the actual hidden size and layer count from the loaded VLM.
+        # Qwen3-VL stores num_hidden_layers under text_config; Qwen2.5-VL puts
+        # it on the top-level config — getattr handles both.
+        vlm_hf_cfg = self.qwen_vl_interface.model.config
+        text_cfg = getattr(vlm_hf_cfg, "text_config", vlm_hf_cfg)
+        num_vl_layers = int(text_cfg.num_hidden_layers)
+        llm_hidden_size = int(vlm_hf_cfg.hidden_size)
+        self.config.framework.qwenvl.vl_hidden_dim = llm_hidden_size
+        self.config.framework.qwenvl.num_vl_layers = num_vl_layers
+
+        # DiT runs at the LLM hidden size (no compression).
+        populate_layerwise_dit_cfg(
+            self.config,
+            dit_hidden_dim=llm_hidden_size,
+            num_dit_layers=num_vl_layers,
+        )
+
+        self.action_model: LayerwiseDiscreteDiffusionActionHead = get_action_model(config=self.config)
+
+        # action_horizon is the single source of truth for chunk length.
+        self.action_horizon = int(self.config.framework.action_model.action_horizon)
+
+    def _encode_vl_hidden_states(self, batch_images: List, instructions: List[str]) -> List[torch.Tensor]:
+        """Run QwenVL and return the last-N layer-wise hidden states for the Action DiT."""
+        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(images=batch_images, instructions=instructions)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            qwenvl_outputs = self.qwen_vl_interface(
+                **qwen_inputs,
+                output_attentions=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+            expected_layers = len(self.action_model.model.transformer_blocks)
+            vl_embs_list = list(qwenvl_outputs.hidden_states[-expected_layers:])
+        return vl_embs_list
+
+    def forward(
+        self,
+        examples: Optional[List[dict]] = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Args:
+            examples: List[dict], each dict requires:
+                - image: List[PIL.Image] (multi-view)
+                - lang: str instruction
+                - action: np.ndarray or list shaped [T, action_dim]
+                - state: optional np.ndarray [state_dim]
+        Returns:
+            dict: action_loss (torch.Tensor)
+        """
+        batch_images = [example["image"] for example in examples]
+        instructions = [example["lang"] for example in examples]
+        actions = [example["action"] for example in examples]
+        state = [example["state"] for example in examples] if "state" in examples[0] else None
+
+        # Step 1: encode through QwenVL
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
+
+        # Step 2: Action head forward + loss
+        with torch.autocast("cuda", dtype=torch.float32):
+            actions = torch.tensor(np.array(actions), device=base_hidden.device, dtype=base_hidden.dtype)
+            actions_target = actions[:, -self.action_horizon :, :]
+
+            repeated_diffusion_steps = int(self.config.framework.action_model.get("repeated_diffusion_steps", 2))
+            actions_target_repeated = actions_target.repeat(repeated_diffusion_steps, 1, 1)
+            vl_embs_list_repeated = [h.repeat(repeated_diffusion_steps, 1, 1) for h in vl_embs_list]
+
+            state_repeated = None
+            if state is not None:
+                state = torch.tensor(np.array(state), device=base_hidden.device, dtype=base_hidden.dtype)
+                state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
+
+            pred, target, extra = self.action_model(
+                vl_embs_list_repeated,
+                actions_target_repeated,
+                state_repeated,
+            )
+            action_loss = self.action_model.loss(pred, target, **extra)
+
+        return {"action_loss": action_loss}
+
+    @torch.inference_mode()
+    def predict_action(
+        self,
+        examples: Optional[List[dict]] = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Inference: MaskGIT-style iterative decode to future actions.
+
+        Returns:
+            dict: normalized_actions (np.ndarray) [B, action_horizon, action_dim]
+        """
+        if not isinstance(examples, list):
+            examples = [examples]
+
+        batch_images = [to_pil_preserve(example["image"]) for example in examples]
+        instructions = [example["lang"] for example in examples]
+        state = [example["state"] for example in examples] if "state" in examples[0] else None
+
+        train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
+        if train_obs_image_size:
+            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
+
+        state = (
+            torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
+            if state is not None
+            else None
+        )
+
+        decode_temperature = kwargs.get("decode_temperature", 0.1)
+        choice_temperature = kwargs.get("choice_temperature", 0.1)
+        use_simple_max = kwargs.get(
+            "use_simple_max",
+            bool(self.config.framework.action_model.get("use_simple_max", False)),
+        )
+
+        with torch.autocast("cuda", dtype=torch.float32):
+            pred_actions = self.action_model.predict_action(
+                vl_embs_list,
+                state,
+                choice_temperature=choice_temperature,
+                decode_temperature=decode_temperature,
+                use_simple_max=use_simple_max,
+            )
+
+        normalized_actions = pred_actions.detach().float().cpu().numpy()
+        return {"normalized_actions": normalized_actions}
+
+    @torch.inference_mode()
+    def predict_action_realtime(
+        self,
+        examples: Optional[List[dict]] = None,
+        prev_action_chunk_normalized: np.ndarray = None,
+        inference_delay: int = 1,
+        **kwargs,
+    ) -> dict:
+        """
+        RTC-aware inference: the previous chunk's un-executed tail is encoded
+        into bins and pinned as a known prefix; only the trailing
+        ``execution_horizon`` positions are masked and resampled.
+
+        Args:
+            prev_action_chunk_normalized: (B, action_horizon, action_dim)
+                *normalized* continuous actions from the previous prediction.
+            inference_delay: fallback for ``execution_horizon`` when not given;
+                also used as prefix length under ``hard_mask=True``.
+            execution_horizon (kw): number of trailing positions to regenerate.
+                Defaults to ``inference_delay``.
+            hard_mask (kw): if True, prefix length = ``inference_delay``
+                (legacy). If False (default), prefix length =
+                ``action_horizon - execution_horizon``.
+            fixed_steps (kw): always run ``num_inference_steps``; otherwise
+                scale step count by mask fraction.
+            choice_temperature / decode_temperature: MaskGIT sampling.
+            early_stop (kw): exit early once all non-prefix slots are unmasked.
+
+        Returns:
+            dict: normalized_actions (np.ndarray) [B, action_horizon, action_dim]
+        """
+        if prev_action_chunk_normalized is None or inference_delay <= 0:
+            return self.predict_action(examples, **kwargs)
+
+        if not isinstance(examples, list):
+            examples = [examples]
+
+        batch_images = [to_pil_preserve(example["image"]) for example in examples]
+        instructions = [example["lang"] for example in examples]
+        state = [example["state"] for example in examples] if "state" in examples[0] else None
+
+        train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
+        if train_obs_image_size:
+            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+
+        vl_embs_list = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
+
+        state_t = (
+            torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
+            if state is not None
+            else None
+        )
+
+        prev_chunk_t = torch.from_numpy(np.array(prev_action_chunk_normalized)).to(
+            base_hidden.device, dtype=torch.float32
+        )
+
+        decode_temperature = kwargs.get("decode_temperature", 0.1)
+        choice_temperature = kwargs.get("choice_temperature", 0.1)
+        fixed_steps = kwargs.get("fixed_steps", False)
+        execution_horizon = kwargs.get("execution_horizon", None)
+        hard_mask = kwargs.get("hard_mask", False)
+        early_stop = kwargs.get("early_stop", False)
+
+        with torch.autocast("cuda", dtype=torch.float32):
+            pred_actions = self.action_model.predict_action_realtime(
+                vl_embs_list,
+                state_t,
+                prev_action_chunk=prev_chunk_t,
+                inference_delay=inference_delay,
+                execution_horizon=execution_horizon,
+                choice_temperature=choice_temperature,
+                decode_temperature=decode_temperature,
+                fixed_steps=fixed_steps,
+                hard_mask=hard_mask,
+                early_stop=early_stop,
+            )
+
+        normalized_actions = pred_actions.detach().float().cpu().numpy()
+        return {"normalized_actions": normalized_actions}

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -294,6 +294,73 @@ class Qwen_PI(baseframework):
         normalized_actions = pred_actions.detach().cpu().numpy()
         return {"normalized_actions": normalized_actions}
 
+    @torch.inference_mode()
+    def predict_action_realtime(
+        self,
+        examples: Optional[List[dict]] = None,
+        prev_action_chunk_normalized: Optional[np.ndarray] = None,
+        inference_delay: int = 1,
+        **kwargs,
+    ) -> dict:
+        """RTC-aware inference: condition sampling on a known prefix.
+
+        Fixes a known prefix of the action chunk to the previous prediction
+        and resamples the rest, so chunks splice smoothly under execution
+        latency.  Mode / schedule kwargs are forwarded to the action head's
+        ``predict_action_realtime``.
+
+        Args:
+            examples: list of dict, same shape as ``predict_action``.
+            prev_action_chunk_normalized: (B, T, action_dim) *normalized*
+                continuous actions from the previous prediction.
+            inference_delay: number of leading timesteps to keep as prefix.
+            **kwargs: forwarded to ``self.action_model.predict_action_realtime``
+                (e.g. ``mode``, ``suffix_length``, ``prefix_attention_schedule``,
+                ``max_guidance_weight``).
+
+        Returns:
+            dict with key ``"normalized_actions"`` -> np.ndarray of shape
+            ``(B, T, action_dim)``.
+        """
+        if prev_action_chunk_normalized is None or inference_delay <= 0:
+            return self.predict_action(examples)
+
+        if type(examples) is not list:
+            examples = [examples]
+
+        batch_images = [to_pil_preserve(example["image"]) for example in examples]
+        instructions = [example["lang"] for example in examples]
+        state = [example["state"] for example in examples] if "state" in examples[0] else None
+
+        train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
+        if train_obs_image_size:
+            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+
+        vl_embs_list, _ = self._encode_vl_hidden_states(batch_images, instructions)
+        base_hidden = vl_embs_list[-1]
+
+        state_t = (
+            torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
+            if state is not None
+            else None
+        )
+
+        prev_chunk_t = torch.from_numpy(np.array(prev_action_chunk_normalized)).to(
+            base_hidden.device, dtype=torch.float32
+        )
+
+        with torch.autocast("cuda", dtype=torch.float32):
+            pred_actions = self.action_model.predict_action_realtime(
+                vl_embs_list,
+                state_t,
+                prev_action_chunk=prev_chunk_t,
+                inference_delay=inference_delay,
+                **kwargs,
+            )
+
+        normalized_actions = pred_actions.detach().cpu().numpy()
+        return {"normalized_actions": normalized_actions}
+
 
 if __name__ == "__main__":
     import argparse

--- a/starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py
@@ -1,0 +1,445 @@
+"""
+Layerwise Discrete Diffusion Action Head (MaskGIT-style).
+QwenPI-style: layer-wise cross-attention with vl_embs_list, same arch size as QwenPI.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from starVLA.model.modules.action_model.discrete_diffusion import (
+    IGNORE_TOKEN,
+    ActionBinning,
+    decode_mask_schedule,
+    mask_by_deterministic_lowest,
+    mask_by_random_topk,
+    train_mask_schedule,
+)
+from starVLA.model.modules.action_model.flow_matching_head.cross_attention_dit import DiT
+
+DiTConfig = {
+    "num_layers": 36,
+    "input_embedding_dim": 2048,
+    "attention_head_dim": 64,
+    "num_attention_heads": 32,
+}
+
+
+class MLP(nn.Module):
+    def __init__(self, input_dim, hidden_dim, output_dim):
+        super().__init__()
+        self.layer1 = nn.Linear(input_dim, hidden_dim)
+        self.layer2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        return self.layer2(F.relu(self.layer1(x)))
+
+
+def _bin_range(config, action_norm_stats):
+    if action_norm_stats and ("min" in action_norm_stats or "q01" in action_norm_stats):
+        return (-1.0, 1.0)
+    return config.get("action_low", -1.0), config.get("action_high", 1.0)
+
+
+def _to_embed_ids(tokens, mask_token_id, ignore_token=IGNORE_TOKEN):
+    return torch.where(tokens == ignore_token, torch.full_like(tokens, mask_token_id), tokens)
+
+
+class LayerwiseDiscreteDiffusionActionHead(nn.Module):
+    """
+    MaskGIT-style discrete diffusion with QwenPI layer-wise cross-attention.
+    Same DiT architecture size as LayerwiseFlowmatchingActionHead (QwenPI).
+    """
+
+    def __init__(self, global_config, action_norm_stats=None):
+        super().__init__()
+        action_config = global_config.framework.action_model
+        diffusion_model_cfg = action_config.diffusion_model_cfg
+
+        # Match QwenPI: override DiTConfig from qwenvl
+        DiTConfig["num_layers"] = global_config.framework.qwenvl.num_vl_layers
+        DiTConfig["input_embedding_dim"] = global_config.framework.qwenvl.vl_hidden_dim
+        DiTConfig["num_attention_heads"] = DiTConfig["input_embedding_dim"] // DiTConfig["attention_head_dim"]
+        self.action_dim = action_config.action_dim
+        self.action_horizon = action_config.future_action_window_size + 1
+        self.seq_len = self.action_horizon * self.action_dim
+        self.num_inference_steps = action_config.get("num_inference_steps", 8)
+        self.num_bins = action_config.get("num_bins", 256)
+        self.mask_token_id = self.num_bins
+        self.train_mask_schedule = action_config.get("train_mask_schedule", "cosine")
+        self.no_mask_token_prob = action_config.get("no_mask_token_prob", 0.0)
+        self.decode_schedule = action_config.get("decode_schedule", "cosine")
+        self.l1_loss_weight = action_config.get("l1_loss_weight", 0.1)
+        self.config = action_config
+
+        low, high = _bin_range(action_config, action_norm_stats)
+        representation = action_config.get("representation", "bin")
+        self.binning = ActionBinning(
+            num_bins=self.num_bins,
+            action_dim=self.action_dim,
+            low=low,
+            high=high,
+            representation=representation,
+        )
+
+        diffusion_model_cfg.update(DiTConfig)
+        diffusion_model_cfg.cross_attention_dim = DiTConfig["input_embedding_dim"]
+        diffusion_model_cfg.output_dim = self.binning.logits_dim
+
+        self.input_embedding_dim = global_config.framework.qwenvl.vl_hidden_dim
+        self.model = DiT(**diffusion_model_cfg)
+
+        self.inner_dim = DiTConfig["num_attention_heads"] * DiTConfig["attention_head_dim"]
+        self.token_embedding = nn.Embedding(self.num_bins + 1, self.inner_dim)
+        nn.init.normal_(self.token_embedding.weight, std=0.02)
+
+        if action_config.get("state_dim", 0) > 0:
+            self.state_encoder = MLP(action_config.state_dim, self.inner_dim, self.inner_dim)
+        else:
+            self.state_encoder = None
+
+        self.future_tokens = nn.Embedding(action_config.get("num_target_vision_tokens", 32), self.inner_dim)
+        nn.init.normal_(self.future_tokens.weight, mean=0.0, std=0.02)
+
+        if action_config.get("add_pos_embed", True):
+            self.position_embedding = nn.Embedding(action_config.get("max_seq_len", 1024), self.inner_dim)
+            nn.init.normal_(self.position_embedding.weight, mean=0.0, std=0.02)
+        else:
+            self.position_embedding = None
+
+    def apply_mask(self, input_tokens, generator=None):
+        B, T, D = input_tokens.shape
+        device = input_tokens.device
+        L = T * D
+
+        total_unknown = torch.full((B,), L, dtype=torch.float, device=device)
+        mask_ratios = train_mask_schedule(torch.rand(B, device=device, generator=generator), self.train_mask_schedule)
+        num_mask = (total_unknown * mask_ratios).round().long().clamp(1, L)
+        num_mask = torch.where(total_unknown > 0, num_mask, torch.zeros_like(num_mask))
+
+        vals = torch.rand(B, T, D, device=device, generator=generator)
+        perm = torch.argsort(vals.reshape(B, L), dim=1)
+        ranks = torch.argsort(perm, dim=1)
+        masked_mask = (ranks < num_mask.unsqueeze(1)).reshape(B, T, D)
+
+        if self.no_mask_token_prob > 0:
+            prob = torch.rand(B, T, D, device=device, generator=generator)
+            unmask = (prob < self.no_mask_token_prob) & masked_mask
+            masked_mask = masked_mask & ~unmask
+
+        return torch.where(masked_mask, IGNORE_TOKEN, input_tokens)
+
+    def _forward_logits(self, vl_embs_list, token_ids, state_features, device):
+        B = token_ids.shape[0]
+        x = _to_embed_ids(token_ids.reshape(B, -1), self.mask_token_id)
+        action_emb = self.token_embedding(x)
+
+        if self.position_embedding is not None:
+            pos_len = action_emb.shape[1]
+            pos_ids = torch.arange(pos_len, dtype=torch.long, device=device)
+            pos_embs = self.position_embedding(pos_ids).unsqueeze(0)
+            action_emb = action_emb + pos_embs
+
+        future = self.future_tokens.weight.unsqueeze(0).expand(B, -1, -1)
+        if state_features is not None:
+            sa_embs = torch.cat([state_features, future, action_emb], dim=1)
+        else:
+            sa_embs = torch.cat([future, action_emb], dim=1)
+
+        temb = self.model.timestep_encoder(torch.zeros(B, device=device, dtype=torch.long))
+        for layer_idx, layer in enumerate(self.model.transformer_blocks):
+            sa_embs = layer(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs_list[layer_idx],
+                temb=temb,
+            )
+
+        shift, scale = self.model.proj_out_1(F.silu(temb)).chunk(2, dim=1)
+        sa_embs = self.model.norm_out(sa_embs) * (1 + scale[:, None]) + shift[:, None]
+        logits = self.model.proj_out_2(sa_embs)
+
+        n_prefix = (1 + future.shape[1]) if state_features is not None else future.shape[1]
+        action_logits = logits[:, n_prefix:, :]
+        return action_logits.reshape(B, self.action_horizon, self.action_dim, self.binning.logits_dim)
+
+    def forward(self, vl_embs_list, actions, state=None, logging: bool = False):
+        _, T, D = actions.shape
+        assert T == self.action_horizon and D == self.action_dim
+
+        target_bins = self.binning.encode(actions)
+        input_tokens = self.apply_mask(target_bins)
+        loss_mask = input_tokens == IGNORE_TOKEN
+        x = _to_embed_ids(input_tokens, self.mask_token_id)
+
+        state_feat = None
+        if state is not None and self.state_encoder is not None:
+            if state.dim() == 3:
+                state = state.squeeze(1)
+            state_feat = self.state_encoder(state).unsqueeze(1)
+
+        logits = self._forward_logits(vl_embs_list, x, state_feat, actions.device)
+        if logging:
+            print(f"target_bins shape: {target_bins.shape}")
+            print(f"target_bins first batch first action: {target_bins[0, 0, :]}")
+        return logits, target_bins, {"loss_mask": loss_mask, "actions": actions}
+
+    def loss(self, pred, target, loss_mask=None, actions=None, **kwargs):
+        B = pred.shape[0]
+        device = pred.device
+
+        if loss_mask is None:
+            loss_mask = torch.ones(B, *target.shape[1:], dtype=torch.bool, device=device)
+
+        logits_dim = self.binning.logits_dim
+        pred_flat = pred.reshape(B, self.seq_len, logits_dim)
+
+        if self.binning.representation == "bin":
+            ce = F.cross_entropy(
+                pred_flat.reshape(-1, logits_dim),
+                target.reshape(-1),
+                reduction="none",
+            ).reshape(B, *target.shape[1:])
+        else:
+            bit_targets = self.binning.indices_to_bit_targets(target)
+            bce = F.binary_cross_entropy_with_logits(pred_flat, bit_targets, reduction="none").mean(dim=-1)
+            ce = bce
+
+        ce_masked = torch.where(loss_mask, ce, torch.zeros_like(ce))
+        num_masked = loss_mask.float().sum(dim=(1, 2)) + 1e-8
+        ce_loss = (ce_masked.sum(dim=(1, 2)) / num_masked).mean()
+
+        l1_loss = torch.tensor(0.0, device=device)
+        if self.l1_loss_weight > 0 and actions is not None:
+            pred_cont = self.binning.decode_logits(pred_flat)
+            l1_loss = (pred_cont - actions).abs().mean()
+
+        return ce_loss + self.l1_loss_weight * l1_loss
+
+    @torch.no_grad()
+    def predict_action(
+        self,
+        vl_embs_list,
+        state=None,
+        choice_temperature=0.1,
+        decode_temperature=1.0,
+        use_simple_max=False,
+    ):
+        """
+        use_simple_max: if True, single forward pass with all-mask input,
+            argmax per position, decode. No iterative MaskGIT decode.
+        """
+        B = vl_embs_list[0].shape[0]
+        device = vl_embs_list[0].device
+        L = self.seq_len
+
+        cur_seqs = torch.full(
+            (B, self.action_horizon, self.action_dim),
+            self.mask_token_id,
+            dtype=torch.long,
+            device=device,
+        )
+
+        state_feat = None
+        if state is not None and self.state_encoder is not None:
+            if state.dim() == 3:
+                state = state.squeeze(1)
+            state_feat = self.state_encoder(state).unsqueeze(1)
+
+        if use_simple_max:
+            logits = self._forward_logits(vl_embs_list, cur_seqs, state_feat, device)
+            return self.binning.decode_logits(logits)
+
+        deterministic_decode = decode_temperature == 0
+        deterministic_choice = choice_temperature == 0
+        unknown_init = torch.full((B,), L, dtype=torch.long, device=device)
+
+        for step_idx in range(self.num_inference_steps):
+            logits = self._forward_logits(vl_embs_list, cur_seqs, state_feat, device)
+            safe_temp = max(decode_temperature, 1e-8)
+            sampled, selected_probs = self.binning.sample_indices_from_logits(
+                logits,
+                temperature=safe_temp,
+                deterministic=deterministic_decode,
+            )
+
+            unknown_map = cur_seqs == self.mask_token_id
+            sampled = torch.where(unknown_map, sampled, cur_seqs)
+
+            ratio = (step_idx + 1.0) / self.num_inference_steps
+            mask_ratio = decode_mask_schedule(torch.tensor(ratio, device=device), self.decode_schedule)
+            mask_len = (unknown_init.float() * mask_ratio).long()
+            min_len = torch.full_like(mask_len, 1)
+            max_len = (unknown_init - 1).clamp(min=0)
+            mask_len = mask_len.clamp(min=min_len, max=max_len)
+            if step_idx == self.num_inference_steps - 1:
+                mask_len = torch.zeros_like(mask_len)
+
+            # Once unmasked, positions stay fixed (no remask).
+            selected_probs = torch.where(
+                unknown_map,
+                selected_probs,
+                torch.full_like(selected_probs, float("inf")),
+            )
+
+            selected_flat = selected_probs.reshape(B, L)
+            if deterministic_choice:
+                action_mask_flat = mask_by_deterministic_lowest(selected_flat, mask_len)
+            else:
+                temp = choice_temperature * (1.0 - ratio)
+                action_mask_flat = mask_by_random_topk(selected_flat, mask_len, temperature=temp)
+            action_mask = action_mask_flat.reshape(B, self.action_horizon, self.action_dim)
+            cur_seqs = torch.where(action_mask, self.mask_token_id, sampled)
+
+        return self.binning.decode(cur_seqs)
+
+    @torch.no_grad()
+    def predict_action_realtime(
+        self,
+        vl_embs_list,
+        state=None,
+        prev_action_chunk: torch.Tensor | None = None,
+        inference_delay: int = 1,
+        execution_horizon: int | None = None,
+        choice_temperature: float = 0.1,
+        decode_temperature: float = 1.0,
+        fixed_steps: bool = False,
+        hard_mask: bool = False,
+        early_stop: bool = False,
+    ) -> torch.Tensor:
+        """
+        RTC-aware MaskGIT decode.
+
+        The previous chunk's un-executed actions become the known prefix:
+            prefix_length = action_horizon - execution_horizon
+        Only the last `execution_horizon` positions need to be generated.
+
+        Schedule over action horizon H with execution_horizon s:
+            positions  0 .. H-s-1   : known prefix (from prev chunk)
+            positions  H-s .. H-1   : masked, to be generated
+
+        Args:
+            prev_action_chunk: (B, T, action_dim) continuous actions from
+                the previous prediction.
+            inference_delay: number of actions executed between predictions.
+                Used as fallback for execution_horizon if not provided.
+            execution_horizon: number of new positions to generate (s).
+                Defaults to inference_delay.
+            fixed_steps: if True, always use self.num_inference_steps;
+                if False (default), scale steps proportionally to the
+                fraction of tokens that need to be generated.
+        """
+        if prev_action_chunk is None or inference_delay <= 0:
+            return self.predict_action(
+                vl_embs_list,
+                state,
+                choice_temperature=choice_temperature,
+                decode_temperature=decode_temperature,
+            )
+
+        B = vl_embs_list[0].shape[0]
+        device = vl_embs_list[0].device
+        L = self.seq_len
+        deterministic_decode = decode_temperature == 0
+        deterministic_choice = choice_temperature == 0
+
+        if execution_horizon is None:
+            execution_horizon = inference_delay
+        execution_horizon = min(execution_horizon, self.action_horizon)
+
+        if hard_mask:
+            prefix_length = inference_delay
+        else:
+            prefix_length = self.action_horizon - execution_horizon
+
+        # Pad prev_action_chunk to action_horizon if shorter (right-pad with zeros;
+        # padded positions fall under prefix_mask=False and get replaced by mask_token).
+        T_prev = prev_action_chunk.shape[1]
+        if T_prev < self.action_horizon:
+            pad = torch.zeros(
+                B,
+                self.action_horizon - T_prev,
+                prev_action_chunk.shape[2],
+                device=device,
+                dtype=prev_action_chunk.dtype,
+            )
+            prev_action_chunk = torch.cat([prev_action_chunk, pad], dim=1)
+
+        # Encode the prefix into bin indices
+        prefix_bins = self.binning.encode(prev_action_chunk)
+        prefix_mask = (torch.arange(self.action_horizon, device=device)[None, :, None] < prefix_length).expand(
+            B, self.action_horizon, self.action_dim
+        )
+
+        cur_seqs = torch.where(
+            prefix_mask,
+            prefix_bins,
+            torch.full_like(prefix_bins, self.mask_token_id),
+        )
+
+        # Count actual masked tokens from cur_seqs
+        num_unknown_tokens = (cur_seqs == self.mask_token_id).sum(dim=(1, 2))  # (B,)
+        unknown_init = num_unknown_tokens
+        if fixed_steps:
+            num_steps = self.num_inference_steps
+        else:
+            # Use the max across the batch to determine step count
+            num_steps = max(1, int(self.num_inference_steps * num_unknown_tokens.max().item() / L))
+
+        state_feat = None
+        if state is not None and self.state_encoder is not None:
+            if state.dim() == 3:
+                state = state.squeeze(1)
+            state_feat = self.state_encoder(state).unsqueeze(1)
+
+        for step_idx in range(num_steps):
+            logits = self._forward_logits(vl_embs_list, cur_seqs, state_feat, device)
+            safe_temp = max(decode_temperature, 1e-8)
+            sampled, selected_probs = self.binning.sample_indices_from_logits(
+                logits,
+                temperature=safe_temp,
+                deterministic=deterministic_decode,
+            )
+
+            unknown_map = cur_seqs == self.mask_token_id
+            # Force prefix positions to stay as encoded prefix
+            sampled = torch.where(prefix_mask, prefix_bins, sampled)
+            sampled = torch.where(unknown_map, sampled, cur_seqs)
+
+            ratio = (step_idx + 1.0) / num_steps
+            mask_ratio = decode_mask_schedule(torch.tensor(ratio, device=device), self.decode_schedule)
+            mask_len = (unknown_init.float() * mask_ratio).long()
+            min_len = torch.full_like(mask_len, 1)
+            max_len = (unknown_init - 1).clamp(min=0)
+            mask_len = mask_len.clamp(min=min_len, max=max_len)
+            if step_idx == num_steps - 1:
+                mask_len = torch.zeros_like(mask_len)
+
+            selected_probs = torch.where(
+                unknown_map,
+                selected_probs,
+                torch.full_like(selected_probs, float("inf")),
+            )
+
+            selected_flat = selected_probs.reshape(B, L)
+            if deterministic_choice:
+                action_mask_flat = mask_by_deterministic_lowest(selected_flat, mask_len)
+            else:
+                temp = choice_temperature * (1.0 - ratio)
+                action_mask_flat = mask_by_random_topk(selected_flat, mask_len, temperature=temp)
+            action_mask = action_mask_flat.reshape(B, self.action_horizon, self.action_dim)
+            cur_seqs = torch.where(
+                prefix_mask,
+                prefix_bins,
+                torch.where(action_mask, self.mask_token_id, sampled),
+            )
+
+            # Early stop if all non-prefix positions are unmasked
+            if early_stop:
+                if (cur_seqs[:, prefix_length:, :] != self.mask_token_id).all():
+                    break
+
+        return self.binning.decode(cur_seqs)
+
+
+def get_action_model(config=None, action_norm_stats=None):
+    return LayerwiseDiscreteDiffusionActionHead(global_config=config, action_norm_stats=action_norm_stats)

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -415,6 +415,225 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
             actions = actions + dt * pred_velocity
         return actions
 
+    def predict_action_realtime(
+        self,
+        vl_embs_list: list,
+        state: torch.Tensor = None,
+        prev_action_chunk: torch.Tensor = None,
+        inference_delay: int = 1,
+        mode: str = "pigdm",
+        suffix_length: int | None = None,
+        prefix_attention_schedule: str = "exp",
+        max_guidance_weight: float = 10.0,
+    ) -> torch.Tensor:
+        """RTC-aware flow-matching inference.
+
+        Conditions sampling on the previous chunk's un-executed actions as a
+        known prefix, so chunks splice smoothly under execution latency.
+
+        Args:
+            vl_embs_list: layer-wise VL embeddings, list of (B, seq, D).
+            state: optional state tensor (B, 1, state_dim).
+            prev_action_chunk: (B, action_horizon, action_dim) normalised
+                actions from the previous prediction.
+            inference_delay: number of leading timesteps to fix as prefix (d).
+            mode: "pigdm" (default, VJP-guided; works without retraining,
+                ~2x cost per step) or "simulated_delay" (naive
+                replace-and-denoise with per-position timesteps; requires
+                model trained with simulated-delay loss).
+            suffix_length: ΠGDM only. Number of trailing timesteps with
+                weight 0. Defaults to ``inference_delay``.
+            prefix_attention_schedule: ΠGDM only. Weight schedule for the
+                transition zone — "exp", "linear", "ones", or "zeros".
+            max_guidance_weight: ΠGDM only. Cap on the guidance weight.
+
+        Returns:
+            actions: (B, action_horizon, action_dim) predicted actions.
+        """
+        if prev_action_chunk is None or inference_delay <= 0:
+            return self.predict_action(vl_embs_list, state)
+
+        import math
+
+        batch_size = vl_embs_list[0].shape[0]
+        device = vl_embs_list[0].device
+        dtype = vl_embs_list[0].dtype
+
+        def _prefix_weights(start: int, end: int, total: int, schedule: str) -> torch.Tensor:
+            """ΠGDM prefix attention weight schedule across the action horizon."""
+            start = min(start, end)
+            positions = torch.arange(total, device=device, dtype=torch.float32)
+            if schedule == "ones":
+                w = torch.ones(total, device=device)
+            elif schedule == "zeros":
+                w = (positions < start).float()
+            elif schedule in ("linear", "exp"):
+                w = ((start - 1 - positions) / (end - start + 1) + 1).clamp(0, 1)
+                if schedule == "exp":
+                    w = w * torch.expm1(w) / (math.e - 1)
+            else:
+                raise ValueError(f"Invalid schedule: {schedule}")
+            return torch.where(positions >= end, torch.zeros_like(w), w)
+
+        def _forward_velocity(actions, timesteps, state_features):
+            """Single DiT forward pass returning predicted velocity."""
+            B = actions.shape[0]
+            action_features = self.action_encoder(actions, timesteps)
+            if self.config.add_pos_embed:
+                pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+                pos_embs = self.position_embedding(pos_ids).unsqueeze(0)
+                action_features = action_features + pos_embs
+            future_tokens = self.future_tokens.weight.unsqueeze(0).expand(B, -1, -1)
+            sa_embs = (
+                torch.cat((state_features, future_tokens, action_features), dim=1)
+                if state_features is not None
+                else torch.cat((future_tokens, action_features), dim=1)
+            )
+            temb = self.model.timestep_encoder(timesteps)
+            model_output = sa_embs
+            for layer_idx, layer in enumerate(self.model.transformer_blocks):
+                model_output = layer(
+                    hidden_states=model_output,
+                    encoder_hidden_states=vl_embs_list[layer_idx],
+                    temb=temb,
+                )
+            pred = self.action_decoder(model_output)
+            return pred[:, -self.action_horizon :]
+
+        T_prev = prev_action_chunk.shape[1]
+        if T_prev < self.action_horizon:
+            pad = torch.zeros(
+                batch_size,
+                self.action_horizon - T_prev,
+                prev_action_chunk.shape[2],
+                device=device,
+                dtype=prev_action_chunk.dtype,
+            )
+            prev_action_chunk = torch.cat([prev_action_chunk, pad], dim=1)
+
+        num_steps = self.num_inference_timesteps
+        dt = 1.0 / num_steps
+
+        actions = torch.randn(
+            size=(batch_size, self.action_horizon, self.action_dim),
+            dtype=dtype,
+            device=device,
+        )
+
+        state_features = self.state_encoder(state) if state is not None else None
+
+        if mode == "pigdm":
+            # ── ΠGDM: pseudo-inverse guided diffusion ──
+            if suffix_length is None:
+                suffix_length = inference_delay
+            prefix_attention_end = self.action_horizon - suffix_length
+            weights = _prefix_weights(
+                inference_delay,
+                prefix_attention_end,
+                self.action_horizon,
+                prefix_attention_schedule,
+            )
+            prev = prev_action_chunk.to(dtype)
+
+            for t_step in range(num_steps):
+                t_cont = t_step / float(num_steps)
+                t_bucket = int(t_cont * self.num_timestep_buckets)
+                timesteps_tensor = torch.full(
+                    (batch_size,),
+                    t_bucket,
+                    device=device,
+                    dtype=torch.long,
+                )
+
+                with torch.enable_grad():
+                    x_t = actions.detach().requires_grad_(True)
+                    v_t = _forward_velocity(x_t, timesteps_tensor, state_features)
+                    x_1_hat = x_t + v_t * (1.0 - t_cont)
+                    error = (prev - x_1_hat) * weights[None, :, None]
+                    pinv_correction = torch.autograd.grad(
+                        x_1_hat,
+                        x_t,
+                        grad_outputs=error,
+                    )[0]
+
+                # Guidance weight schedule from ΠGDM paper
+                t = t_cont
+                inv_r2 = (t**2 + (1 - t) ** 2) / ((1 - t) ** 2 + 1e-8)
+                c = (1 - t) / (t + 1e-8)
+                gw = min(c * inv_r2, max_guidance_weight)
+
+                v_corrected = v_t.detach() + gw * pinv_correction.detach()
+                actions = actions.detach() + dt * v_corrected
+
+            return actions
+
+        # ── simulated_delay mode ──
+        with torch.no_grad():
+            prefix_mask = torch.zeros(
+                1,
+                self.action_horizon,
+                1,
+                device=device,
+                dtype=torch.bool,
+            )
+            prefix_mask[:, :inference_delay, :] = True
+
+            for t_step in range(num_steps):
+                t_cont = t_step / float(num_steps)
+                actions = torch.where(prefix_mask, prev_action_chunk.to(dtype), actions)
+
+                t_bucket = int(t_cont * self.num_timestep_buckets)
+                t_bucket_prefix = int(1.0 * self.num_timestep_buckets) - 1
+                timesteps_tensor = torch.full(
+                    (batch_size, self.action_horizon),
+                    t_bucket,
+                    device=device,
+                    dtype=torch.long,
+                )
+                timesteps_tensor[:, :inference_delay] = t_bucket_prefix
+
+                # Inline ActionEncoder with per-position timesteps
+                a_emb = self.action_encoder.layer1(actions)
+                tau_emb = self.action_encoder.pos_encoding(timesteps_tensor).to(dtype=a_emb.dtype)
+                x_enc = torch.cat([a_emb, tau_emb], dim=-1)
+                x_enc = swish(self.action_encoder.layer2(x_enc))
+                action_features = self.action_encoder.layer3(x_enc)
+
+                if self.config.add_pos_embed:
+                    pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+                    pos_embs = self.position_embedding(pos_ids).unsqueeze(0)
+                    action_features = action_features + pos_embs
+
+                future_tokens = self.future_tokens.weight.unsqueeze(0).expand(batch_size, -1, -1)
+                sa_embs = (
+                    torch.cat((state_features, future_tokens, action_features), dim=1)
+                    if state_features is not None
+                    else torch.cat((future_tokens, action_features), dim=1)
+                )
+
+                temb_tensor = torch.full(
+                    (batch_size,),
+                    t_bucket,
+                    device=device,
+                    dtype=torch.long,
+                )
+                temb = self.model.timestep_encoder(temb_tensor)
+
+                model_output = sa_embs
+                for layer_idx, layer in enumerate(self.model.transformer_blocks):
+                    model_output = layer(
+                        hidden_states=model_output,
+                        encoder_hidden_states=vl_embs_list[layer_idx],
+                        temb=temb,
+                    )
+
+                pred = self.action_decoder(model_output)
+                pred_velocity = pred[:, -self.action_horizon :]
+                actions = actions + dt * pred_velocity
+                actions = torch.where(prefix_mask, prev_action_chunk.to(dtype), actions)
+
+            return actions
+
     @property
     def device(self):
         return next(iter(self.parameters())).device

--- a/starVLA/model/modules/action_model/discrete_diffusion/__init__.py
+++ b/starVLA/model/modules/action_model/discrete_diffusion/__init__.py
@@ -1,0 +1,19 @@
+# Discrete diffusion policy components for VLA action prediction.
+
+from .action_binning import ActionBinning
+from .mask_git_schedule import (
+    IGNORE_TOKEN,
+    decode_mask_schedule,
+    mask_by_deterministic_lowest,
+    mask_by_random_topk,
+    train_mask_schedule,
+)
+
+__all__ = [
+    "IGNORE_TOKEN",
+    "ActionBinning",
+    "decode_mask_schedule",
+    "mask_by_deterministic_lowest",
+    "mask_by_random_topk",
+    "train_mask_schedule",
+]

--- a/starVLA/model/modules/action_model/discrete_diffusion/action_binning.py
+++ b/starVLA/model/modules/action_model/discrete_diffusion/action_binning.py
@@ -1,0 +1,164 @@
+"""
+Uniform action binning for discrete diffusion.
+Aligns with ref_dd_mode: floor-based encode, bin centers for decode.
+Maps continuous actions in [low, high] to discrete bins in [0, num_bins-1].
+
+Representation modes:
+- "bin": model outputs num_bins logits per position; decode via argmax.
+- "bit": model outputs 8 logits (P(bit_i=1) via sigmoid); 8 bits simulate 256-bin
+  distribution. decode via threshold (0.5) or sampling.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def continuous_to_bins(actions: torch.Tensor, num_bins: int, low: float = -1.0, high: float = 1.0) -> torch.Tensor:
+    """Map continuous actions in [low, high] to bin indices in [0, num_bins-1]. Ref: floor((x+1)/2 * num_bins)."""
+    clamped = actions.clamp(low + 1e-6, high - 1e-6)
+    x = (clamped - low) / (high - low)  # [0, 1)
+    bins = (x * num_bins).floor().long().clamp(0, num_bins - 1)
+    return bins
+
+
+def bins_to_continuous(bin_indices: torch.Tensor, num_bins: int, low: float = -1.0, high: float = 1.0) -> torch.Tensor:
+    """Map bin indices to continuous actions (bin centers). Ref: (i+0.5)/num_bins * 2 - 1 for [-1,1]."""
+    scale = (high - low) / num_bins
+    centers = (bin_indices.float() + 0.5) * scale + low
+    return centers
+
+
+class ActionBinning(nn.Module):
+    """
+    Discretize continuous actions via uniform binning.
+    Supports two representations:
+    - "bin": model outputs num_bins logits per position; argmax to get bin index.
+    - "bit": model outputs 8 logits (P(bit_i=1)); bits form bin index in [0,255].
+    """
+
+    def __init__(
+        self,
+        num_bins: int,
+        action_dim: int,
+        low: float = -1.0,
+        high: float = 1.0,
+        representation: str = "bin",
+        num_bits: int = 8,
+    ):
+        super().__init__()
+        self.num_bins = num_bins
+        self.action_dim = action_dim
+        self.low = low
+        self.high = high
+        self.representation = representation
+        self.num_bits = num_bits
+
+        if representation == "bit":
+            expected_bins = 1 << num_bits
+            assert num_bins == expected_bins, f"bit representation requires num_bins={expected_bins}, got {num_bins}"
+
+        # Bin centers for decoding
+        scale = (high - low) / num_bins
+        centers = (torch.arange(num_bins, dtype=torch.float32) + 0.5) * scale + low
+        self.register_buffer("bin_centers", centers)
+
+        # Powers of 2 for bit->bin conversion
+        if representation == "bit":
+            self.register_buffer("bit_powers", torch.arange(num_bits, dtype=torch.long))
+
+    @property
+    def logits_dim(self) -> int:
+        """Per-position model output dimension (last dim of logits)."""
+        return self.num_bits if self.representation == "bit" else self.num_bins
+
+    def encode(self, actions: torch.Tensor) -> torch.Tensor:
+        """Encode continuous actions to discrete bin indices. (B, T, action_dim) -> (B, T, action_dim) long."""
+        return continuous_to_bins(actions, self.num_bins, self.low, self.high)
+
+    def decode(self, indices: torch.Tensor, logging: bool = False) -> torch.Tensor:
+        """Decode discrete bin indices to continuous actions (bin centers)."""
+        flat = indices.reshape(-1)
+        decoded = self.bin_centers[flat].to(indices.device)
+        B = indices.shape[0]
+        output = decoded.reshape(B, -1, self.action_dim)
+        if logging:
+            print(f"indices output shape: {indices.shape}")
+            print(f"indices output first batch first action: {indices[0, :]}")
+        return output
+
+    def _logits_to_indices_bin(
+        self,
+        logits: torch.Tensor,
+        temperature: float = 1.0,
+        deterministic: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns (indices, selected_probs)."""
+        safe_temp = max(temperature, 1e-8)
+        probs = F.softmax(logits / safe_temp, dim=-1)
+        if deterministic:
+            indices = logits.argmax(dim=-1)
+            selected_probs = probs.max(dim=-1).values
+        else:
+            flat = probs.reshape(-1, self.num_bins)
+            sampled_flat = torch.multinomial(flat, 1, generator=generator).squeeze(-1)
+            indices = sampled_flat.reshape(*logits.shape[:-1])
+            selected_probs = probs.gather(-1, indices.unsqueeze(-1)).squeeze(-1)
+        return indices, selected_probs
+
+    def _logits_to_indices_bit(
+        self,
+        logits: torch.Tensor,
+        deterministic: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Convert 8 bit logits to bin indices. Returns (indices, selected_probs)."""
+        probs = logits.sigmoid()
+        if deterministic:
+            bits = (probs > 0.5).long()
+        else:
+            bits = (torch.rand_like(probs, generator=generator) < probs).long()
+        powers = 2 ** self.bit_powers.to(logits.device)
+        indices = (bits * powers).sum(dim=-1)
+        # P(bin) under factorized model = prod_i (p_i if b_i else (1-p_i))
+        chosen = probs * bits + (1 - probs) * (1 - bits)
+        selected_probs = chosen.prod(dim=-1)
+        return indices, selected_probs
+
+    def decode_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Decode model logits to continuous actions. Same interface for bin and bit."""
+        if self.representation == "bin":
+            indices, _ = self._logits_to_indices_bin(logits, temperature=1.0, deterministic=True)
+        else:
+            indices, _ = self._logits_to_indices_bit(logits, deterministic=True)
+        return self.decode(indices)
+
+    def sample_indices_from_logits(
+        self,
+        logits: torch.Tensor,
+        temperature: float = 1.0,
+        deterministic: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Sample bin indices from logits (for iterative decode).
+        Returns (indices, selected_probs) where selected_probs is used for mask scheduling.
+        """
+        if self.representation == "bin":
+            return self._logits_to_indices_bin(
+                logits, temperature=temperature, deterministic=deterministic, generator=generator
+            )
+        return self._logits_to_indices_bit(logits, deterministic=deterministic, generator=generator)
+
+    def indices_to_bit_targets(self, indices: torch.Tensor) -> torch.Tensor | None:
+        """
+        Convert bin indices to 8-bit targets for BCE loss. Returns None for bin representation.
+        (B, T, D) long -> (B, T, D, 8) float in {0,1}.
+        """
+        if self.representation != "bit":
+            return None
+        # bit_i = (indices >> i) & 1
+        shifts = self.bit_powers.to(indices.device)
+        bits = ((indices.unsqueeze(-1) >> shifts) & 1).float()
+        return bits

--- a/starVLA/model/modules/action_model/discrete_diffusion/mask_git_schedule.py
+++ b/starVLA/model/modules/action_model/discrete_diffusion/mask_git_schedule.py
@@ -1,0 +1,85 @@
+"""
+MaskGIT-style masking schedule for discrete diffusion (ref: ref_dd_mode.py).
+Training: rand_time -> mask_ratio -> num_mask positions.
+Decode: ratio -> mask_ratio (fraction of unknown to keep masked).
+"""
+
+import torch
+
+# In the input action token sequence, this value means "masked" (model uses MASK embedding).
+IGNORE_TOKEN = -100
+
+
+def train_mask_schedule(rand_time: torch.Tensor, method: str = "cosine") -> torch.Tensor:
+    """
+    Training-time mask schedule: rand_time in [0, 1) -> mask_ratio in (0, 1].
+    How much of the maskable positions to mask; used as num_mask = round(total_unknown * mask_ratio).
+
+    Args:
+        rand_time: (B,) uniform in [0, 1)
+        method: "cosine" or "linear"
+    Returns:
+        mask_ratio: (B,) in (0, 1]
+    """
+    if method == "cosine":
+        return torch.clamp(1.0 - torch.cos(torch.pi * 0.5 * rand_time), 1e-6, 1.0)
+    elif method == "linear":
+        return torch.clamp(rand_time, 1e-6, 1.0)
+    else:
+        raise ValueError(f"Unknown train mask schedule: {method}")
+
+
+def decode_mask_schedule(ratio: torch.Tensor, method: str = "cosine") -> torch.Tensor:
+    """
+    Decode-time schedule: ratio in [0, 1] -> mask_ratio (fraction of unknown to keep masked).
+    As ratio increases (later in decode), mask_ratio decreases (more positions unmasked).
+
+    Args:
+        ratio: (B,) or scalar, progress in [0, 1]
+        method: "cosine" or "linear"
+    Returns:
+        mask_ratio: (B,) or scalar
+    """
+    if method == "cosine":
+        return 0.5 * (1.0 + torch.cos(torch.pi * ratio))
+    elif method == "linear":
+        return 1.0 - ratio
+    else:
+        raise ValueError(f"Unknown decode schedule: {method}")
+
+
+def mask_by_random_topk(
+    selected_probs: torch.Tensor,
+    mask_len: torch.Tensor,
+    temperature: float = 1.0,
+    generator=None,
+) -> torch.Tensor:
+    """
+    Which positions stay masked: Gumbel + top-k (ref: ref_dd_mode.py).
+    selected_probs [B, L]; mask_len [B].
+    Returns action_mask [B, L] with True = stay masked (low confidence / low prob).
+    Score = -log(probs)/temp + gumbel; temperature adds stochasticity to ranking.
+    """
+    B, L = selected_probs.shape
+    device = selected_probs.device
+
+    gumbel = -torch.log(-torch.log(torch.rand(B, L, device=device, generator=generator) + 1e-10) + 1e-10)
+    score = -torch.log(selected_probs + 1e-8) / max(temperature, 1e-8) + gumbel
+    perm = torch.argsort(score, dim=1)
+    ranks = torch.argsort(perm, dim=1)
+    action_mask = ranks < mask_len.unsqueeze(1)
+    return action_mask
+
+
+def mask_by_deterministic_lowest(
+    selected_probs: torch.Tensor,
+    mask_len: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Which positions stay masked: deterministic = mask the mask_len lowest-confidence positions.
+    selected_probs [B, L]; mask_len [B].
+    Returns action_mask [B, L] with True = stay masked.
+    """
+    perm = torch.argsort(selected_probs, dim=1)  # ascending: smallest prob first
+    ranks = torch.argsort(perm, dim=1)
+    return ranks < mask_len.unsqueeze(1)


### PR DESCRIPTION
## Motivation

This PR adds a new starVLA framework, **`QwenDiscreteDiffusion`**, that pairs the existing Qwen-VL backbone with a **MaskGIT-style discrete-diffusion action head** instead of continuous flow-matching. Each continuous action is quantized into a uniform bin index; the head predicts bin logits and decodes them via iterative MaskGIT-style unmasking.

The same head also exposes a **real-time chunking (RTC)** decode that conditions on the previous chunk's un-executed actions as a known prefix — enabling smooth closed-loop control under inference latency.

For symmetric coverage across heads, this PR also adds `predict_action_realtime` to the existing flow-matching head (`LayerwiseFlowmatchingActionHead`) and to `Qwen_PI`, so the same RTC pattern is available with either head from a deployment client's perspective.

See [`examples/modelExtensions/DiscreteDiffusion/README.md`](../blob/feat/discrete-diffusion/examples/modelExtensions/DiscreteDiffusion/README.md) for the full architecture description, training and inference recipes, config reference, and file map.

## Changes

### New: discrete-diffusion action head and framework

| File | Description |
|---|---|
| `starVLA/model/modules/action_model/discrete_diffusion/action_binning.py` | Uniform quantizer (continuous ↔ bin indices). Supports `bin` (per-bin logits + cross-entropy) and `bit` (8 sigmoid bits + BCE) representations. |
| `starVLA/model/modules/action_model/discrete_diffusion/mask_git_schedule.py` | Cosine / linear train + decode schedules, top-k mask helpers. |
| `starVLA/model/modules/action_model/discrete_diffusion/__init__.py` | Re-exports. |
| `starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py` | Layer-wise cross-attention DiT head with MaskGIT decode (`predict_action`) and RTC variant (`predict_action_realtime`). Mirrors the QwenPI flow-matching head's shape; same VLM-hidden-state interface. |
| `starVLA/model/framework/VLM4A/QwenDiscreteDiffusion.py` | Framework wrapper. Registers as `QwenDiscreteDiffusion` via `FRAMEWORK_REGISTRY`. Same train/inference entry surface as `QwenPI`. |
| `starVLA/config/training/starvla_train_discrete_diffusion.yaml` | Example training config — sim (RoboTwin, 14D dual-arm). |
| `starVLA/config/training/starvla_train_discrete_diffusion_real.yaml` | Example training config — real (FastUMI, 10D single-arm). |

### Modification: RTC inference on flow-matching head

- **`starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py`** (+284 LOC):
  - **+** top-level `get_prefix_weights(...)` helper (ΠGDM prefix attention schedule: `ones`/`zeros`/`linear`/`exp`).
  - **+** `LayerwiseFlowmatchingActionHead._forward_velocity(...)` — single-step velocity forward helper used by RTC.
  - **+** `LayerwiseFlowmatchingActionHead.predict_action_realtime(...)` with two modes:
    - `pigdm` (default) — **Pseudo-Inverse Guided Diffusion**. VJP-based correction guiding generation toward the known prefix. Works without retraining. ~2× cost per step (forward + VJP).
    - `simulated_delay` — naive replace-and-denoise with per-position timesteps. Requires model trained with simulated-delay loss. Single forward per step.
  - The existing `forward`, `predict_action`, `prepare_input`, and `sample_time` methods are **unchanged**.

- **`starVLA/model/framework/VLM4A/QwenPI.py`** (+72 / -6 LOC):
  - **+** `Qwen_PI.predict_action_realtime(...)` that mirrors `predict_action` (uses `to_pil_preserve` + `_encode_vl_hidden_states` + `resize_images` in the same pattern) and delegates to the head's RTC sampler. Forwards `mode` / `suffix_length` / `prefix_attention_schedule` / `max_guidance_weight` kwargs.
  - Existing `__init__`, `forward`, `predict_action`, `_encode_vl_hidden_states` are **unchanged**.

### Docs

- **`examples/modelExtensions/DiscreteDiffusion/README.md`** — architecture overview, RTC decode contract, configs at a glance, training commands (sim and real), inference (single-shot + RTC) snippets, file map.

## Testing

- **`black --check`** and **`ruff check`** pass on all touched code files.
- **Zero new lint debt** vs upstream baseline: the two modified files (`LayerwiseFM_ActionHeader.py`, `VLM4A/QwenPI.py`) report exactly the same lint findings as their upstream-`starVLA_dev` versions (all 6 `E402` from upstream's interleaved imports in `QwenPI.py`, 3 `RUF003` from upstream's full-width commas, etc.).
- All 7 touched files parse (`ast.parse`).
- The `discrete_diffusion/` package imports cleanly with no extra dependencies.
- **Standalone framework smoke test** (`python starVLA/model/framework/VLM4A/QwenDiscreteDiffusion.py`) requires the full starVLA conda env (transformers + diffusers + omegaconf) and a Qwen2.5-VL checkpoint at `playground/Pretrained_models/`. Not run on the dev box this PR was prepared on; **will re-run on the cluster** and report results in a follow-up comment.
- **Real-world deployment validation** — these methods have been used to drive a UR5e + Robotiq pick-and-place loop in closed loop. Deployment-side adapters (UR RTDE, Robotiq, V4L2 camera) are intentionally out of scope for this PR; the framework contract (the `predict_action_realtime` API) is what's stable.

## Breaking changes

**None — fully additive.**

Every modification to an existing upstream file is a new symbol: `get_prefix_weights` (top-level), `_forward_velocity` (new method), two `predict_action_realtime` (new methods), and three copyright comment lines. No existing method had its signature, behavior, or call site changed. Any code that doesn't call the new methods will behave identically.

Copyright attribution preserved on `LayerwiseFM_ActionHeader.py`: original NVIDIA + Jinhui YE/HKUST headers kept; appended a new line attributing only the RTC additions to Kaiwen Hong.

## Open Questions for Maintainers

1. **PR size.** This PR is ~1.8k LOC, over the stated ≤500 LOC budget in `docs/PR_readme.md`. The contribution is intentionally bundled because the head + framework + configs + RTC patterns are tightly coupled and each piece is hard to evaluate alone. Happy to split into `feat/discrete-rtc-utils` + `feat/discrete-rtc-head` + `feat/discrete-rtc-fm` if that's preferred.

2. **Drop of non-Layerwise `models.py`?** The plain `DiscreteDiT` reference implementation (`discrete_diffusion/models.py` in Kaiwen's internal branch) is **not** included here — the Layerwise variant is the production head and the standalone DiT is unused. Easy to add as a follow-up if you want it for testing.

3. **HF checkpoint + benchmark.** Per the framework-PR contract in `docs/PR_readme.md`, a public HF checkpoint + benchmark result is required. We have FastUMI real-world checkpoints; happy to publish to `StarVLA/Qwen-DiscreteDiffusion-FastUMI` once we've agreed on the model card template. Same for a sim benchmark (RoboTwin or LIBERO) on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)