### PR TITLE
Clarify LIBERO state dimension docs

### DIFF
--- a/docs/starVLA_guideline.md
+++ b/docs/starVLA_guideline.md
@@ -158,10 +158,12 @@ framework:
     attn_implementation: flash_attention_2
   action_model:
     action_dim: 7                # LIBERO: 7-DoF (xyz + rpy + gripper)
-    state_dim: 7
+    state_dim: 7                 # unused while datasets.vla_data.include_state is false
     future_action_window_size: 7 # predict 7 future steps
     action_horizon: 8            # total action chunk size
 ```
+
+> **Using LIBERO state input:** The default config leaves `datasets.vla_data.include_state` disabled. If you enable state input for QwenGR00T, keep the 8-D LIBERO state layout defined by `Libero4in1DataConfig.state_keys`: `x, y, z, roll, pitch, yaw, pad, gripper`, and set `framework.action_model.state_dim: 8`. The `state.pad` field is a LIBERO padding placeholder, not a second gripper qpos dimension.
 
 StarVLA supports four framework variants — just change `framework.name`:
 

--- a/examples/LIBERO/README.md
+++ b/examples/LIBERO/README.md
@@ -118,6 +118,18 @@ bash examples/LIBERO/data_preparation.sh
 
 Most of the required training files have been organized in [train_files](train_files).  
 
+### LIBERO State Dimension
+
+The default LIBERO training config keeps `datasets.vla_data.include_state` disabled, so `framework.action_model.state_dim` is not used in the shipped image/language/action-only setup.
+
+If you enable state input for QwenGR00T, keep the 8-D LIBERO state layout defined in `examples/LIBERO/train_files/data_registry/data_config.py`:
+
+```text
+x, y, z, roll, pitch, yaw, pad, gripper
+```
+
+In that case, set `framework.action_model.state_dim: 8`. The `state.pad` entry is a LIBERO padding placeholder and does not correspond to a second gripper qpos dimension.
+
 Please run the following command to start training:
 
 ```bash


### PR DESCRIPTION
## Description

Clarifies the LIBERO state dimension guidance in the training README and quick-start guide. The docs now state that the shipped LIBERO config keeps `datasets.vla_data.include_state` disabled, so the default `state_dim: 7` is unused in the image/language/action-only setup.

For users who enable state input for QwenGR00T, the docs recommend keeping the 8-D LIBERO state layout (`x, y, z, roll, pitch, yaw, pad, gripper`) and setting `framework.action_model.state_dim: 8`. This is a documentation-only change and does not modify any training defaults.

## Related Issue

Related to #302.

## Motivation and Context

Issue #302 asked whether LIBERO state input should use the 8-D layout from `Libero4in1DataConfig.state_keys` or a 7-D layout without `state.pad`. The maintainer clarified that `state.pad` is a LIBERO padding placeholder, not a second gripper qpos dimension, and that keeping the 8-D state is the simplest safe choice when state input is enabled.

## How Has This Been / Can This Be Tested?

Documentation-only change. I checked the edited markdown diff and verified that it only updates:

```text
docs/starVLA_guideline.md
examples/LIBERO/README.md
```

I also ran:

```bash
git diff --check
```

No whitespace errors were reported.

## Checklist

- [x] Added LIBERO state-dimension guidance to the training README.
- [x] Added the same guidance near the quick-start config explanation.
- [x] Preserved all training defaults and dataset config values.
- [x] Verified the diff is documentation-only.