### PR TITLE
[fix] resolve potential negative sampling in sample_time (#287)

### DIFF
--- a/starVLA/model/modules/action_model/AML_ActionHeader.py
+++ b/starVLA/model/modules/action_model/AML_ActionHeader.py
@@ -254,7 +254,7 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
-        return self.config.noise_s * (1 - sample)
+        return (self.config.noise_s - sample) / self.config.noise_s
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)

--- a/starVLA/model/modules/action_model/GR00T_ActionHeader.py
+++ b/starVLA/model/modules/action_model/GR00T_ActionHeader.py
@@ -304,7 +304,7 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype).clamp(max=self.config.noise_s)
-        return self.config.noise_s * (1 - sample)
+        return (self.config.noise_s - sample) / self.config.noise_s
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -280,7 +280,7 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
-        return self.config.noise_s * (1 - sample)
+        return (self.config.noise_s - sample) / self.config.noise_s
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)


### PR DESCRIPTION
This reverts commit a5a51fdafe6bed6154a827bc097af5ee1754a415.

## Description
This PR reverts the previous sample-time change and restores the earlier sampling behavior.

## Motivation
The reverted change modified the sample-time/noise-time sampling logic. To avoid unintended behavior changes and keep the training behavior consistent with the previous implementation, this PR restores the original logic.

Reverts #287

## Changes
- Reverted the sample-time change introduced in commit `a5a51fdafe6bed6154a827bc097af5ee1754a415`.
- Restored the previous noise/sample time sampling behavior.

## Testing
<!-- How was this verified? Check at least one -->
<!-- - [ ] `make check` passes  TODO: enable later -->
- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
| N/A       | N/A    | N/A    |

- **Checkpoint**: N/A
- **Config**: N/A
- **Reproduce**: N/A

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

## Screenshots / Logs (optional)
N/A