### PR TITLE
[feat] trainer: add full training-state resume support

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -102,9 +102,10 @@ Model-only `.pt` / `.safetensors` files should continue to use
 `trainer.pretrained_checkpoint`; `trainer.resume_from_checkpoint` expects a full
 `steps_<N>_state` directory.
 
-Note: native StarVLA dataloaders are recreated on resume. This restores the
-training state needed for continued optimization, but it does not guarantee a
-bitwise-identical dataloader cursor for interrupted runs.
+StarVLA also stores the native trainer's dataloader cursor in
+`trainer_state.json` and skips already-consumed training batches when resuming.
+For the closest-to-continuous behavior, resume with the same code, config,
+dataset ordering, distributed world size, and Accelerate/DeepSpeed config.
 </details>
 
 <details>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,13 +70,41 @@ trainer:
 <details>
 <summary><b>Q: Can I resume training from a checkpoint?</b></summary>
 
-A: Yes, somehow can. Specify the latest checkpoint path in `config.yaml`, e.g.:
+A: There are now two different modes.
+
+**Warm start / fine-tuning from model weights** loads only model parameters. This
+is useful for continued fine-tuning, partial module reloads, and released
+model-zoo checkpoints:
 ```yaml
 trainer:
   pretrained_checkpoint: path_to_steps_10000.pt
   reload_modules: "action_model"
 ```
-Empty `reload_modules` means full load all model. However, starVLA does not save  `optimizer state`. It requires a lot of  memory/disk and bring limited benefit.
+Empty `reload_modules` means loading the whole model state dict.
+
+**Full training-state resume** restores the Accelerate/DeepSpeed state, including
+the model, optimizer, scheduler, and RNG state saved by Accelerate. Enable state
+checkpoint saving during training:
+```yaml
+trainer:
+  save_training_state: true
+```
+Then resume with either the latest state checkpoint in the current run:
+```bash
+--trainer.resume_from_checkpoint latest
+```
+or an explicit state directory:
+```bash
+--trainer.resume_from_checkpoint path/to/checkpoints/steps_10000_state
+```
+
+Model-only `.pt` / `.safetensors` files should continue to use
+`trainer.pretrained_checkpoint`; `trainer.resume_from_checkpoint` expects a full
+`steps_<N>_state` directory.
+
+Note: native StarVLA dataloaders are recreated on resume. This restores the
+training state needed for continued optimization, but it does not guarantee a
+bitwise-identical dataloader cursor for interrupted runs.
 </details>
 
 <details>

--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -10,6 +10,11 @@ from starVLA.dataloader.vlm_datasets import make_vlm_dataloader
 
 logger = get_logger(__name__)
 
+
+def _is_main_process():
+    return (not dist.is_available()) or (not dist.is_initialized()) or dist.get_rank() == 0
+
+
 def save_dataset_statistics(dataset_statistics, run_dir):
     """Saves a `dataset_statistics.json` file."""
     out_path = run_dir / "dataset_statistics.json"
@@ -55,7 +60,7 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
             prefetch_factor=4,
             # shuffle=True
         )        
-        if dist.get_rank() == 0: 
+        if _is_main_process():
             
             output_dir = Path(cfg.output_dir)
             vla_dataset.save_dataset_statistics(output_dir / "dataset_statistics.json")

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -49,6 +49,15 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = get_logger(__name__)
 
 
+def _is_distributed_ready():
+    return dist.is_available() and dist.is_initialized()
+
+
+def _barrier_if_distributed():
+    if _is_distributed_ready():
+        dist.barrier()
+
+
 def load_fast_tokenizer():
     return AutoProcessor.from_pretrained("physical-intelligence/fast", trust_remote_code=True)
 
@@ -71,7 +80,7 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     vla_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vla_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    _barrier_if_distributed()
     return vla_train_dataloader
 
 
@@ -344,7 +353,7 @@ class VLATrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and self.accelerator.is_main_process:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -423,7 +432,7 @@ class VLATrainer(TrainerUtils):
             score = TrainerUtils.euclidean_distance(normalized_actions, actions)
             step_metrics["mse_score"] = score / num_pots
 
-        dist.barrier()
+        self.accelerator.wait_for_everyone()
         return step_metrics
 
     def _log_training_config(self):
@@ -510,8 +519,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    _barrier_if_distributed()
+    if _is_distributed_ready():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -279,6 +279,7 @@ class VLATrainer(TrainerUtils):
         self.accelerator.load_state(checkpoint_path)
         trainer_state = self._load_trainer_state(checkpoint_path, required=True)
         self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._set_dataloader_resume_state(trainer_state)
         self._resume_kind = "training_state"
         self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
         self.accelerator.wait_for_everyone()
@@ -312,6 +313,22 @@ class VLATrainer(TrainerUtils):
                 else:
                     raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
+        self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            tmp_state_dir = self._prepare_training_state_dir(state_dir)
+            self.accelerator.save_state(tmp_state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(
+                    tmp_state_dir,
+                    self.completed_steps,
+                    extra={"dataloader_cursors": self._get_dataloader_cursors()},
+                )
+            self._finalize_training_state_dir(tmp_state_dir, state_dir)
+            self.accelerator.wait_for_everyone()
+
+        if self.accelerator.is_main_process:
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
                 f.write(json.dumps(summary_data) + "\n")
@@ -324,13 +341,6 @@ class VLATrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
-
-        if save_training_state:
-            state_dir = checkpoint_path + "_state"
-            self.accelerator.save_state(state_dir)
-            if self.accelerator.is_main_process:
-                self._save_trainer_state(state_dir, self.completed_steps)
-            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
@@ -345,21 +355,11 @@ class VLATrainer(TrainerUtils):
 
     def _create_data_iterators(self):
         """Create data iterators."""
-        self.vla_iter = iter(self.vla_train_dataloader)
+        self.vla_iter = self._create_tracked_iterator("vla", self.vla_train_dataloader)
 
     def _get_next_batch(self):
         """Get next batch (automatically handle data loop)."""
-        try:
-            batch_vla = next(self.vla_iter)
-        except StopIteration:
-            if not hasattr(self, "vla_epoch_count"):
-                self.vla_epoch_count = 0
-            self.vla_iter, self.vla_epoch_count = TrainerUtils._reset_dataloader(
-                self.vla_train_dataloader, self.vla_epoch_count
-            )
-            batch_vla = next(self.vla_iter)
-
-        return batch_vla
+        return self._next_tracked_batch("vla", self.vla_train_dataloader, "vla_iter")
 
     def train(self):
         """Execute training loop."""
@@ -393,7 +393,7 @@ class VLATrainer(TrainerUtils):
                 )
 
             if self.completed_steps % self.config.trainer.eval_interval == 0:
-                step_metrics = self.eval_action_model(step_metrics)
+                step_metrics = self.eval_action_model(step_metrics, examples=batch_vla)
 
             step_metrics["timing/data"] = t_end_data - t_start_data
             step_metrics["timing/model"] = t_end_model - t_start_model
@@ -407,9 +407,10 @@ class VLATrainer(TrainerUtils):
 
         self._finalize_training()
 
