### PR TITLE
Fix QwenGR00T smoke sample dimensions

### DIFF
--- a/starVLA/model/framework/VLM4A/QwenGR00T.py
+++ b/starVLA/model/framework/VLM4A/QwenGR00T.py
@@ -294,12 +294,19 @@ if __name__ == "__main__":
     model: Qwen_GR00T = Qwen_GR00T(cfg)
     print(model)
 
+    action_dim = int(model.action_model.action_dim)
+    state_dim = int(model.action_model.config.get("state_dim", 0) or 0)
+    action_steps = 2 * int(model.action_horizon)
+
     image = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
     sample = {
-        "action": np.random.uniform(-1, 1, size=(16, 7)).astype(np.float16),
+        "action": np.random.uniform(-1, 1, size=(action_steps, action_dim)).astype(np.float16),
         "image": [image],
         "lang": "This is a fake instruction for testing.",
     }
+    if state_dim > 0:
+        sample["state"] = np.random.uniform(-1, 1, size=(1, state_dim)).astype(np.float16)
+
     sample2 = sample.copy()
     sample2["lang"] = "Another fake instruction for testing."
 


### PR DESCRIPTION
## Description

Updates the QwenGR00T module smoke sample to derive its fake action and state shapes from the instantiated model config instead of hard-coding `(16, 7)` actions.

The runtime model path is unchanged. This only affects the `if __name__ == "__main__"` smoke path in `QwenGR00T.py`.

## Related Issue

N/A.

## Motivation and Context

The smoke path is useful when checking framework wiring, but the hard-coded fake action shape can drift from config values such as `action_dim`, `state_dim`, or `action_horizon`. Deriving the fake sample dimensions from the model keeps the smoke check aligned when users adjust QwenGR00T action/state settings.

## How Has This Been / Can This Be Tested?

Tested locally on Windows with Anaconda `py311` / Python 3.11.15.

```bash
D:\Dev\conda-envs\py311\python.exe -m py_compile starVLA\model\framework\VLM4A\QwenGR00T.py
git diff --check
```

I did not run the full smoke script because it requires loading the configured Qwen3-VL checkpoint.

## Checklist

- [x] Fake action shape now follows `action_dim` and `action_horizon`.
- [x] Fake state is included when `state_dim > 0`.
- [x] No training, evaluation, or model defaults are changed.
- [x] Syntax and whitespace checks passed.