### PR TITLE
 Bug Fix: Use correct video chunk/file indices in get_video_path function

### DIFF
--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -1591,8 +1591,8 @@ class LeRobotSingleDataset(Dataset):
                 video_file_index = episode_meta["data/file_index"]
             video_filename = self.video_path_pattern.format(
                 video_key=original_key,
-                chunk_index=episode_meta["data/chunk_index"],
-                file_index=episode_meta["data/file_index"],
+                chunk_index=video_chunk_index,
+                file_index=video_file_index,
             )
         return self.dataset_path / video_filename
 


### PR DESCRIPTION


# Bug Fix: Use correct video chunk/file indices in get_video_path function
Location: starVLA/starVLA/dataloader/gr00t_lerobot/datasets.py - get_video_path function

# Problem:
When original_key exists in video_file_indices, the function correctly extracts video_chunk_index and video_file_index from video_file_indices[original_key]. However, when constructing video_filename, it still uses episode_meta["data/chunk_index"] and episode_meta["data/file_index"] regardless of which branch was taken.

# Fix:
Use the already-assigned video_chunk_index and video_file_index variables when formatting the video path pattern, ensuring the correct indices are used for both conditional branches.

# Before:
```
            if original_key in video_file_indices:
                video_chunk_index = video_file_indices[original_key]["chunk_index"]
                video_file_index = video_file_indices[original_key]["file_index"]
            else:
                video_chunk_index = episode_meta["data/chunk_index"]
                video_file_index = episode_meta["data/file_index"]
            video_filename = self.video_path_pattern.format(
                video_key=original_key,
                chunk_index=episode_meta["data/chunk_index"],
                file_index=episode_meta["data/file_index"],
            )
```

After:

```
            if original_key in video_file_indices:
                video_chunk_index = video_file_indices[original_key]["chunk_index"]
                video_file_index = video_file_indices[original_key]["file_index"]
            else:
                video_chunk_index = episode_meta["data/chunk_index"]
                video_file_index = episode_meta["data/file_index"]
            video_filename = self.video_path_pattern.format(
                video_key=original_key,
                chunk_index=video_chunk_index ,
                file_index=video_file_index ,
            )
```