-    def eval_action_model(self, step_metrics: dict = None) -> float:
+    def eval_action_model(self, step_metrics: dict = None, examples=None) -> float:
         """Run simple action-eval on current batch and attach score to metrics."""
-        examples = self._get_next_batch()
+        if examples is None:
+            examples = self._get_next_batch()
         actions = [example["action"] for example in examples]
         output_dict = self.accelerator.unwrap_model(self.model).predict_action(
             examples=examples, use_ddim=True, num_ddim_steps=20
@@ -422,7 +423,6 @@ class VLATrainer(TrainerUtils):
             score = TrainerUtils.euclidean_distance(normalized_actions, actions)
             step_metrics["mse_score"] = score / num_pots
 
-        del examples
         dist.barrier()
         return step_metrics
 

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -114,6 +114,8 @@ class VLATrainer(TrainerUtils):
         self.accelerator = accelerator
 
         self.completed_steps = 0
+        self._pending_training_state_checkpoint = None
+        self._resume_kind = None
         self.total_batch_size = self._calculate_total_batch_size()
 
     def prepare_training(self):
@@ -144,6 +146,7 @@ class VLATrainer(TrainerUtils):
             self.vla_train_dataloader,
         )
 
+        self._resume_training_state_after_prepare()
         self._init_wandb()
 
     def _calculate_total_batch_size(self):
@@ -187,40 +190,79 @@ class VLATrainer(TrainerUtils):
             logger.info(f"📊 Accessed config snapshot saved at {output_dir / 'config.yaml'}")
 
     def _init_checkpointing(self):
-        """Initialize checkpoint directory and handle checkpoint loading."""
+        """Initialize checkpoint directory and resolve warm-start/full-resume intent."""
         self.checkpoint_dir = os.path.join(self.config.output_dir, "checkpoints")
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 
         pretrained_checkpoint = getattr(self.config.trainer, "pretrained_checkpoint", None)
-        is_resume = getattr(self.config.trainer, "is_resume", False)
-        self.resume_from_checkpoint = pretrained_checkpoint
+        resume_request = getattr(self.config.trainer, "resume_from_checkpoint", None)
+        if isinstance(resume_request, str) and resume_request.strip().lower() in {"", "0", "false", "none", "null"}:
+            resume_request = None
+        is_resume = self._cfg_bool(getattr(self.config.trainer, "is_resume", False), default=False)
+        self.resume_from_checkpoint = resume_request
 
-        if is_resume:
-            resume_from_checkpoint, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
-            if resume_from_checkpoint:
-                self.resume_from_checkpoint = resume_from_checkpoint
-                self.model = self.load_pretrained_backbones(self.model, self.resume_from_checkpoint, reload_modules=None)
+        if is_resume and not resume_request:
+            training_state, state_steps = self._get_latest_training_state(self.checkpoint_dir)
+            if training_state:
+                self._pending_training_state_checkpoint = training_state
+                self.completed_steps = state_steps
+                self._resume_kind = "training_state"
                 logger.info(
-                    f"Resuming training from checkpoint: {self.resume_from_checkpoint}, steps: {self.completed_steps}"
+                    "`trainer.is_resume` is deprecated; using latest full training-state checkpoint "
+                    f"{training_state} at step {self.completed_steps}."
+                )
+                return
+
+            model_checkpoint, model_steps = self._get_latest_model_checkpoint(self.checkpoint_dir)
+            if model_checkpoint:
+                self.resume_from_checkpoint = model_checkpoint
+                self.model = self.load_pretrained_backbones(self.model, model_checkpoint, reload_modules=None)
+                self.completed_steps = model_steps
+                self._resume_kind = "model_only"
+                logger.warning(
+                    "`trainer.is_resume` fell back to model-only checkpoint loading because no full "
+                    "training-state checkpoint was found. Optimizer/RNG/dataloader state will not be restored. "
+                    f"Loaded {model_checkpoint} at step {self.completed_steps}."
                 )
                 return
 
             logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting training from scratch.")
             self.completed_steps = 0
 
+        if resume_request:
+            training_state, state_steps = self._resolve_training_state_checkpoint(
+                self.checkpoint_dir,
+                resume_request,
+            )
+            if not training_state:
+                raise FileNotFoundError(
+                    f"No full training-state checkpoint found for resume_from_checkpoint={resume_request!r}."
+                )
+            if pretrained_checkpoint:
+                logger.warning(
+                    "Both trainer.resume_from_checkpoint and trainer.pretrained_checkpoint are set; "
+                    "full training-state resume takes precedence."
+                )
+            self._pending_training_state_checkpoint = training_state
+            self.completed_steps = state_steps
+            self._resume_kind = "training_state"
+            logger.info(f"Will resume full training state from {training_state}, steps: {self.completed_steps}")
+            return
+
         if pretrained_checkpoint:
             reload_modules = getattr(self.config.trainer, "reload_modules", None)
             self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
             self.completed_steps = 0
             self.resume_from_checkpoint = pretrained_checkpoint
+            self._resume_kind = "warm_start"
             logger.info(f"Loaded pretrained checkpoint: {pretrained_checkpoint}, steps: {self.completed_steps}")
         else:
             logger.info("No pretrained checkpoint provided. Starting training from scratch.")
             self.completed_steps = 0
 
     def _adjust_lr_scheduler_for_resume(self):
-        """Adjust LR scheduler state after resuming from non-zero steps."""
-        if self.completed_steps > 0:
+        """Adjust LR scheduler only for legacy model-only resume."""
+        if self.completed_steps > 0 and self._resume_kind == "model_only":
             logger.info(f"Adjusting LR scheduler for resume from step {self.completed_steps}")
             for _ in range(self.completed_steps):
                 self.lr_scheduler.step()
@@ -228,26 +270,47 @@ class VLATrainer(TrainerUtils):
                 f"LR scheduler adjusted to step {self.completed_steps}, current LR: {self.lr_scheduler.get_last_lr()}"
             )
 
-    def _load_checkpoint(self, checkpoint_path):
-        """Load checkpoint."""
+    def _resume_training_state_after_prepare(self):
+        """Load full Accelerator/DeepSpeed state after distributed prepare."""
+        if not self._pending_training_state_checkpoint:
+            return
+
+        checkpoint_path = self._pending_training_state_checkpoint
         self.accelerator.load_state(checkpoint_path)
-        self.accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        trainer_state = self._load_trainer_state(checkpoint_path, required=True)
+        self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._resume_kind = "training_state"
+        self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
+        self.accelerator.wait_for_everyone()
 
     def _save_checkpoint(self):
-        """Save current training state."""
+        """Save model-only checkpoint and, optionally, full training state."""
+        save_model_checkpoint = self._cfg_bool(
+            getattr(self.config.trainer, "save_model_checkpoint", True),
+            default=True,
+        )
+        save_training_state = self._cfg_bool(
+            getattr(self.config.trainer, "save_training_state", False),
+            default=False,
+        )
+        if not save_model_checkpoint and not save_training_state:
+            logger.warning("Both save_model_checkpoint and save_training_state are disabled; skipping checkpoint save.")
+            return
+
+        save_format = getattr(self.config.trainer, "save_format", "pt")
+        checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+
         if self.accelerator.is_main_process:
-            save_format = getattr(self.config.trainer, "save_format", "pt")
-            checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+            if save_model_checkpoint:
+                state_dict = self.accelerator.get_state_dict(self.model)
+                if save_format == "safetensors":
+                    from safetensors.torch import save_file
 
-            state_dict = self.accelerator.get_state_dict(self.model)
-            if save_format == "safetensors":
-                from safetensors.torch import save_file
-
-                save_file(state_dict, checkpoint_path + "_model.safetensors")
-            elif save_format == "pt":
-                torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
-            else:
-                raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
+                    save_file(state_dict, checkpoint_path + "_model.safetensors")
+                elif save_format == "pt":
+                    torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
+                else:
+                    raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
@@ -261,6 +324,13 @@ class VLATrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            self.accelerator.save_state(state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(state_dir, self.completed_steps)
+            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -254,6 +254,7 @@ class VLAMTrainer(TrainerUtils):
         self.accelerator.load_state(checkpoint_path)
         trainer_state = self._load_trainer_state(checkpoint_path, required=True)
         self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._set_dataloader_resume_state(trainer_state)
         self._resume_kind = "training_state"
         self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
         self.accelerator.wait_for_everyone()
@@ -287,6 +288,22 @@ class VLAMTrainer(TrainerUtils):
                 else:
                     raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
+        self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            tmp_state_dir = self._prepare_training_state_dir(state_dir)
+            self.accelerator.save_state(tmp_state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(
+                    tmp_state_dir,
+                    self.completed_steps,
+                    extra={"dataloader_cursors": self._get_dataloader_cursors()},
+                )
+            self._finalize_training_state_dir(tmp_state_dir, state_dir)
+            self.accelerator.wait_for_everyone()
+
+        if self.accelerator.is_main_process:
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
                 f.write(json.dumps(summary_data) + "\n")
@@ -299,13 +316,6 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
-
-        if save_training_state:
-            state_dir = checkpoint_path + "_state"
-            self.accelerator.save_state(state_dir)
-            if self.accelerator.is_main_process:
-                self._save_trainer_state(state_dir, self.completed_steps)
-            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
@@ -320,29 +330,13 @@ class VLAMTrainer(TrainerUtils):
 
     def _create_data_iterators(self):
         """Create data iterators."""
-        self.vla_iter = iter(self.vla_train_dataloader)
-        self.vlm_iter = iter(self.vlm_train_dataloader)
+        self.vla_iter = self._create_tracked_iterator("vla", self.vla_train_dataloader)
+        self.vlm_iter = self._create_tracked_iterator("vlm", self.vlm_train_dataloader)
 
     def _get_next_batch(self):
         """Get next batch (automatically handle data loop)."""
-        try:
-            batch_vla = next(self.vla_iter)
-        except StopIteration:
-            if not hasattr(self, "vla_epoch_count"):
-                self.vla_epoch_count = 0
-            self.vla_iter, self.vla_epoch_count = TrainerUtils._reset_dataloader(
-                self.vla_train_dataloader, self.vla_epoch_count
-            )
-            batch_vla = next(self.vla_iter)
-
-        try:
-            batch_vlm = next(self.vlm_iter)
-        except StopIteration:
-            if not hasattr(self, "vlm_epoch_count"):
-                self.vlm_epoch_count = 0
-            self.vlm_iter, self.vlm_epoch_count = self._reset_dataloader(self.vlm_train_dataloader, self.vlm_epoch_count)
-            batch_vlm = next(self.vlm_iter)
-
+        batch_vla = self._next_tracked_batch("vla", self.vla_train_dataloader, "vla_iter")
+        batch_vlm = self._next_tracked_batch("vlm", self.vlm_train_dataloader, "vlm_iter")
         return batch_vla, batch_vlm
 
     def train(self):
@@ -377,7 +371,7 @@ class VLAMTrainer(TrainerUtils):
                 )
 
             if self.completed_steps % self.config.trainer.eval_interval == 0:
-                step_metrics = self.eval_action_model(step_metrics)
+                step_metrics = self.eval_action_model(step_metrics, examples=batch_vla)
 
             step_metrics["timing/data"] = t_end_data - t_start_data
             step_metrics["timing/model"] = t_end_model - t_start_model
@@ -392,10 +386,12 @@ class VLAMTrainer(TrainerUtils):
 
         self._finalize_training()
 
-    def eval_action_model(self, step_metrics: dict = None) -> float:
+    def eval_action_model(self, step_metrics: dict = None, examples=None) -> float:
         """Evaluate action prediction with current model."""
-        if self.accelerator.is_main_process:
+        if examples is None:
             examples, _ = self._get_next_batch()
+
+        if self.accelerator.is_main_process:
             actions = [example["action"] for example in examples]
 
             output_dict = self.accelerator.unwrap_model(self.model).predict_action(examples=examples)

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -87,6 +87,8 @@ class VLAMTrainer(TrainerUtils):
         self.accelerator = accelerator
 
         self.completed_steps = 0
+        self._pending_training_state_checkpoint = None
+        self._resume_kind = None
         self.total_batch_size = self._calculate_total_batch_size()
 
     def prepare_training(self):
@@ -98,12 +100,8 @@ class VLAMTrainer(TrainerUtils):
         # leaves a from_pretrained-able run dir behind.
         self._save_initial_configs()
 
-        if hasattr(self.config.trainer, "pretrained_checkpoint") and self.config.trainer.pretrained_checkpoint:
-            pretrained_checkpoint = self.config.trainer.pretrained_checkpoint
-            reload_modules = (
-                self.config.trainer.reload_modules if hasattr(self.config.trainer, "reload_modules") else None
-            )
-            self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
+        self._init_checkpointing()
+        self._adjust_lr_scheduler_for_resume()
 
         freeze_modules = (
             self.config.trainer.freeze_modules
@@ -123,8 +121,8 @@ class VLAMTrainer(TrainerUtils):
             )
         )
 
+        self._resume_training_state_after_prepare()
         self._init_wandb()
-        self._init_checkpointing()
 
     def _save_initial_configs(self):
         """Save full config and training script at the very start of training."""
@@ -167,36 +165,127 @@ class VLAMTrainer(TrainerUtils):
             )
 
     def _init_checkpointing(self):
-        """Initialize checkpoint directory."""
+        """Initialize checkpoint directory and resolve warm-start/full-resume intent."""
         self.checkpoint_dir = os.path.join(self.config.output_dir, "checkpoints")
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 
         pretrained_checkpoint = getattr(self.config.trainer, "pretrained_checkpoint", None)
-        is_resume = getattr(self.config.trainer, "is_resume", False)
+        resume_request = getattr(self.config.trainer, "resume_from_checkpoint", None)
+        if isinstance(resume_request, str) and resume_request.strip().lower() in {"", "0", "false", "none", "null"}:
+            resume_request = None
+        is_resume = self._cfg_bool(getattr(self.config.trainer, "is_resume", False), default=False)
+        self.resume_from_checkpoint = resume_request
 
-        if pretrained_checkpoint and is_resume:
-            self._load_checkpoint(self.config.resume_from_checkpoint)
+        if is_resume and not resume_request:
+            training_state, state_steps = self._get_latest_training_state(self.checkpoint_dir)
+            if training_state:
+                self._pending_training_state_checkpoint = training_state
+                self.completed_steps = state_steps
+                self._resume_kind = "training_state"
+                logger.info(
+                    "`trainer.is_resume` is deprecated; using latest full training-state checkpoint "
+                    f"{training_state} at step {self.completed_steps}."
+                )
+                return
 
-    def _load_checkpoint(self, checkpoint_path):
-        """Load checkpoint."""
+            model_checkpoint, model_steps = self._get_latest_model_checkpoint(self.checkpoint_dir)
+            if model_checkpoint:
+                self.resume_from_checkpoint = model_checkpoint
+                self.model = self.load_pretrained_backbones(self.model, model_checkpoint, reload_modules=None)
+                self.completed_steps = model_steps
+                self._resume_kind = "model_only"
+                logger.warning(
+                    "`trainer.is_resume` fell back to model-only checkpoint loading because no full "
+                    "training-state checkpoint was found. Optimizer/RNG/dataloader state will not be restored. "
+                    f"Loaded {model_checkpoint} at step {self.completed_steps}."
+                )
+                return
+
+            logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting training from scratch.")
+            self.completed_steps = 0
+
+        if resume_request:
+            training_state, state_steps = self._resolve_training_state_checkpoint(
+                self.checkpoint_dir,
+                resume_request,
+            )
+            if not training_state:
+                raise FileNotFoundError(
+                    f"No full training-state checkpoint found for resume_from_checkpoint={resume_request!r}."
+                )
+            if pretrained_checkpoint:
+                logger.warning(
+                    "Both trainer.resume_from_checkpoint and trainer.pretrained_checkpoint are set; "
+                    "full training-state resume takes precedence."
+                )
+            self._pending_training_state_checkpoint = training_state
+            self.completed_steps = state_steps
+            self._resume_kind = "training_state"
+            logger.info(f"Will resume full training state from {training_state}, steps: {self.completed_steps}")
+            return
+
+        if pretrained_checkpoint:
+            reload_modules = getattr(self.config.trainer, "reload_modules", None)
+            self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
+            self.completed_steps = 0
+            self.resume_from_checkpoint = pretrained_checkpoint
+            self._resume_kind = "warm_start"
+            logger.info(f"Loaded pretrained checkpoint: {pretrained_checkpoint}, steps: {self.completed_steps}")
+        else:
+            logger.info("No pretrained checkpoint provided. Starting training from scratch.")
+            self.completed_steps = 0
+
+    def _adjust_lr_scheduler_for_resume(self):
+        """Adjust LR scheduler only for legacy model-only resume."""
+        if self.completed_steps > 0 and self._resume_kind == "model_only":
+            logger.info(f"Adjusting LR scheduler for resume from step {self.completed_steps}")
+            for _ in range(self.completed_steps):
+                self.lr_scheduler.step()
+            logger.info(
+                f"LR scheduler adjusted to step {self.completed_steps}, current LR: {self.lr_scheduler.get_last_lr()}"
+            )
+
+    def _resume_training_state_after_prepare(self):
+        """Load full Accelerator/DeepSpeed state after distributed prepare."""
+        if not self._pending_training_state_checkpoint:
+            return
+
+        checkpoint_path = self._pending_training_state_checkpoint
         self.accelerator.load_state(checkpoint_path)
-        self.accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        trainer_state = self._load_trainer_state(checkpoint_path, required=True)
+        self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._resume_kind = "training_state"
+        self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
+        self.accelerator.wait_for_everyone()
 
     def _save_checkpoint(self):
-        """Save current training state."""
+        """Save model-only checkpoint and, optionally, full training state."""
+        save_model_checkpoint = self._cfg_bool(
+            getattr(self.config.trainer, "save_model_checkpoint", True),
+            default=True,
+        )
+        save_training_state = self._cfg_bool(
+            getattr(self.config.trainer, "save_training_state", False),
+            default=False,
+        )
+        if not save_model_checkpoint and not save_training_state:
+            logger.warning("Both save_model_checkpoint and save_training_state are disabled; skipping checkpoint save.")
+            return
+
+        save_format = getattr(self.config.trainer, "save_format", "pt")
+        checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+
         if self.accelerator.is_main_process:
-            save_format = getattr(self.config.trainer, "save_format", "pt")
-            checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+            if save_model_checkpoint:
+                state_dict = self.accelerator.get_state_dict(self.model)
+                if save_format == "safetensors":
+                    from safetensors.torch import save_file
 
-            state_dict = self.accelerator.get_state_dict(self.model)
-            if save_format == "safetensors":
-                from safetensors.torch import save_file
-
-                save_file(state_dict, checkpoint_path + "_model.safetensors")
-            elif save_format == "pt":
-                torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
-            else:
-                raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
+                    save_file(state_dict, checkpoint_path + "_model.safetensors")
+                elif save_format == "pt":
+                    torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
+                else:
+                    raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
@@ -210,6 +299,13 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            self.accelerator.save_state(state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(state_dir, self.completed_steps)
+            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -49,6 +49,15 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = get_logger(__name__)
 
 
+def _is_distributed_ready():
+    return dist.is_available() and dist.is_initialized()
+
+
+def _barrier_if_distributed():
+    if _is_distributed_ready():
+        dist.barrier()
+
+
 def load_fast_tokenizer():
     return AutoProcessor.from_pretrained("physical-intelligence/fast", trust_remote_code=True)
 
@@ -72,7 +81,7 @@ def prepare_data(cfg, accelerator, output_dir) -> Tuple[DataLoader, DataLoader]:
     vlm_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vlm_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    _barrier_if_distributed()
     return vla_train_dataloader, vlm_train_dataloader
 
 
@@ -319,7 +328,7 @@ class VLAMTrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and self.accelerator.is_main_process:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -379,7 +388,7 @@ class VLAMTrainer(TrainerUtils):
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
                 self._save_checkpoint()
-                dist.barrier()
+                self.accelerator.wait_for_everyone()
 
             if self.completed_steps >= self.config.trainer.max_train_steps:
                 break
@@ -402,7 +411,7 @@ class VLAMTrainer(TrainerUtils):
             score = TrainerUtils.euclidean_distance(normalized_actions, actions)
             step_metrics["mse_score"] = score / num_pots
 
-        dist.barrier()
+        self.accelerator.wait_for_everyone()
         return step_metrics
 
     def _log_training_config(self):
@@ -498,8 +507,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    _barrier_if_distributed()
+    if _is_distributed_ready():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -46,6 +46,15 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = get_logger(__name__)
 
 
+def _is_distributed_ready():
+    return dist.is_available() and dist.is_initialized()
+
+
+def _barrier_if_distributed():
+    if _is_distributed_ready():
+        dist.barrier()
+
+
 def load_fast_tokenizer():
     return AutoProcessor.from_pretrained("physical-intelligence/fast", trust_remote_code=True)
 
@@ -68,7 +77,7 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     vlm_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vlm_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    _barrier_if_distributed()
     return vlm_train_dataloader
 
 
@@ -304,7 +313,7 @@ class VLAMTrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and self.accelerator.is_main_process:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -349,7 +358,7 @@ class VLAMTrainer(TrainerUtils):
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
                 self._save_checkpoint()
-                dist.barrier()
+                self.accelerator.wait_for_everyone()
 
             if self.completed_steps >= self.config.trainer.max_train_steps:
                 break
@@ -440,8 +449,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    _barrier_if_distributed()
+    if _is_distributed_ready():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -82,6 +82,8 @@ class VLAMTrainer(TrainerUtils):
         self.accelerator = accelerator
 
         self.completed_steps = 0
+        self._pending_training_state_checkpoint = None
+        self._resume_kind = None
         self.total_batch_size = self._calculate_total_batch_size()
 
     def prepare_training(self):
@@ -93,12 +95,8 @@ class VLAMTrainer(TrainerUtils):
         # leaves a from_pretrained-able run dir behind.
         self._save_initial_configs()
 
-        if hasattr(self.config.trainer, "pretrained_checkpoint") and self.config.trainer.pretrained_checkpoint:
-            pretrained_checkpoint = self.config.trainer.pretrained_checkpoint
-            reload_modules = (
-                self.config.trainer.reload_modules if hasattr(self.config.trainer, "reload_modules") else None
-            )
-            self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
+        self._init_checkpointing()
+        self._adjust_lr_scheduler_for_resume()
 
         freeze_modules = self.config.trainer.freeze_modules if hasattr(self.config.trainer, "freeze_modules") else None
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
@@ -111,8 +109,8 @@ class VLAMTrainer(TrainerUtils):
             self.vlm_train_dataloader,
         )
 
+        self._resume_training_state_after_prepare()
         self._init_wandb()
-        self._init_checkpointing()
 
     def _save_initial_configs(self):
         """Save full config and training script at the very start of training."""
@@ -152,35 +150,127 @@ class VLAMTrainer(TrainerUtils):
             )
 
     def _init_checkpointing(self):
-        """Initialize checkpoint directory."""
+        """Initialize checkpoint directory and resolve warm-start/full-resume intent."""
         self.checkpoint_dir = os.path.join(self.config.output_dir, "checkpoints")
         os.makedirs(self.checkpoint_dir, exist_ok=True)
 
         pretrained_checkpoint = getattr(self.config.trainer, "pretrained_checkpoint", None)
-        is_resume = getattr(self.config.trainer, "is_resume", False)
-        if pretrained_checkpoint and is_resume:
-            self._load_checkpoint(self.config.resume_from_checkpoint)
+        resume_request = getattr(self.config.trainer, "resume_from_checkpoint", None)
+        if isinstance(resume_request, str) and resume_request.strip().lower() in {"", "0", "false", "none", "null"}:
+            resume_request = None
+        is_resume = self._cfg_bool(getattr(self.config.trainer, "is_resume", False), default=False)
+        self.resume_from_checkpoint = resume_request
 
-    def _load_checkpoint(self, checkpoint_path):
-        """Load checkpoint."""
+        if is_resume and not resume_request:
+            training_state, state_steps = self._get_latest_training_state(self.checkpoint_dir)
+            if training_state:
+                self._pending_training_state_checkpoint = training_state
+                self.completed_steps = state_steps
+                self._resume_kind = "training_state"
+                logger.info(
+                    "`trainer.is_resume` is deprecated; using latest full training-state checkpoint "
+                    f"{training_state} at step {self.completed_steps}."
+                )
+                return
+
+            model_checkpoint, model_steps = self._get_latest_model_checkpoint(self.checkpoint_dir)
+            if model_checkpoint:
+                self.resume_from_checkpoint = model_checkpoint
+                self.model = self.load_pretrained_backbones(self.model, model_checkpoint, reload_modules=None)
+                self.completed_steps = model_steps
+                self._resume_kind = "model_only"
+                logger.warning(
+                    "`trainer.is_resume` fell back to model-only checkpoint loading because no full "
+                    "training-state checkpoint was found. Optimizer/RNG/dataloader state will not be restored. "
+                    f"Loaded {model_checkpoint} at step {self.completed_steps}."
+                )
+                return
+
+            logger.warning(f"No valid checkpoint found in {self.checkpoint_dir}. Starting training from scratch.")
+            self.completed_steps = 0
+
+        if resume_request:
+            training_state, state_steps = self._resolve_training_state_checkpoint(
+                self.checkpoint_dir,
+                resume_request,
+            )
+            if not training_state:
+                raise FileNotFoundError(
+                    f"No full training-state checkpoint found for resume_from_checkpoint={resume_request!r}."
+                )
+            if pretrained_checkpoint:
+                logger.warning(
+                    "Both trainer.resume_from_checkpoint and trainer.pretrained_checkpoint are set; "
+                    "full training-state resume takes precedence."
+                )
+            self._pending_training_state_checkpoint = training_state
+            self.completed_steps = state_steps
+            self._resume_kind = "training_state"
+            logger.info(f"Will resume full training state from {training_state}, steps: {self.completed_steps}")
+            return
+
+        if pretrained_checkpoint:
+            reload_modules = getattr(self.config.trainer, "reload_modules", None)
+            self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
+            self.completed_steps = 0
+            self.resume_from_checkpoint = pretrained_checkpoint
+            self._resume_kind = "warm_start"
+            logger.info(f"Loaded pretrained checkpoint: {pretrained_checkpoint}, steps: {self.completed_steps}")
+        else:
+            logger.info("No pretrained checkpoint provided. Starting training from scratch.")
+            self.completed_steps = 0
+
+    def _adjust_lr_scheduler_for_resume(self):
+        """Adjust LR scheduler only for legacy model-only resume."""
+        if self.completed_steps > 0 and self._resume_kind == "model_only":
+            logger.info(f"Adjusting LR scheduler for resume from step {self.completed_steps}")
+            for _ in range(self.completed_steps):
+                self.lr_scheduler.step()
+            logger.info(
+                f"LR scheduler adjusted to step {self.completed_steps}, current LR: {self.lr_scheduler.get_last_lr()}"
+            )
+
+    def _resume_training_state_after_prepare(self):
+        """Load full Accelerator/DeepSpeed state after distributed prepare."""
+        if not self._pending_training_state_checkpoint:
+            return
+
+        checkpoint_path = self._pending_training_state_checkpoint
         self.accelerator.load_state(checkpoint_path)
-        self.accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        trainer_state = self._load_trainer_state(checkpoint_path, required=True)
+        self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._resume_kind = "training_state"
+        self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
+        self.accelerator.wait_for_everyone()
 
     def _save_checkpoint(self):
-        """Save current training state."""
+        """Save model-only checkpoint and, optionally, full training state."""
+        save_model_checkpoint = self._cfg_bool(
+            getattr(self.config.trainer, "save_model_checkpoint", True),
+            default=True,
+        )
+        save_training_state = self._cfg_bool(
+            getattr(self.config.trainer, "save_training_state", False),
+            default=False,
+        )
+        if not save_model_checkpoint and not save_training_state:
+            logger.warning("Both save_model_checkpoint and save_training_state are disabled; skipping checkpoint save.")
+            return
+
+        save_format = getattr(self.config.trainer, "save_format", "pt")
+        checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+
         if self.accelerator.is_main_process:
-            save_format = getattr(self.config.trainer, "save_format", "pt")
-            checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
+            if save_model_checkpoint:
+                state_dict = self.accelerator.get_state_dict(self.model)
+                if save_format == "safetensors":
+                    from safetensors.torch import save_file
 
-            state_dict = self.accelerator.get_state_dict(self.model)
-            if save_format == "safetensors":
-                from safetensors.torch import save_file
-
-                save_file(state_dict, checkpoint_path + "_model.safetensors")
-            elif save_format == "pt":
-                torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
-            else:
-                raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
+                    save_file(state_dict, checkpoint_path + "_model.safetensors")
+                elif save_format == "pt":
+                    torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
+                else:
+                    raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
@@ -194,6 +284,13 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            self.accelerator.save_state(state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(state_dir, self.completed_steps)
+            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -239,6 +239,7 @@ class VLAMTrainer(TrainerUtils):
         self.accelerator.load_state(checkpoint_path)
         trainer_state = self._load_trainer_state(checkpoint_path, required=True)
         self.completed_steps = int(trainer_state.get("completed_steps", self.completed_steps))
+        self._set_dataloader_resume_state(trainer_state)
         self._resume_kind = "training_state"
         self.accelerator.print(f"Resumed full training state from {checkpoint_path} at step {self.completed_steps}")
         self.accelerator.wait_for_everyone()
@@ -272,6 +273,22 @@ class VLAMTrainer(TrainerUtils):
                 else:
                     raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
 
+        self.accelerator.wait_for_everyone()
+
+        if save_training_state:
+            state_dir = checkpoint_path + "_state"
+            tmp_state_dir = self._prepare_training_state_dir(state_dir)
+            self.accelerator.save_state(tmp_state_dir)
+            if self.accelerator.is_main_process:
+                self._save_trainer_state(
+                    tmp_state_dir,
+                    self.completed_steps,
+                    extra={"dataloader_cursors": self._get_dataloader_cursors()},
+                )
+            self._finalize_training_state_dir(tmp_state_dir, state_dir)
+            self.accelerator.wait_for_everyone()
+
+        if self.accelerator.is_main_process:
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
                 f.write(json.dumps(summary_data) + "\n")
@@ -284,13 +301,6 @@ class VLAMTrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
-
-        if save_training_state:
-            state_dir = checkpoint_path + "_state"
-            self.accelerator.save_state(state_dir)
-            if self.accelerator.is_main_process:
-                self._save_trainer_state(state_dir, self.completed_steps)
-            self.accelerator.wait_for_everyone()
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
@@ -308,17 +318,11 @@ class VLAMTrainer(TrainerUtils):
 
     def _create_data_iterators(self):
         """Create data iterators."""
-        self.vlm_iter = iter(self.vlm_train_dataloader)
+        self.vlm_iter = self._create_tracked_iterator("vlm", self.vlm_train_dataloader)
 
     def _get_next_batch(self):
         """Get next batch (automatically handle data loop)."""
-        try:
-            return next(self.vlm_iter)
-        except StopIteration:
-            if not hasattr(self, "vlm_epoch_count"):
-                self.vlm_epoch_count = 0
-            self.vlm_iter, self.vlm_epoch_count = self._reset_dataloader(self.vlm_train_dataloader, self.vlm_epoch_count)
-            return next(self.vlm_iter)
+        return self._next_tracked_batch("vlm", self.vlm_train_dataloader, "vlm_iter")
 
     def train(self):
         """Execute training loop."""

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -8,6 +8,7 @@ endpoints (e.g., JSONL local logs, Weights & Biases).
 import json
 import os
 import re
+import shutil
 from typing import Tuple
 
 import numpy as np
@@ -642,6 +643,24 @@ class TrainerUtils:
             json.dump(trainer_state, f, indent=2)
         return state_path
 
+    def _prepare_training_state_dir(self, state_dir):
+        """Create a clean temporary directory for atomic training-state saves."""
+        tmp_state_dir = state_dir + ".tmp"
+        if self.accelerator.is_main_process:
+            if os.path.exists(tmp_state_dir):
+                shutil.rmtree(tmp_state_dir)
+        self.accelerator.wait_for_everyone()
+        return tmp_state_dir
+
+    def _finalize_training_state_dir(self, tmp_state_dir, state_dir):
+        """Publish a fully written temporary training-state directory."""
+        self.accelerator.wait_for_everyone()
+        if self.accelerator.is_main_process:
+            if os.path.exists(state_dir):
+                shutil.rmtree(state_dir)
+            os.replace(tmp_state_dir, state_dir)
+        self.accelerator.wait_for_everyone()
+
     def _load_trainer_state(self, state_dir, required=True):
         """Load trainer-owned metadata from a full training-state checkpoint."""
         state_path = os.path.join(state_dir, "trainer_state.json")
@@ -652,6 +671,73 @@ class TrainerUtils:
 
         with open(state_path, "r") as f:
             return json.load(f)
+
+    def _set_dataloader_resume_state(self, trainer_state):
+        """Store dataloader cursor metadata until iterators are created."""
+        self._dataloader_resume_state = trainer_state.get("dataloader_cursors", {}) if trainer_state else {}
+
+    def _get_dataloader_cursors(self):
+        """Return a JSON-serializable snapshot of tracked dataloader cursors."""
+        return getattr(self, "_dataloader_cursors", {})
+
+    def _create_tracked_iterator(self, tag, dataloader):
+        """Create an iterator restored to the saved epoch/batch cursor for `tag`."""
+        resume_state = getattr(self, "_dataloader_resume_state", {}).get(tag, {})
+        epoch = int(resume_state.get("epoch", 0))
+        batches_seen = int(resume_state.get("batches_seen_in_epoch", 0))
+
+        if hasattr(dataloader, "sampler") and callable(getattr(dataloader.sampler, "set_epoch", None)):
+            dataloader.sampler.set_epoch(epoch)
+
+        if not hasattr(self, "_dataloader_cursors"):
+            self._dataloader_cursors = {}
+        self._dataloader_cursors[tag] = {
+            "epoch": epoch,
+            "batches_seen_in_epoch": batches_seen,
+        }
+
+        if batches_seen <= 0:
+            return iter(dataloader)
+
+        try:
+            from accelerate.data_loader import skip_first_batches
+
+            return iter(skip_first_batches(dataloader, batches_seen))
+        except Exception as exc:
+            logger.warning(
+                f"Falling back to manual dataloader skip for `{tag}` after skip_first_batches failed: {exc}"
+            )
+            iterator = iter(dataloader)
+            for _ in range(batches_seen):
+                next(iterator)
+            return iterator
+
+    def _next_tracked_batch(self, tag, dataloader, iterator_attr):
+        """Read the next training batch and update the saved dataloader cursor."""
+        if not hasattr(self, "_dataloader_cursors"):
+            self._dataloader_cursors = {}
+        if tag not in self._dataloader_cursors:
+            self._dataloader_cursors[tag] = {"epoch": 0, "batches_seen_in_epoch": 0}
+
+        iterator = getattr(self, iterator_attr)
+        try:
+            batch = next(iterator)
+        except StopIteration:
+            cursor = self._dataloader_cursors[tag]
+            cursor["epoch"] = int(cursor.get("epoch", 0)) + 1
+            cursor["batches_seen_in_epoch"] = 0
+
+            if hasattr(dataloader, "sampler") and callable(getattr(dataloader.sampler, "set_epoch", None)):
+                dataloader.sampler.set_epoch(cursor["epoch"])
+
+            iterator = iter(dataloader)
+            setattr(self, iterator_attr, iterator)
+            batch = next(iterator)
+
+        self._dataloader_cursors[tag]["batches_seen_in_epoch"] = (
+            int(self._dataloader_cursors[tag].get("batches_seen_in_epoch", 0)) + 1
+        )
+        return batch
 
 
 def is_main_process():

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -21,6 +21,14 @@ from accelerate.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _is_distributed_ready():
+    return dist.is_available() and dist.is_initialized()
+
+
+def _is_main_process():
+    return (not _is_distributed_ready()) or dist.get_rank() == 0
+
+
 # === Define Tracker Interface ===
 #
 
@@ -71,7 +79,7 @@ def setup_optimizer_and_scheduler(model, cfg) -> Tuple[torch.optim.Optimizer, to
         fused=fused_available,
     )
 
-    if dist.is_initialized() and dist.get_rank() == 0:
+    if _is_distributed_ready() and dist.get_rank() == 0:
         for group in optimizer.param_groups:
             logger.info(f"LR Group {group['name']}: lr={group['lr']}, num_params={len(group['params'])}")
 
@@ -156,7 +164,7 @@ def only_main_process(func):
     """
 
     def wrapper(*args, **kwargs):
-        if dist.is_initialized() and dist.get_rank() != 0:
+        if _is_distributed_ready() and dist.get_rank() != 0:
             return None  # non-main process does not execute
         return func(*args, **kwargs)
 
@@ -239,7 +247,7 @@ class TrainerUtils:
                     continue
 
         # accelerator.wait_for_everyone()  # synchronize when distributed training
-        if dist.get_rank == 0:
+        if _is_main_process():
             print(f"🔒 Frozen modules with re pattern: {frozen}")
         return model
 
@@ -249,7 +257,7 @@ class TrainerUtils:
         print the total number of parameters and trainable parameters of the model
         :param model: PyTorch model instance
         """
-        if dist.get_rank() != 0:
+        if not _is_main_process():
             return
         print("📊 model parameter statistics:")
         num_params = sum(p.numel() for p in model.parameters())
@@ -271,7 +279,7 @@ class TrainerUtils:
         """
         if not checkpoint_path:
             return []
-        if dist.get_rank() == 0:
+        if _is_main_process():
             print(f"📦 loading checkpoint: {checkpoint_path}")
         try:
             if _is_safetensors_path(checkpoint_path):
@@ -297,7 +305,7 @@ class TrainerUtils:
                     sub_state_dict = {k[len(prefix) :]: v for k, v in checkpoint.items() if k.startswith(prefix)}
                     if sub_state_dict:
                         module.load_state_dict(sub_state_dict, strict=True)
-                        if dist.get_rank() == 0:
+                        if _is_main_process():
                             print(f"✅ parameters loaded to module '{path}'")
                         loaded_modules.append(path)
                     else:
@@ -307,7 +315,7 @@ class TrainerUtils:
         else:  # full load
             try:
                 model.load_state_dict(checkpoint, strict=False)
-                if dist.get_rank() == 0:
+                if _is_main_process():
                     print("✅ loaded <full_model> model parameters")
                 loaded_modules = ["<full_model>"]
             except Exception as e:

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -5,9 +5,11 @@ Utility classes defining a Metrics container and multiple Trackers to enable mod
 endpoints (e.g., JSONL local logs, Weights & Biases).
 """
 
-from typing import Tuple
-import re
 import json
+import os
+import re
+from typing import Tuple
+
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -184,6 +186,17 @@ import torch.distributed as dist
 
 
 class TrainerUtils:
+    @staticmethod
+    def _cfg_bool(value, default=False):
+        """Read bool-like OmegaConf / CLI values without treating "false" as truthy."""
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+        return bool(value)
+
     @staticmethod
     def freeze_backbones(model, freeze_modules=""):
         """
@@ -499,8 +512,8 @@ class TrainerUtils:
             print("No valid JSON part found")
             return None
 
-    def _get_latest_checkpoint(self, checkpoint_dir):
-        """Find the latest checkpoint in the directory based on step number."""
+    def _get_latest_model_checkpoint(self, checkpoint_dir):
+        """Find the latest model-only checkpoint in the directory by step number."""
         if not os.path.exists(checkpoint_dir):
             self.accelerator.print(f"No checkpoint directory found at {checkpoint_dir}")
             return None, 0
@@ -534,7 +547,111 @@ class TrainerUtils:
         self.accelerator.print(f"Latest checkpoint found: {latest_checkpoint_path}")
         return latest_checkpoint_path, completed_steps
 
-import os
+    def _get_latest_checkpoint(self, checkpoint_dir):
+        """Backward-compatible alias for the latest model-only checkpoint."""
+        return self._get_latest_model_checkpoint(checkpoint_dir)
+
+    def _get_latest_training_state(self, checkpoint_dir):
+        """Find the latest full training-state checkpoint directory by step number."""
+        if not os.path.exists(checkpoint_dir):
+            self.accelerator.print(f"No checkpoint directory found at {checkpoint_dir}")
+            return None, 0
+
+        checkpoints = [
+            f for f in os.listdir(checkpoint_dir)
+            if re.match(r"steps_(\d+)_state$", f)
+            and os.path.isdir(os.path.join(checkpoint_dir, f))
+        ]
+
+        if not checkpoints:
+            self.accelerator.print(f"No training-state checkpoints found in {checkpoint_dir}")
+            return None, 0
+
+        try:
+            checkpoints_with_steps = [
+                (ckpt, int(re.search(r"steps_(\d+)_state$", ckpt).group(1)))
+                for ckpt in checkpoints
+            ]
+        except AttributeError as e:
+            self.accelerator.print(f"Error parsing training-state checkpoint names: {e}")
+            return None, 0
+
+        checkpoints_with_steps.sort(key=lambda x: x[1])
+        latest_checkpoint, completed_steps = checkpoints_with_steps[-1]
+        latest_checkpoint_path = os.path.join(checkpoint_dir, latest_checkpoint)
+        self.accelerator.print(f"Latest training-state checkpoint found: {latest_checkpoint_path}")
+        return latest_checkpoint_path, completed_steps
+
+    def _resolve_training_state_checkpoint(self, checkpoint_dir, resume_from_checkpoint):
+        """Resolve a full training-state checkpoint request.
+
+        `resume_from_checkpoint` accepts:
+        - None / "" / False: no full resume.
+        - "latest" / True: latest `steps_<N>_state` directory in checkpoint_dir.
+        - explicit path to a `steps_<N>_state` directory.
+
+        Model-only `.pt` / `.safetensors` checkpoints are intentionally rejected
+        here so warm-start and full resume cannot be confused.
+        """
+        if not resume_from_checkpoint:
+            return None, 0
+
+        if isinstance(resume_from_checkpoint, str) and resume_from_checkpoint.strip().lower() in {
+            "",
+            "0",
+            "false",
+            "none",
+            "null",
+        }:
+            return None, 0
+
+        if resume_from_checkpoint is True or str(resume_from_checkpoint).lower() == "latest":
+            return self._get_latest_training_state(checkpoint_dir)
+
+        resume_path = os.fspath(resume_from_checkpoint)
+        if os.path.isfile(resume_path):
+            raise ValueError(
+                "resume_from_checkpoint expects a full training-state directory. "
+                "For model-only .pt/.safetensors files, use trainer.pretrained_checkpoint instead."
+            )
+
+        if not os.path.isdir(resume_path):
+            raise FileNotFoundError(f"Training-state checkpoint directory not found: {resume_path}")
+
+        state = self._load_trainer_state(resume_path, required=False)
+        completed_steps = state.get("completed_steps")
+        if completed_steps is None:
+            match = re.search(r"steps_(\d+)_state$", os.path.basename(os.path.normpath(resume_path)))
+            completed_steps = int(match.group(1)) if match else 0
+
+        return resume_path, int(completed_steps)
+
+    def _save_trainer_state(self, state_dir, completed_steps, extra=None):
+        """Save trainer-owned metadata next to Accelerator/DeepSpeed state."""
+        os.makedirs(state_dir, exist_ok=True)
+        trainer_state = {
+            "completed_steps": int(completed_steps),
+            "checkpoint_type": "training_state",
+            "version": 1,
+        }
+        if extra:
+            trainer_state.update(extra)
+
+        state_path = os.path.join(state_dir, "trainer_state.json")
+        with open(state_path, "w") as f:
+            json.dump(trainer_state, f, indent=2)
+        return state_path
+
+    def _load_trainer_state(self, state_dir, required=True):
+        """Load trainer-owned metadata from a full training-state checkpoint."""
+        state_path = os.path.join(state_dir, "trainer_state.json")
+        if not os.path.exists(state_path):
+            if required:
+                raise FileNotFoundError(f"Missing trainer state metadata: {state_path}")
+            return {}
+
+        with open(state_path, "r") as f:
+            return json.load(f)
 
 
 def is_main_process():


### PR DESCRIPTION
## Summary

This PR adds full training-state resume support for StarVLA training.

It separates two checkpoint-loading modes:

- `trainer.pretrained_checkpoint`: model-only warm start / fine-tuning
- `trainer.resume_from_checkpoint`: full training-state resume from a `steps_N_state` directory

Full resume restores:

- model state
- optimizer state
- scheduler state
- Accelerate / DeepSpeed state
- RNG state saved by Accelerate
- `completed_steps`
- native trainer dataloader cursor

Training-state checkpoints are saved atomically via:

```text
steps_N_state.tmp -> steps_N_state
```

This PR also guards distributed helper calls so single-process DeepSpeed smoke tests do not call `dist.get_rank()`, `dist.barrier()`, or `dist.destroy_process_group()` outside initialized process-group contexts.

## Validation

Validated on a single RTX 4090D with DeepSpeed ZeRO-2.

Config:

- framework: `QwenOFT`
- backbone: `Qwen/Qwen2.5-VL-3B-Instruct`
- dataset: LIBERO goal, `libero_goal`
- precision: bf16
- batch size: 1
- attention: `sdpa`
- `trainer.save_training_state=true`
- `trainer.save_model_checkpoint=false`

Validation flow:

1. Fresh training from step 0 to step 2 saved `steps_2_state`.
2. `resume_from_checkpoint=latest` restored `steps_2_state`.
3. Continued to step 4 and saved `steps_4_state`.
4. Explicit path resume from `steps_4_state`.
5. Continued to step 5 and saved `steps_5_state`.

Observed trainer states:

```text
steps_2_state: completed_steps=2, dataloader cursor=2
steps_4_state: completed_steps=4, dataloader cursor=4
steps_5_state: completed_steps=5, dataloader cursor=5
```

Consistency check from the same `steps_2_state`:

```text
Route A: step2 -> step4 -> resume -> step5
Route B: step2 -> directly train to step5
```

Results:

- model state SHA256 matched exactly
- optimizer tensor comparison passed with `max_diff = 0.0`
- no tensor key mismatch in optimizer states

This confirms that model parameters and optimizer tensor state are restored consistently across interrupted training.

## Reproduce

The validation used the same command pattern with different `max_train_steps` / `resume_from_checkpoint` values:

```bash
accelerate launch \
  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
  --num_processes 1 \
  --num_machines 1 \
  --mixed_precision bf16 \
  starVLA/training/train_starvla.py \
  --config_yaml examples/LIBERO/train_files/starvla_cotrain_libero.yaml \
  --framework.name QwenOFT \
  --framework.qwenvl.base_vlm ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct \
  --framework.qwenvl.attn_implementation sdpa \
  --framework.action_model.action_horizon 2 \
  --datasets.vla_data.data_root_dir playground/Datasets/LEROBOT_LIBERO_DATA \
  --datasets.vla_data.data_mix libero_goal \
  --datasets.vla_data.per_device_batch_size 1 \
  --trainer.freeze_modules qwen_vl_interface \
  --trainer.gradient_accumulation_steps 1 \
  --trainer.save_interval 2 \
  --trainer.eval_interval 999999 \
  --trainer.logging_frequency 1 \
  --trainer.save_training_state true \
  --trainer.save_model_checkpoint false \
  --run_root_dir ./playground/Checkpoints \
  --run_id resume_full_verify
```

Resume was tested with both:

```bash
--trainer.resume_from_checkpoint latest
```

and:

```bash
--trainer.resume_from_checkpoint ./playground/Checkpoints/resume_full_verify/checkpoints/steps_4_state
```

## Notes

Model-only loading remains available through `trainer.pretrained_checkpoint`.

Full training-state resume should use:

```bash
--trainer.resume_from_checkpoint latest
```

or:

```bash
--trainer.resume_from_checkpoint path/to/checkpoints/steps_N_state
```

A strict comparison was performed from the same `steps_2_state` because bitwise equivalence between two independent fresh runs is not guaranteed when model initialization occurs before seeding.