### PR TITLE
[feat] Add opt-in VLM LoRA training support

### DIFF
--- a/docs/LoRA.md
+++ b/docs/LoRA.md
@@ -1,0 +1,260 @@
+# VLM LoRA Training
+
+LoRA support fine-tunes the VLM backbone through PEFT while keeping the StarVLA
+action model, optimizer, checkpoint, and `from_pretrained()` flows intact. The
+main training entrypoint is `starVLA/training/train_starvla.py`.
+
+## Support Scope
+
+Formal support:
+
+- All Qwen-series StarVLA VLM backbones that are mounted at
+  `model.qwen_vl_interface.model`.
+- All benches that launch `starVLA/training/train_starvla.py`, including
+  Robotwin, LIBERO, SimplerEnv/OXE, DOMINO, Franka, Calvin, Robocasa,
+  Robocasa365, RoboChallenge Table30v2, VLA-Arena, Gemma4, MiniCPM, and
+  NeuralVLA launchers.
+
+Experimental support:
+
+- Non-Qwen VLMs whose StarVLA framework exposes a PEFT-compatible backbone
+  module. The default module path is still `qwen_vl_interface.model` because
+  current StarVLA VLM frameworks reuse that attribute name for the backbone
+  interface.
+- For non-Qwen models, start with `target_modules: all-linear` or explicitly
+  set the target module names after inspecting the backbone.
+
+Not included in this VLM LoRA path:
+
+- WM4A internal world-model LoRA for DiT/T5/VAE. DiT LoRA can be useful as a
+  separate follow-up, T5 LoRA is workload-dependent, and VAE LoRA is uncommon
+  for this training target.
+
+## Configuration
+
+Use `framework.vlm.lora` as the canonical config path:
+
+```yaml
+framework:
+  name: QwenOFT
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+  vlm:
+    lora:
+      enabled: true
+      r: 16
+      alpha: 32
+      dropout: 0.05
+      bias: none
+      target_modules: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+      adapter_path: null
+      adapter_name: default
+      is_trainable: true
+      save_adapter_only: false
+      module_path: qwen_vl_interface.model
+      adapter_dir_name: vlm_lora_adapter
+      task_type: CAUSAL_LM
+      modules_to_save: null
+```
+
+`framework.qwenvl.lora` remains load-compatible for older local configs and
+checkpoints, but new configs should use `framework.vlm.lora`.
+
+For non-Qwen experiments:
+
+```bash
+export VLM_LORA_ENABLED=true
+export VLM_LORA_TARGET_MODULES=all-linear
+export VLM_LORA_R=8
+export VLM_LORA_ALPHA=16
+```
+
+If a framework stores the backbone somewhere else, override:
+
+```bash
+export VLM_LORA_MODULE_PATH=some_interface.model
+```
+
+## Launchers
+
+Direct `train_starvla.py` launchers source:
+
+```bash
+examples/common/vlm_lora_args.sh
+```
+
+Recommended environment variables:
+
+```bash
+export VLM_LORA_ENABLED=true
+export VLM_LORA_R=16
+export VLM_LORA_ALPHA=32
+export VLM_LORA_DROPOUT=0.05
+export VLM_LORA_TARGET_MODULES=q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+export VLM_LORA_LR=2.0e-4
+```
+
+The helper also accepts the previous `LORA_*` names for compatibility. It maps
+LoRA LR to `trainer.learning_rate.qwen_vl_interface` by default; in current
+StarVLA this is the VLM interface module name, not a restriction to Qwen models.
+Override it with `VLM_LORA_LR_MODULE` if a framework uses a different module
+name.
+
+Small Robotwin smoke example:
+
+```bash
+cd /home/hfang/code/starvla-lora
+export PYTHONPATH="$PWD"
+export WANDB_MODE=disabled
+
+export NUM_PROCESSES=1
+export PER_DEVICE_BATCH_SIZE=1
+export MAX_TRAIN_STEPS=1
+export SAVE_INTERVAL=999999
+export EVAL_INTERVAL=999999
+export LOGGING_FREQUENCY=1
+
+export VLM_LORA_ENABLED=true
+export VLM_LORA_R=2
+export VLM_LORA_ALPHA=4
+export VLM_LORA_DROPOUT=0.0
+export VLM_LORA_TARGET_MODULES=q_proj,v_proj
+export VLM_LORA_LR=2.0e-4
+
+bash examples/Robotwin/train_files/run_robotwin_train.sh
+```
+
+The command still needs valid local model and dataset paths. On Ascend/NPU, a
+backend-specific PEFT/transformers/torch_npu failure is not treated as a LoRA
+migration failure if compile, config, and local module-path smoke checks pass.
+
+## Optional ZeRO-1 Config
+
+LoRA trains far fewer parameters than full fine-tuning. If ZeRO-2 communication
+overhead dominates on a local cluster or Ascend/NPU setup, try the migrated
+LoRA-oriented ZeRO-1 config:
+
+```bash
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_lora_zero1.yaml \
+  --num_processes 8 \
+  starVLA/training/train_starvla.py \
+  --config_yaml <bench_config.yaml> \
+  --framework.vlm.lora.enabled true
+```
+
+Keep the default ZeRO-2 config when the model/head memory footprint requires
+more optimizer-state partitioning. Use ZeRO-1 as a communication-light first
+try for adapter-only or small-rank LoRA runs.
+
+## Checkpoints
+
+Full model checkpoints are saved by default. A sibling PEFT adapter directory is
+also saved:
+
+- `steps_N_pytorch_model.pt` -> `steps_N_vlm_lora_adapter/`
+- `steps_N_model.safetensors` -> `steps_N_vlm_lora_adapter/`
+- `final_model/pytorch_model.pt` -> `final_model/vlm_lora_adapter/`
+- `final_model/model.safetensors` -> `final_model/vlm_lora_adapter/`
+
+Set `save_adapter_only: true` to skip full StarVLA model weights and write only
+the PEFT adapter directories.
+
+The loader prefers `vlm_lora_adapter` and falls back to legacy
+`qwen_lora_adapter` directories.
+
+`trainer.is_resume=true` can discover `steps_N_vlm_lora_adapter/` adapter-only
+checkpoints and restore the adapter with the correct step count. Exact recovery
+of action-head weights and optimizer state still requires full checkpoint files;
+use adapter-only saves for compact adapter export or continuation from a fixed
+base checkpoint, not for bitwise-identical training resume.
+
+## Local Smoke Checks
+
+Config-only check:
+
+```bash
+python - <<'PY'
+from omegaconf import OmegaConf
+from starVLA.model.modules.vlm.lora_utils import get_lora_settings
+
+cfg = OmegaConf.create({"framework": {"vlm": {"lora": {
+    "enabled": True,
+    "r": 2,
+    "alpha": 4,
+    "target_modules": "all-linear",
+}}}})
+settings = get_lora_settings(cfg)
+assert settings.enabled is True
+assert settings.target_modules == "all-linear"
+assert settings.module_path == "qwen_vl_interface.model"
+print("vlm_lora_config_ok")
+PY
+```
+
+Tiny PEFT check without downloading Qwen:
+
+```bash
+python - <<'PY'
+from tempfile import TemporaryDirectory
+
+import torch
+from omegaconf import OmegaConf
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from starVLA.model.modules.vlm.lora_utils import (
+    apply_lora_to_vlm_backbone,
+    save_vlm_lora_adapter,
+)
+
+class TinyInterface(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = GPT2LMHeadModel(
+            GPT2Config(n_layer=1, n_head=1, n_embd=16, vocab_size=32, n_positions=8)
+        )
+
+class TinyVLA(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.qwen_vl_interface = TinyInterface()
+
+cfg = OmegaConf.create({"framework": {"vlm": {"lora": {
+    "enabled": True,
+    "r": 2,
+    "alpha": 4,
+    "dropout": 0.0,
+    "bias": "none",
+    "target_modules": ["c_attn"],
+    "adapter_name": "smoke",
+}}}})
+
+model, settings = apply_lora_to_vlm_backbone(TinyVLA(), cfg)
+trainable = [name for name, param in model.named_parameters() if param.requires_grad]
+assert trainable and all("lora_" in name for name in trainable), trainable[:10]
+with TemporaryDirectory() as output_dir:
+    save_vlm_lora_adapter(
+        model,
+        output_dir,
+        adapter_name=settings.adapter_name,
+        module_path=settings.module_path,
+    )
+print("vlm_lora_peft_ok", len(trainable))
+PY
+```
+
+## Tuning Notes
+
+- Start with `r=8` or `r=16`; increase to `r=32` when the task underfits and
+  there is enough data.
+- Use `alpha = 2 * r` as a first pass.
+- Use `dropout=0.05` for small real-robot datasets; use `0.0` for smoke tests.
+- For lower memory on Qwen, start with `q_proj,v_proj`.
+- For stronger Qwen adaptation, use
+  `q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj`.
+- For non-Qwen experiments, prefer `all-linear` first, then narrow the target
+  modules after checking trainable parameter count and memory.
+- If `trainer.freeze_modules=qwen_vl_interface`, the trainer strips that freeze
+  pattern before rebuilding the optimizer so PEFT adapter parameters remain
+  trainable. PEFT keeps the base VLM weights frozen.

--- a/examples/DOMINO/train_files/run_domino_train.sh
+++ b/examples/DOMINO/train_files/run_domino_train.sh
@@ -32,6 +32,9 @@ mkdir -p ${output_dir}
 # keep a copy of the launch script next to the checkpoints
 cp "$0" "${output_dir}/"
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
 
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
@@ -50,5 +53,6 @@ accelerate launch \
   --run_root_dir ${run_root_dir} \
   --run_id ${run_id} \
   --wandb_project starVLA_DOMINO \
-  --wandb_entity your_wandb_entity
+  --wandb_entity your_wandb_entity \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True

--- a/examples/Franka/train_files/run_franka_train_dual.sh
+++ b/examples/Franka/train_files/run_franka_train_dual.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -25,6 +27,9 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
 
 
 accelerate launch \
@@ -44,6 +49,7 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_franka \
   --wandb_entity zwanggk \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/Franka/train_files/run_franka_train_single.sh
+++ b/examples/Franka/train_files/run_franka_train_single.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -25,6 +27,9 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
 
 
 accelerate launch \
@@ -44,6 +49,7 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_franka \
   --wandb_entity zwanggk \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/Gemma4/submit_hpc3_libero.sh
+++ b/examples/Gemma4/submit_hpc3_libero.sh
@@ -72,6 +72,10 @@ echo "[gemma4-vla] GRAD_ACCUM=${GRAD_ACCUM}  effective BS = ${PER_DEVICE_BS}Ã—8Ã
 echo "[gemma4-vla] ENABLE_GRAD_CKPT=${ENABLE_GRAD_CKPT}  ZERO_STAGE=${ZERO_STAGE}"
 echo "[gemma4-vla] RUN_ID=${RUN_ID}"
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file "${ACCEL_CONFIG}" \
   --num_processes 8 \
@@ -92,4 +96,5 @@ accelerate launch \
   --trainer.logging_frequency 100 \
   --trainer.eval_interval 5000 \
   --run_root_dir "${RUN_ROOT_DIR}" \
-  --run_id "${RUN_ID}"
+  --run_id "${RUN_ID}" \
+  "${EXTRA_ARGS[@]}"

--- a/examples/LIBERO/train_files/run_libero_train.sh
+++ b/examples/LIBERO/train_files/run_libero_train.sh
@@ -1,5 +1,7 @@
 
 
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -29,6 +31,10 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 
 num_processes=${NUM_PROCESSES:-$(nvidia-smi -L | wc -l)}
 
@@ -52,6 +58,7 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_Libero \
   --wandb_entity jinhuiye \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/MiniCPM/submit_hpc3_libero.sh
+++ b/examples/MiniCPM/submit_hpc3_libero.sh
@@ -61,6 +61,10 @@ echo "[minicpm-vla] DATA_MIX=${DATA_MIX}  STEPS=${MAX_STEPS}  PER_DEVICE_BS=${PE
 echo "[minicpm-vla] effective BS = ${PER_DEVICE_BS}×8×1 (GA=1 from ds_config.yaml)"
 echo "[minicpm-vla] FREEZE_MODULES='${FREEZE_MODULES}'  RUN_ID=${RUN_ID}"
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file "${ACCEL_CONFIG}" \
   --num_processes 8 \
@@ -81,4 +85,5 @@ accelerate launch \
   --trainer.logging_frequency 100 \
   --trainer.eval_interval 5000 \
   --run_root_dir "${RUN_ROOT_DIR}" \
-  --run_id "${RUN_ID}"
+  --run_id "${RUN_ID}" \
+  "${EXTRA_ARGS[@]}"

--- a/examples/RoboChallenge_table30v2/train_files/run_robochallenge_table30v2.sh
+++ b/examples/RoboChallenge_table30v2/train_files/run_robochallenge_table30v2.sh
@@ -34,6 +34,10 @@ cp "$0" "${output_dir}/"
 # Disable WandB for the walk-through; remove this line and `wandb login` for real runs.
 export WANDB_MODE=${WANDB_MODE:-disabled}
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes "${NUM_GPUS}" \
@@ -46,4 +50,5 @@ accelerate launch \
   --trainer.eval_interval "${EVAL_EVERY}" \
   --run_root_dir "${run_root_dir}" \
   --run_id "${run_id}" \
-  --wandb_project starVLA_robochallenge_table30v2
+  --wandb_project starVLA_robochallenge_table30v2 \
+  "${EXTRA_ARGS[@]}"

--- a/examples/Robocasa_365/train_files/run_robocasa365.sh
+++ b/examples/Robocasa_365/train_files/run_robocasa365.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # WandB — set your own key, or run `wandb login` before launching,
 # or uncomment the line below to disable WandB entirely:
 #   export WANDB_MODE=disabled
-export WANDB_API_KEY=<your_wandb_api_key>
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
 
 # NCCL networking — uncomment and edit to match your InfiniBand / RoCE setup:
 #   export NCCL_SOCKET_IFNAME=<your_network_interface>   # e.g. eth0, bond0
@@ -46,6 +46,10 @@ output_dir=${run_root_dir}/${run_id}
 mkdir -p "${output_dir}"
 cp "$0" "${output_dir}/"
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes "${NUM_GPUS}" \
@@ -58,4 +62,5 @@ accelerate launch \
   --trainer.eval_interval "${EVAL_EVERY}" \
   --run_root_dir "${run_root_dir}" \
   --run_id "${run_id}" \
-  --wandb_project starVLA_robocasa365
+  --wandb_project starVLA_robocasa365 \
+  "${EXTRA_ARGS[@]}"

--- a/examples/Robocasa_365/train_files/run_robocasa365_all.sh
+++ b/examples/Robocasa_365/train_files/run_robocasa365_all.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # WandB — set your own key, or run `wandb login` before launching,
 # or uncomment the line below to disable WandB entirely:
 #   export WANDB_MODE=disabled
-export WANDB_API_KEY=<your_wandb_api_key>
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
 
 # NCCL networking — uncomment and edit to match your InfiniBand / RoCE setup:
 #   export NCCL_SOCKET_IFNAME=<your_network_interface>   # e.g. eth0, bond0
@@ -50,6 +50,10 @@ output_dir=${run_root_dir}/${run_id}
 mkdir -p "${output_dir}"
 cp "$0" "${output_dir}/"
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes "${NUM_GPUS}" \
@@ -63,4 +67,5 @@ accelerate launch \
   --trainer.eval_interval "${EVAL_EVERY}" \
   --run_root_dir "${run_root_dir}" \
   --run_id "${run_id}" \
-  --wandb_project starVLA_robocasa365
+  --wandb_project starVLA_robocasa365 \
+  "${EXTRA_ARGS[@]}"

--- a/examples/Robocasa_tabletop/train_files/run_robocasa.sh
+++ b/examples/Robocasa_tabletop/train_files/run_robocasa.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -24,6 +26,10 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes 8 \
@@ -45,6 +51,6 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_robocasa \
   --wandb_entity jinhuiye \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
-
 

--- a/examples/Robocasa_tabletop/train_files/submit_robocasa_training.sh
+++ b/examples/Robocasa_tabletop/train_files/submit_robocasa_training.sh
@@ -75,7 +75,12 @@ cp $0 ${output_dir}/
 
   # --datasets.vla_data.include_state ${include_state} \
 
-srun --jobid $SLURM_JOBID bash -c 'accelerate launch \
+srun --jobid $SLURM_JOBID bash -c '
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
+accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --main_process_ip $MASTER_ADDR \
   --main_process_port $MASTER_PORT \
@@ -100,5 +105,5 @@ srun --jobid $SLURM_JOBID bash -c 'accelerate launch \
   --run_id ${run_id} \
   --wandb_project StarVLA_Robocasa \
   --wandb_entity jinhuiye \
-  --trainer.is_resume True '
-
+  --trainer.is_resume True \
+  "${EXTRA_ARGS[@]}" '

--- a/examples/Robotwin/train_files/run_robotwin_train.sh
+++ b/examples/Robotwin/train_files/run_robotwin_train.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -8,43 +10,55 @@ export NCCL_TIMEOUT=1000  # timeout set to 1 hour (unit: seconds)
 
 ###########################################################################################
 # === Please modify the following paths according to your environment ===
-Framework_name=QwenOFT
-freeze_module_list=''
-base_vlm=playground/Pretrained_models/Qwen3-VL-4B-Instruct
-config_yaml=./examples/Robotwin/train_files/starvla_cotrain_robotwin_abs.yaml
-run_root_dir=./results/Checkpoints
-data_mix=robotwin_all_50
-run_id=0129_${data_mix}_qwen3OFT_all
+Framework_name="${Framework_name:-QwenOFT}"
+freeze_module_list="${FREEZE_MODULES:-}"
+base_vlm="${BASE_VLM:-playground/Pretrained_models/Qwen3-VL-4B-Instruct}"
+config_yaml="${CONFIG_YAML:-./examples/Robotwin/train_files/starvla_cotrain_robotwin_abs.yaml}"
+run_root_dir="${RUN_ROOT_DIR:-./results/Checkpoints}"
+data_mix="${DATA_MIX:-robotwin_all_50}"
+run_id="${RUN_ID:-0129_${data_mix}_qwen3OFT_all}"
+num_processes="${NUM_PROCESSES:-8}"
+per_device_batch_size="${PER_DEVICE_BATCH_SIZE:-4}"
+max_train_steps="${MAX_TRAIN_STEPS:-150000}"
+save_interval="${SAVE_INTERVAL:-10000}"
+logging_frequency="${LOGGING_FREQUENCY:-100}"
+eval_interval="${EVAL_INTERVAL:-1000}"
 # === End of environment variable configuration ===
 ###########################################################################################
 
 
 # export WANDB_MODE=disabled
 
-output_dir=${run_root_dir}/${run_id}
-mkdir -p ${output_dir}
+output_dir="${run_root_dir}/${run_id}"
+mkdir -p "${output_dir}"
 # mv this script to the output dir
-cp $0 ${output_dir}/
+cp "$0" "${output_dir}/"
+
+EXTRA_ARGS=()
+
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
 
 
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
-  --num_processes 8 \
+  --num_processes "${num_processes}" \
   starVLA/training/train_starvla.py \
-  --config_yaml ${config_yaml} \
-  --framework.name ${Framework_name} \
-  --framework.qwenvl.base_vlm ${base_vlm} \
-  --datasets.vla_data.per_device_batch_size 4 \
-  --datasets.vla_data.data_mix ${data_mix} \
-  --trainer.freeze_modules ${freeze_module_list} \
-  --trainer.max_train_steps 150000 \
-  --trainer.save_interval 10000 \
-  --trainer.logging_frequency 100 \
-  --trainer.eval_interval 1000 \
-  --run_root_dir ${run_root_dir} \
-  --run_id ${run_id} \
+  --config_yaml "${config_yaml}" \
+  --framework.name "${Framework_name}" \
+  --framework.qwenvl.base_vlm "${base_vlm}" \
+  --datasets.vla_data.per_device_batch_size "${per_device_batch_size}" \
+  --datasets.vla_data.data_mix "${data_mix}" \
+  --trainer.freeze_modules "${freeze_module_list}" \
+  --trainer.max_train_steps "${max_train_steps}" \
+  --trainer.save_interval "${save_interval}" \
+  --trainer.logging_frequency "${logging_frequency}" \
+  --trainer.eval_interval "${eval_interval}" \
+  --run_root_dir "${run_root_dir}" \
+  --run_id "${run_id}" \
   --wandb_project starVLA_Robotwin \
   --wandb_entity axi-the-cat \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/Robotwin/train_files/run_robotwin_train_batch.sh
+++ b/examples/Robotwin/train_files/run_robotwin_train_batch.sh
@@ -53,6 +53,10 @@ srun --jobid "$SLURM_JOBID" bash -c '
   set -e
   echo "Host=$(hostname)  SLURM_PROCID=$SLURM_PROCID"
 
+  EXTRA_ARGS=()
+  source examples/common/vlm_lora_args.sh
+  append_vlm_lora_args
+
   accelerate launch \
     --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
     --main_process_ip '"$MASTER_ADDR"' \
@@ -76,5 +80,6 @@ srun --jobid "$SLURM_JOBID" bash -c '
     --run_root_dir '"$run_root_dir"' \
     --run_id '"$run_id"' \
     --wandb_project starVLA_Robotwin \
-    --wandb_entity axi-the-cat
+    --wandb_entity axi-the-cat \
+    "${EXTRA_ARGS[@]}"
 '

--- a/examples/Robotwin/train_files/starvla_cotrain_robotwin_abs.yaml
+++ b/examples/Robotwin/train_files/starvla_cotrain_robotwin_abs.yaml
@@ -12,6 +12,20 @@ framework:
     base_vlm: ./playground/Pretrained_models/Qwen3-VL-4B-Instruct
     attn_implementation: flash_attention_2
     vl_hidden_dim: 2048
+  vlm:
+    lora:
+      enabled: false
+      r: 16
+      alpha: 32
+      dropout: 0.05
+      bias: none
+      target_modules: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+      adapter_path: null
+      adapter_name: default
+      is_trainable: true
+      save_adapter_only: false
+      module_path: qwen_vl_interface.model
+      adapter_dir_name: vlm_lora_adapter
   dino:
     dino_backbone: dinov2_vits14
 

--- a/examples/SimplerEnv/train_files/run_oxe_train.sh
+++ b/examples/SimplerEnv/train_files/run_oxe_train.sh
@@ -1,5 +1,7 @@
 
 
+#!/usr/bin/env bash
+
 export NCCL_SOCKET_IFNAME=bond0
 export NCCL_IB_HCA=mlx5_2,mlx5_3
 
@@ -29,6 +31,9 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
 
 
 accelerate launch \
@@ -50,6 +55,7 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_simplerEnv \
   --wandb_entity jinhuiye \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/VLA-Arena/train_files/run_vla_arena_train.sh
+++ b/examples/VLA-Arena/train_files/run_vla_arena_train.sh
@@ -48,6 +48,10 @@ mkdir -p ${output_dir}
 # Archive this script for reproducibility
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 # ---------------------------------------------------------------------------
 # Single-node launch (8 GPUs via accelerate + DeepSpeed ZeRO-2)
 # ---------------------------------------------------------------------------
@@ -71,7 +75,8 @@ accelerate launch \
   --run_root_dir ${run_root_dir} \
   --run_id ${run_id} \
   --wandb_project starVLA_VLA_Arena \
-  --wandb_entity your_wandb_entity
+  --wandb_entity your_wandb_entity \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/calvin/train_files/run_calvin_train.sh
+++ b/examples/calvin/train_files/run_calvin_train.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # export CUDA_VISIBLE_DEVICES=0
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
@@ -32,6 +34,10 @@ mkdir -p ${output_dir}
 # mv this script to the output dir
 cp $0 ${output_dir}/
 
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes 8 \
@@ -52,6 +58,7 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project starVLA_Calvin \
   --wandb_entity your_wandb_entity \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
 
 

--- a/examples/common/vlm_lora_args.sh
+++ b/examples/common/vlm_lora_args.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Shared VLM LoRA CLI overrides for train_starvla.py launchers.
+# Call append_vlm_lora_args after declaring EXTRA_ARGS=().
+
+append_vlm_lora_args() {
+  if ! declare -p EXTRA_ARGS >/dev/null 2>&1; then
+    EXTRA_ARGS=()
+  fi
+
+  local lora_enabled_value="${VLM_LORA_ENABLED:-${LORA_ENABLED:-${USE_LORA:-}}}"
+  if [[ -n "${lora_enabled_value}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.enabled "${lora_enabled_value}")
+  fi
+
+  if [[ -n "${VLM_LORA_R:-${LORA_R:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.r "${VLM_LORA_R:-${LORA_R:-}}")
+  fi
+  if [[ -n "${VLM_LORA_ALPHA:-${LORA_ALPHA:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.alpha "${VLM_LORA_ALPHA:-${LORA_ALPHA:-}}")
+  fi
+  if [[ -n "${VLM_LORA_DROPOUT:-${LORA_DROPOUT:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.dropout "${VLM_LORA_DROPOUT:-${LORA_DROPOUT:-}}")
+  fi
+  if [[ -n "${VLM_LORA_BIAS:-${LORA_BIAS:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.bias "${VLM_LORA_BIAS:-${LORA_BIAS:-}}")
+  fi
+  if [[ -n "${VLM_LORA_TARGET_MODULES:-${LORA_TARGET_MODULES:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.target_modules "${VLM_LORA_TARGET_MODULES:-${LORA_TARGET_MODULES:-}}")
+  fi
+  if [[ -n "${VLM_LORA_ADAPTER_PATH:-${LORA_ADAPTER_PATH:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.adapter_path "${VLM_LORA_ADAPTER_PATH:-${LORA_ADAPTER_PATH:-}}")
+  fi
+  if [[ -n "${VLM_LORA_ADAPTER_NAME:-${LORA_ADAPTER_NAME:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.adapter_name "${VLM_LORA_ADAPTER_NAME:-${LORA_ADAPTER_NAME:-}}")
+  fi
+  if [[ -n "${VLM_LORA_IS_TRAINABLE:-${LORA_IS_TRAINABLE:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.is_trainable "${VLM_LORA_IS_TRAINABLE:-${LORA_IS_TRAINABLE:-}}")
+  fi
+  if [[ -n "${VLM_LORA_SAVE_ADAPTER_ONLY:-${LORA_SAVE_ADAPTER_ONLY:-}}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.save_adapter_only "${VLM_LORA_SAVE_ADAPTER_ONLY:-${LORA_SAVE_ADAPTER_ONLY:-}}")
+  fi
+  if [[ -n "${VLM_LORA_MODULE_PATH:-}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.module_path "${VLM_LORA_MODULE_PATH}")
+  fi
+  if [[ -n "${VLM_LORA_ADAPTER_DIR_NAME:-}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.adapter_dir_name "${VLM_LORA_ADAPTER_DIR_NAME}")
+  fi
+  if [[ -n "${VLM_LORA_TASK_TYPE:-}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.task_type "${VLM_LORA_TASK_TYPE}")
+  fi
+  if [[ -n "${VLM_LORA_MODULES_TO_SAVE:-}" ]]; then
+    EXTRA_ARGS+=(--framework.vlm.lora.modules_to_save "${VLM_LORA_MODULES_TO_SAVE}")
+  fi
+
+  local lora_lr="${VLM_LORA_LR:-${LORA_LR:-}}"
+  if [[ -n "${lora_lr}" ]]; then
+    local lora_lr_module="${VLM_LORA_LR_MODULE:-qwen_vl_interface}"
+    EXTRA_ARGS+=("--trainer.learning_rate.${lora_lr_module}" "${lora_lr}")
+  fi
+}

--- a/examples/modelExtensions/NeuralVLA/run_libero_train_yibu.sh
+++ b/examples/modelExtensions/NeuralVLA/run_libero_train_yibu.sh
@@ -1,4 +1,6 @@
 
+#!/usr/bin/env bash
+
 # export HF_HOME=/mnt/petrelfs/share/yejinhui/Models/huggingface_cache
 
 # export NCCL_SOCKET_IFNAME=bond0
@@ -29,6 +31,11 @@ framework_name=NeuroVLA
 dataset_py=lerobot_datasets
 data_mix=libero_goal
 action_chunk=4
+
+EXTRA_ARGS=()
+source examples/common/vlm_lora_args.sh
+append_vlm_lora_args
+
 accelerate launch \
   --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
   --num_processes 4 \
@@ -48,6 +55,6 @@ accelerate launch \
   --run_id ${run_id} \
   --wandb_project spikeVLA-MLP \
   --wandb_entity weiyuguo \
+  "${EXTRA_ARGS[@]}"
   # --is_debug True
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ numpy==1.26.4
 wandb
 rich
 diffusers
+peft
 timm
 tyro
 websockets

--- a/starVLA/config/deepseeds/deepspeed_lora_zero1.yaml
+++ b/starVLA/config/deepseeds/deepspeed_lora_zero1.yaml
@@ -1,0 +1,19 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  deepspeed_config_file: "./starVLA/config/deepseeds/ds_config_lora_zero1.json"
+  deepspeed_multinode_launcher: standard
+  zero3_init_flag: false
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/starVLA/config/deepseeds/ds_config_lora_zero1.json
+++ b/starVLA/config/deepseeds/ds_config_lora_zero1.json
@@ -1,0 +1,20 @@
+{
+  "fp16": {
+    "enabled": false
+  },
+  "bf16": {
+    "enabled": true
+  },
+  "train_micro_batch_size_per_gpu": "auto",
+  "train_batch_size": "auto",
+  "gradient_accumulation_steps": "auto",
+  "zero_optimization": {
+    "stage": 1,
+    "reduce_bucket_size": 20000000.0,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "cpu_offload": false
+  },
+  "gradient_clipping": "auto",
+  "steps_per_print": 100000
+}

--- a/starVLA/model/framework/base_framework.py
+++ b/starVLA/model/framework/base_framework.py
@@ -16,6 +16,13 @@ import torch
 from transformers import PretrainedConfig, PreTrainedModel
 
 from starVLA.model.framework.share_tools import dict_to_namespace, read_mode_config
+from starVLA.model.modules.vlm.lora_utils import (
+    apply_lora_to_vlm_backbone,
+    get_lora_settings,
+    inject_lora_adapter_path,
+    is_lora_enabled,
+    resolve_vlm_lora_adapter_dir,
+)
 from starVLA.model.tools import FRAMEWORK_REGISTRY, FrameworkTools, auto_get_trainable_modules
 from starVLA.training.trainer_utils import initialize_overwatch
 
@@ -235,10 +242,27 @@ class baseframework(PreTrainedModel):
         config = dict_to_namespace(model_config)
         model_config = config
         model_config.trainer.pretrained_checkpoint = None
-        
+
+        adapter_dir = cls._resolve_lora_adapter_dir(pretrained_checkpoint)
+        lora_was_enabled = is_lora_enabled(model_config)
+        if lora_was_enabled and adapter_dir is not None:
+            try:
+                inject_lora_adapter_path(model_config, adapter_dir, is_trainable=False)
+            except Exception as exc:
+                logger.warning(f"Failed to inject LoRA adapter_path into config: {exc}")
+
         FrameworkModel = build_framework(cfg=model_config)
         # set for action un-norm
         FrameworkModel.norm_stats = norm_stats
+
+        # PEFT LoRA changes state_dict key structure, so wrap before loading.
+        if lora_was_enabled:
+            FrameworkModel, _ = apply_lora_to_vlm_backbone(
+                FrameworkModel,
+                model_config,
+                logger=logger,
+            )
+
         # Load from Checkpoint (Custom --> should load both *projector* and *llm* weights)
         if pretrained_checkpoint.suffix == ".safetensors":
             from safetensors.torch import load_file
@@ -249,8 +273,9 @@ class baseframework(PreTrainedModel):
         # logger.info(f"Loading model weights from `{pretrained_checkpoint}`")
         model_keys = set(FrameworkModel.state_dict().keys())
         checkpoint_keys = set(model_state_dict.keys())
+        use_strict = not lora_was_enabled
         try:
-            FrameworkModel.load_state_dict(model_state_dict, strict=True)
+            missing_keys, unexpected_keys = FrameworkModel.load_state_dict(model_state_dict, strict=use_strict)
         except RuntimeError as e:
             # must keep all keys matched
             common_keys = model_keys.intersection(checkpoint_keys)
@@ -263,7 +288,35 @@ class baseframework(PreTrainedModel):
 
             raise e
 
+        if not use_strict:
+            unexpected_keys = list(unexpected_keys) if unexpected_keys else []
+            missing_keys = list(missing_keys) if missing_keys else []
+            if unexpected_keys:
+                raise RuntimeError(
+                    f"Unexpected keys when loading LoRA checkpoint (likely a model/ckpt mismatch): {unexpected_keys[:10]}..."
+                )
+            if missing_keys:
+                logger.warning(
+                    f"{len(missing_keys)} keys missing from LoRA checkpoint (using model defaults): "
+                    f"{missing_keys[:10]}..."
+                )
+            logger.info(
+                f"LoRA checkpoint loaded ({len(model_state_dict)} tensors); "
+                f"adapter_dir={'found' if adapter_dir is not None else 'absent'}."
+            )
+
         # **ensure model is on GPU**
         FrameworkModel = FrameworkModel
         return FrameworkModel
 
+    @staticmethod
+    def _resolve_lora_adapter_dir(pretrained_checkpoint: Path) -> "Path | None":
+        try:
+            model_config, _ = read_mode_config(pretrained_checkpoint)
+            settings = get_lora_settings(dict_to_namespace(model_config))
+            return resolve_vlm_lora_adapter_dir(
+                pretrained_checkpoint,
+                adapter_dir_name=settings.adapter_dir_name,
+            )
+        except Exception:
+            return resolve_vlm_lora_adapter_dir(pretrained_checkpoint)

--- a/starVLA/model/modules/vlm/lora_utils.py
+++ b/starVLA/model/modules/vlm/lora_utils.py
@@ -1,0 +1,414 @@
+"""Utilities for optional VLM backbone LoRA fine-tuning.
+
+Keep PEFT imports inside enabled LoRA paths so the repository remains importable
+when PEFT is not installed and LoRA is disabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterable, Optional
+
+
+DEFAULT_QWEN_TARGET_MODULES = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+]
+
+# Backward-compatible name used by the earlier Qwen-only LoRA implementation.
+DEFAULT_TARGET_MODULES = DEFAULT_QWEN_TARGET_MODULES
+
+DEFAULT_VLM_MODULE_PATH = "qwen_vl_interface.model"
+DEFAULT_ADAPTER_DIR_NAME = "vlm_lora_adapter"
+LEGACY_ADAPTER_DIR_NAME = "qwen_lora_adapter"
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class LoraSettings:
+    enabled: bool = False
+    adapter_path: Optional[str] = None
+    adapter_name: str = "default"
+    r: int = 16
+    alpha: int = 32
+    dropout: float = 0.05
+    bias: str = "none"
+    target_modules: list[str] | str | None = None
+    is_trainable: bool = True
+    save_adapter_only: bool = False
+    module_path: str = DEFAULT_VLM_MODULE_PATH
+    adapter_dir_name: str = DEFAULT_ADAPTER_DIR_NAME
+    task_type: Optional[str] = "CAUSAL_LM"
+    modules_to_save: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.target_modules is None:
+            object.__setattr__(self, "target_modules", list(DEFAULT_QWEN_TARGET_MODULES))
+        if not self.module_path:
+            object.__setattr__(self, "module_path", DEFAULT_VLM_MODULE_PATH)
+        if not self.adapter_dir_name:
+            object.__setattr__(self, "adapter_dir_name", DEFAULT_ADAPTER_DIR_NAME)
+
+
+def _get_value(container: Any, key: str, default: Any = None) -> Any:
+    if container is None:
+        return default
+    if hasattr(container, "get"):
+        try:
+            return container.get(key, default)
+        except Exception:
+            pass
+    if isinstance(container, dict):
+        return container.get(key, default)
+    try:
+        return getattr(container, key)
+    except AttributeError:
+        return default
+
+
+def _set_value(container: Any, key: str, value: Any) -> None:
+    if isinstance(container, dict):
+        container[key] = value
+        return
+    try:
+        container[key] = value
+        return
+    except Exception:
+        pass
+    setattr(container, key, value)
+
+
+def _get_nested(container: Any, path: Iterable[str], default: Any = None) -> Any:
+    current = container
+    for key in path:
+        current = _get_value(current, key, default)
+        if current is default:
+            return default
+    return current
+
+
+def _ensure_child(container: Any, key: str) -> Any:
+    child = _get_value(container, key, _MISSING)
+    if child is not _MISSING and child is not None:
+        return child
+
+    if isinstance(container, SimpleNamespace):
+        new_child: Any = SimpleNamespace()
+    else:
+        new_child = {}
+    _set_value(container, key, new_child)
+    return _get_value(container, key, new_child)
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _as_target_modules(value: Any) -> list[str] | str:
+    if value is None:
+        return list(DEFAULT_QWEN_TARGET_MODULES)
+    if isinstance(value, str):
+        value = value.strip()
+        if value == "all-linear":
+            return value
+        return [module.strip() for module in value.split(",") if module.strip()]
+    return [str(module).strip() for module in value if str(module).strip()]
+
+
+def _as_optional_list(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value or value.lower() in {"none", "null"}:
+            return None
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _lora_config_path(cfg: Any) -> tuple[str, str, str]:
+    canonical = _get_nested(cfg, ("framework", "vlm", "lora"), default=_MISSING)
+    if canonical is not _MISSING:
+        return ("framework", "vlm", "lora")
+
+    legacy = _get_nested(cfg, ("framework", "qwenvl", "lora"), default=_MISSING)
+    if legacy is not _MISSING:
+        return ("framework", "qwenvl", "lora")
+
+    return ("framework", "vlm", "lora")
+
+
+def _get_lora_config(cfg: Any) -> Any:
+    return _get_nested(cfg, _lora_config_path(cfg), default=None)
+
+
+def get_lora_settings(cfg: Any) -> LoraSettings:
+    """Return normalized LoRA settings from VLM LoRA config.
+
+    ``framework.vlm.lora`` is the canonical path. ``framework.qwenvl.lora`` is
+    accepted as a compatibility fallback for existing configs and checkpoints.
+    """
+
+    lora_cfg = _get_lora_config(cfg)
+    return LoraSettings(
+        enabled=_as_bool(_get_value(lora_cfg, "enabled", False)),
+        adapter_path=_get_value(lora_cfg, "adapter_path", None),
+        adapter_name=str(_get_value(lora_cfg, "adapter_name", "default")),
+        r=int(_get_value(lora_cfg, "r", 16)),
+        alpha=int(_get_value(lora_cfg, "alpha", 32)),
+        dropout=float(_get_value(lora_cfg, "dropout", 0.05)),
+        bias=str(_get_value(lora_cfg, "bias", "none")),
+        target_modules=_as_target_modules(_get_value(lora_cfg, "target_modules", None)),
+        is_trainable=_as_bool(_get_value(lora_cfg, "is_trainable", True)),
+        save_adapter_only=_as_bool(_get_value(lora_cfg, "save_adapter_only", False)),
+        module_path=str(_get_value(lora_cfg, "module_path", DEFAULT_VLM_MODULE_PATH)),
+        adapter_dir_name=str(_get_value(lora_cfg, "adapter_dir_name", DEFAULT_ADAPTER_DIR_NAME)),
+        task_type=_get_value(lora_cfg, "task_type", "CAUSAL_LM"),
+        modules_to_save=_as_optional_list(_get_value(lora_cfg, "modules_to_save", None)),
+    )
+
+
+def is_lora_enabled(cfg: Any) -> bool:
+    return get_lora_settings(cfg).enabled
+
+
+def inject_lora_adapter_path(cfg: Any, adapter_path: str | Path, *, is_trainable: bool) -> None:
+    """Inject an adapter path into the config path that LoRA settings use."""
+
+    framework = _ensure_child(cfg, "framework")
+    _, framework_key, lora_key = _lora_config_path(cfg)
+    framework_section = _ensure_child(framework, framework_key)
+    lora_section = _ensure_child(framework_section, lora_key)
+    _set_value(lora_section, "enabled", True)
+    _set_value(lora_section, "adapter_path", str(adapter_path))
+    _set_value(lora_section, "is_trainable", is_trainable)
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
+    seen = set()
+    result = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(path)
+    return result
+
+
+def resolve_vlm_lora_adapter_dir(
+    pretrained_checkpoint: str | Path,
+    adapter_dir_name: str = DEFAULT_ADAPTER_DIR_NAME,
+) -> Path | None:
+    """Locate the PEFT adapter folder saved alongside supported checkpoints.
+
+    Generic ``vlm_lora_adapter`` directories are preferred. Legacy
+    ``qwen_lora_adapter`` directories remain load-compatible.
+    """
+
+    ckpt = Path(pretrained_checkpoint)
+    candidates = []
+
+    if ckpt.is_dir() and (
+        ckpt.name.endswith(f"_{adapter_dir_name}")
+        or ckpt.name.endswith(f"_{DEFAULT_ADAPTER_DIR_NAME}")
+        or ckpt.name.endswith(f"_{LEGACY_ADAPTER_DIR_NAME}")
+        or ckpt.name in {adapter_dir_name, DEFAULT_ADAPTER_DIR_NAME, LEGACY_ADAPTER_DIR_NAME}
+        or (ckpt / "adapter_config.json").is_file()
+    ):
+        return ckpt
+
+    if ckpt.is_dir():
+        candidates.extend(
+            [
+                ckpt / adapter_dir_name,
+                ckpt / DEFAULT_ADAPTER_DIR_NAME,
+                ckpt / LEGACY_ADAPTER_DIR_NAME,
+            ]
+        )
+
+    stem = ckpt.stem
+    for suffix in ("_pytorch_model", "_model"):
+        if stem.endswith(suffix):
+            base = stem[: -len(suffix)]
+            candidates.extend(
+                [
+                    ckpt.with_name(f"{base}_{adapter_dir_name}"),
+                    ckpt.with_name(f"{base}_{DEFAULT_ADAPTER_DIR_NAME}"),
+                    ckpt.with_name(f"{base}_{LEGACY_ADAPTER_DIR_NAME}"),
+                ]
+            )
+
+    if stem in {"pytorch_model", "model"}:
+        candidates.extend(
+            [
+                ckpt.with_name(adapter_dir_name),
+                ckpt.with_name(DEFAULT_ADAPTER_DIR_NAME),
+                ckpt.with_name(LEGACY_ADAPTER_DIR_NAME),
+            ]
+        )
+
+    candidates.extend(
+        [
+            ckpt.with_name(f"{stem}_{adapter_dir_name}"),
+            ckpt.with_name(f"{stem}_{DEFAULT_ADAPTER_DIR_NAME}"),
+            ckpt.with_name(f"{stem}_{LEGACY_ADAPTER_DIR_NAME}"),
+        ]
+    )
+
+    for candidate in _dedupe_paths(candidates):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def resolve_qwen_lora_adapter_dir(pretrained_checkpoint: str | Path) -> Path | None:
+    """Backward-compatible alias for the generic VLM adapter resolver."""
+
+    return resolve_vlm_lora_adapter_dir(pretrained_checkpoint)
+
+
+def _get_child(obj: Any, key: str) -> Any:
+    if hasattr(obj, key):
+        return getattr(obj, key)
+    try:
+        return obj[key]
+    except Exception as exc:
+        raise AttributeError(f"LoRA enabled, but `{type(obj).__name__}` has no child `{key}`") from exc
+
+
+def _set_child(obj: Any, key: str, value: Any) -> None:
+    try:
+        setattr(obj, key, value)
+        return
+    except Exception:
+        pass
+    try:
+        obj[key] = value
+        return
+    except Exception as exc:
+        raise AttributeError(f"LoRA enabled, but cannot set child `{key}` on `{type(obj).__name__}`") from exc
+
+
+def _resolve_module_path(root: Any, module_path: str) -> tuple[Any, str, Any]:
+    parts = [part for part in module_path.split(".") if part]
+    if not parts:
+        raise ValueError("framework.vlm.lora.module_path must not be empty")
+
+    parent = root
+    for part in parts[:-1]:
+        parent = _get_child(parent, part)
+    attr = parts[-1]
+    module = _get_child(parent, attr)
+    if module is None:
+        raise AttributeError(f"LoRA enabled, but `{module_path}` resolved to None")
+    return parent, attr, module
+
+
+def _task_type_value(task_type: Optional[str], TaskType: Any) -> Any:
+    if task_type is None:
+        return None
+    task_type = str(task_type).strip()
+    if not task_type or task_type.lower() in {"none", "null"}:
+        return None
+    return getattr(TaskType, task_type, task_type)
+
+
+def apply_lora_to_vlm_backbone(vla_model: Any, cfg: Any, logger: Any = None) -> tuple[Any, LoraSettings]:
+    """Wrap a configured VLM backbone module with a PEFT LoRA adapter."""
+
+    settings = get_lora_settings(cfg)
+    if not settings.enabled:
+        return vla_model, settings
+
+    parent, module_attr, base_vlm_model = _resolve_module_path(vla_model, settings.module_path)
+
+    try:
+        from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+    except ImportError as exc:
+        raise ImportError(
+            "framework.vlm.lora.enabled=true requires the optional 'peft' package. "
+            "Install it with the project requirements or disable LoRA."
+        ) from exc
+
+    if settings.adapter_path:
+        wrapped_vlm_model = PeftModel.from_pretrained(
+            base_vlm_model,
+            settings.adapter_path,
+            adapter_name=settings.adapter_name,
+            is_trainable=settings.is_trainable,
+        )
+        message = f"Loaded VLM LoRA adapter from {settings.adapter_path}"
+    else:
+        lora_kwargs = {
+            "r": settings.r,
+            "lora_alpha": settings.alpha,
+            "lora_dropout": settings.dropout,
+            "bias": settings.bias,
+            "target_modules": settings.target_modules,
+        }
+        task_type = _task_type_value(settings.task_type, TaskType)
+        if task_type is not None:
+            lora_kwargs["task_type"] = task_type
+        if settings.modules_to_save is not None:
+            lora_kwargs["modules_to_save"] = settings.modules_to_save
+
+        peft_config = LoraConfig(**lora_kwargs)
+        wrapped_vlm_model = get_peft_model(
+            base_vlm_model,
+            peft_config,
+            adapter_name=settings.adapter_name,
+        )
+        if not settings.is_trainable:
+            for param in wrapped_vlm_model.parameters():
+                param.requires_grad = False
+        message = (
+            "Initialized VLM LoRA adapter "
+            f"path={settings.module_path}, name={settings.adapter_name}, r={settings.r}, alpha={settings.alpha}"
+        )
+
+    _set_child(parent, module_attr, wrapped_vlm_model)
+    if logger is not None:
+        logger.info(message)
+    return vla_model, settings
+
+
+def apply_lora_to_qwen_vl_interface(vla_model: Any, cfg: Any, logger: Any = None) -> tuple[Any, LoraSettings]:
+    """Backward-compatible alias for VLM backbone LoRA wrapping."""
+
+    return apply_lora_to_vlm_backbone(vla_model, cfg, logger=logger)
+
+
+def save_vlm_lora_adapter(
+    vla_model: Any,
+    output_dir: str,
+    adapter_name: Optional[str] = None,
+    module_path: str = DEFAULT_VLM_MODULE_PATH,
+) -> None:
+    """Save the PEFT adapter attached to the configured VLM backbone module."""
+
+    _, _, vlm_model = _resolve_module_path(vla_model, module_path)
+    if adapter_name:
+        try:
+            vlm_model.save_pretrained(output_dir, selected_adapters=[adapter_name])
+            return
+        except TypeError:
+            pass
+    vlm_model.save_pretrained(output_dir)
+
+
+def save_qwen_lora_adapter(vla_model: Any, output_dir: str, adapter_name: Optional[str] = None) -> None:
+    """Backward-compatible alias for saving VLM backbone LoRA adapters."""
+
+    save_vlm_lora_adapter(vla_model, output_dir, adapter_name=adapter_name)

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -16,7 +16,6 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Tuple
 
 # Third-Party Libraries
 import numpy as np
@@ -38,14 +37,25 @@ from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoProcessor, get_scheduler
+from transformers import AutoProcessor
 
 # Local Modules
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.model.framework.share_tools import apply_config_compat
+from starVLA.model.modules.vlm.lora_utils import (
+    apply_lora_to_vlm_backbone,
+    get_lora_settings,
+    inject_lora_adapter_path,
+    resolve_vlm_lora_adapter_dir,
+    save_vlm_lora_adapter,
+)
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
-from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
+from starVLA.training.trainer_utils.trainer_tools import (
+    TrainerUtils,
+    normalize_dotlist_args,
+    setup_optimizer_and_scheduler,
+)
 
 deepspeed_plugin = DeepSpeedPlugin()
 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
@@ -56,6 +66,23 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Initialize logger
 logger = get_logger(__name__)
+
+
+def _strip_lora_module_from_freeze_modules(freeze_modules, module_path):
+    """Keep LoRA adapter params trainable when the base VLM module is frozen."""
+    if not isinstance(freeze_modules, str) or not freeze_modules.strip():
+        return freeze_modules
+
+    top_level_module = module_path.split(".", 1)[0]
+    keep_patterns = []
+    for pattern in freeze_modules.split(","):
+        pattern = pattern.strip()
+        if not pattern:
+            continue
+        if pattern == top_level_module or pattern.startswith(f"{top_level_module}."):
+            continue
+        keep_patterns.append(pattern)
+    return ",".join(keep_patterns)
 
 
 def load_fast_tokenizer():
@@ -84,35 +111,6 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     return vla_train_dataloader
 
 
-def setup_optimizer_and_scheduler(model, cfg) -> Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler._LRScheduler]:
-    """Set optimizer and scheduler."""
-    param_groups = build_param_lr_groups(model=model, cfg=cfg)
-    optimizer = torch.optim.AdamW(
-        param_groups,
-        lr=cfg.trainer.learning_rate.base,
-        betas=tuple(cfg.trainer.optimizer.betas),
-        weight_decay=cfg.trainer.optimizer.weight_decay,
-        eps=cfg.trainer.optimizer.eps,
-        fused=True,
-    )
-
-    if dist.is_initialized() and dist.get_rank() == 0:
-        for group in optimizer.param_groups:
-            logger.info(f"LR Group {group['name']}: lr={group['lr']}, num_params={len(group['params'])}")
-
-    # Strip keys unknown to transformers' get_scheduler before passing kwargs.
-    sched_kwargs = {k: v for k, v in cfg.trainer.scheduler_specific_kwargs.items()}
-    lr_scheduler = get_scheduler(
-        name=cfg.trainer.lr_scheduler_type,
-        optimizer=optimizer,
-        num_warmup_steps=cfg.trainer.num_warmup_steps,
-        num_training_steps=cfg.trainer.max_train_steps,
-        scheduler_specific_kwargs=sched_kwargs,
-    )
-
-    return optimizer, lr_scheduler
-
-
 class VLATrainer(TrainerUtils):
     def __init__(self, cfg, model, vla_train_dataloader, optimizer, lr_scheduler, accelerator):
         self.config = cfg
@@ -121,6 +119,8 @@ class VLATrainer(TrainerUtils):
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
         self.accelerator = accelerator
+        self.lora_settings = get_lora_settings(cfg)
+        self._deferred_lora_checkpoint_load = None
 
         self.completed_steps = 0
         self.total_batch_size = self._calculate_total_batch_size()
@@ -136,7 +136,6 @@ class VLATrainer(TrainerUtils):
         self._save_initial_configs()
 
         self._init_checkpointing()
-        self._adjust_lr_scheduler_for_resume()
 
         freeze_modules = (
             self.config.trainer.freeze_modules
@@ -144,6 +143,32 @@ class VLATrainer(TrainerUtils):
             else None
         )
         self.model = self.freeze_backbones(self.model, freeze_modules=freeze_modules)
+
+        # LoRA is injected after checkpoint loading/freezing and before
+        # accelerator.prepare so PEFT adapter params are visible to optimizer setup.
+        self.model, self.lora_settings = apply_lora_to_vlm_backbone(
+            self.model,
+            self.config,
+            logger=logger,
+        )
+        self._load_deferred_lora_checkpoint()
+        if self.lora_settings.enabled:
+            optimizer_freeze_modules = _strip_lora_module_from_freeze_modules(
+                self.config.trainer.get("freeze_modules", ""),
+                self.lora_settings.module_path,
+            )
+            if optimizer_freeze_modules != self.config.trainer.get("freeze_modules", ""):
+                logger.info(
+                    "Ignoring VLM backbone freeze pattern while rebuilding the LoRA optimizer; "
+                    "PEFT keeps the base VLM weights frozen and exposes adapter parameters."
+                )
+                self.config.trainer.freeze_modules = optimizer_freeze_modules
+
+        if self.lora_settings.enabled or self.optimizer is None or self.lr_scheduler is None:
+            self.optimizer, self.lr_scheduler = setup_optimizer_and_scheduler(model=self.model, cfg=self.config)
+
+        self._adjust_lr_scheduler_for_resume()
+
         self.print_trainable_parameters(self.model)
 
         self.model, self.optimizer, self.vla_train_dataloader = self.setup_distributed_training(
@@ -208,7 +233,15 @@ class VLATrainer(TrainerUtils):
             resume_from_checkpoint, self.completed_steps = self._get_latest_checkpoint(self.checkpoint_dir)
             if resume_from_checkpoint:
                 self.resume_from_checkpoint = resume_from_checkpoint
-                self.model = self.load_pretrained_backbones(self.model, self.resume_from_checkpoint, reload_modules=None)
+                if not self._defer_lora_checkpoint_load_if_needed(
+                    self.resume_from_checkpoint,
+                    reload_modules=None,
+                ):
+                    self.model = self.load_pretrained_backbones(
+                        self.model,
+                        self.resume_from_checkpoint,
+                        reload_modules=None,
+                    )
                 logger.info(
                     f"Resuming training from checkpoint: {self.resume_from_checkpoint}, steps: {self.completed_steps}"
                 )
@@ -219,13 +252,59 @@ class VLATrainer(TrainerUtils):
 
         if pretrained_checkpoint:
             reload_modules = getattr(self.config.trainer, "reload_modules", None)
-            self.model = self.load_pretrained_backbones(self.model, pretrained_checkpoint, reload_modules=reload_modules)
+            if not self._defer_lora_checkpoint_load_if_needed(pretrained_checkpoint, reload_modules=reload_modules):
+                self.model = self.load_pretrained_backbones(
+                    self.model,
+                    pretrained_checkpoint,
+                    reload_modules=reload_modules,
+                )
             self.completed_steps = 0
             self.resume_from_checkpoint = pretrained_checkpoint
             logger.info(f"Loaded pretrained checkpoint: {pretrained_checkpoint}, steps: {self.completed_steps}")
         else:
             logger.info("No pretrained checkpoint provided. Starting training from scratch.")
             self.completed_steps = 0
+
+    def _defer_lora_checkpoint_load_if_needed(self, checkpoint_path, reload_modules):
+        """Delay LoRA checkpoint loading until PEFT has wrapped the VLM model."""
+
+        settings = get_lora_settings(self.config)
+        if not settings.enabled:
+            return False
+
+        adapter_dir = resolve_vlm_lora_adapter_dir(checkpoint_path, adapter_dir_name=settings.adapter_dir_name)
+        if adapter_dir is None or settings.adapter_path:
+            return False
+
+        inject_lora_adapter_path(self.config, adapter_dir, is_trainable=True)
+        adapter_only_checkpoint = Path(checkpoint_path).is_dir() and Path(checkpoint_path).resolve() == adapter_dir.resolve()
+        self._deferred_lora_checkpoint_load = (
+            None if adapter_only_checkpoint else checkpoint_path,
+            reload_modules,
+        )
+        logger.info(
+            "Detected sibling VLM LoRA adapter at "
+            f"{adapter_dir}; deferring checkpoint load until after PEFT wrapping."
+        )
+        return True
+
+    def _load_deferred_lora_checkpoint(self):
+        if self._deferred_lora_checkpoint_load is None:
+            return
+
+        checkpoint_path, reload_modules = self._deferred_lora_checkpoint_load
+        if checkpoint_path is None:
+            self._deferred_lora_checkpoint_load = None
+            logger.info("Loaded deferred adapter-only LoRA checkpoint after PEFT wrapping.")
+            return
+
+        self.model = self.load_pretrained_backbones(
+            self.model,
+            checkpoint_path,
+            reload_modules=reload_modules,
+        )
+        self._deferred_lora_checkpoint_load = None
+        logger.info(f"Loaded deferred LoRA checkpoint after PEFT wrapping: {checkpoint_path}")
 
     def _adjust_lr_scheduler_for_resume(self):
         """Adjust LR scheduler state after resuming from non-zero steps."""
@@ -248,15 +327,19 @@ class VLATrainer(TrainerUtils):
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
 
-            state_dict = self.accelerator.get_state_dict(self.model)
-            if save_format == "safetensors":
-                from safetensors.torch import save_file
+            if self._should_save_full_checkpoint():
+                state_dict = self.accelerator.get_state_dict(self.model)
+                if save_format == "safetensors":
+                    from safetensors.torch import save_file
 
-                save_file(state_dict, checkpoint_path + "_model.safetensors")
-            elif save_format == "pt":
-                torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
+                    save_file(state_dict, checkpoint_path + "_model.safetensors")
+                elif save_format == "pt":
+                    torch.save(state_dict, checkpoint_path + "_pytorch_model.pt")
+                else:
+                    raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
             else:
-                raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
+                logger.info("Skipping full model checkpoint because LoRA save_adapter_only=true.")
+            self._save_lora_adapter(f"{checkpoint_path}_{self.lora_settings.adapter_dir_name}")
 
             summary_data = {"steps": self.completed_steps}
             with open(os.path.join(self.config.output_dir, "summary.jsonl"), "a") as f:
@@ -270,6 +353,21 @@ class VLATrainer(TrainerUtils):
                 logger.info("✅ Configuration files saved")
 
         self.accelerator.wait_for_everyone()
+
+    def _should_save_full_checkpoint(self) -> bool:
+        return not (self.lora_settings.enabled and self.lora_settings.save_adapter_only)
+
+    def _save_lora_adapter(self, adapter_dir):
+        if not self.lora_settings.enabled:
+            return
+        unwrapped_model = self.accelerator.unwrap_model(self.model)
+        save_vlm_lora_adapter(
+            unwrapped_model,
+            adapter_dir,
+            adapter_name=self.lora_settings.adapter_name,
+            module_path=self.lora_settings.module_path,
+        )
+        logger.info(f"LoRA adapter saved at {adapter_dir}")
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
@@ -408,15 +506,19 @@ class VLATrainer(TrainerUtils):
             save_format = getattr(self.config.trainer, "save_format", "pt")
             final_checkpoint = os.path.join(self.config.output_dir, "final_model")
             os.makedirs(final_checkpoint, exist_ok=True)
-            state_dict = self.accelerator.get_state_dict(self.model)
-            if save_format == "safetensors":
-                from safetensors.torch import save_file
+            if self._should_save_full_checkpoint():
+                state_dict = self.accelerator.get_state_dict(self.model)
+                if save_format == "safetensors":
+                    from safetensors.torch import save_file
 
-                save_file(state_dict, os.path.join(final_checkpoint, "model.safetensors"))
-            elif save_format == "pt":
-                torch.save(state_dict, os.path.join(final_checkpoint, "pytorch_model.pt"))
+                    save_file(state_dict, os.path.join(final_checkpoint, "model.safetensors"))
+                elif save_format == "pt":
+                    torch.save(state_dict, os.path.join(final_checkpoint, "pytorch_model.pt"))
+                else:
+                    raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
             else:
-                raise ValueError(f"Unsupported save_format `{save_format}`. Expected `pt` or `safetensors`.")
+                logger.info("Skipping full final model save because LoRA save_adapter_only=true.")
+            self._save_lora_adapter(os.path.join(final_checkpoint, self.lora_settings.adapter_dir_name))
             logger.info(f"Training complete. Final model saved at {final_checkpoint}")
 
         if self.accelerator.is_main_process:

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -128,8 +128,8 @@ def build_param_lr_groups(model, cfg):
         try:
             for attr in module_name.split("."):
                 module = getattr(module, attr)
-            # filter out frozen parameters
-            params = [p for p in module.parameters() if id(p) not in frozen_params]
+            # Filter out explicitly frozen params and PEFT-frozen base weights.
+            params = [p for p in module.parameters() if p.requires_grad and id(p) not in frozen_params]
             if params:  # only add param group if there are trainable parameters
                 param_groups.append({"params": params, "lr": lr, "name": module_name})
                 used_params.update(id(p) for p in params)
@@ -137,7 +137,9 @@ def build_param_lr_groups(model, cfg):
             ReferenceError(f"⚠️ module path `{module_name}` not found in vla")
 
     # assign base learning rate to the remaining unused parameters (exclude frozen ones)
-    other_params = [p for p in model.parameters() if id(p) not in used_params and id(p) not in frozen_params]
+    other_params = [
+        p for p in model.parameters() if p.requires_grad and id(p) not in used_params and id(p) not in frozen_params
+    ]
     if other_params:
         param_groups.append({"params": other_params, "lr": base_lr, "name": "base"})
 
@@ -505,30 +507,30 @@ class TrainerUtils:
             self.accelerator.print(f"No checkpoint directory found at {checkpoint_dir}")
             return None, 0
 
-        # Find all checkpoints matching the naming convention, supports .pt and .safetensors
-        checkpoints = [
-            f for f in os.listdir(checkpoint_dir) 
-            if re.match(r"steps_(\d+)_(?:pytorch_model\.pt|model\.safetensors)$", f)
-            and os.path.isfile(os.path.join(checkpoint_dir, f))  # ensure it is a file
-        ]
+        # Find all checkpoints matching the naming convention. Prefer full
+        # checkpoint files over same-step adapter-only LoRA directories.
+        checkpoint_pattern = r"steps_(\d+)_(?:pytorch_model\.pt|model\.safetensors)$"
+        adapter_pattern = r"steps_(\d+)_(?:vlm_lora_adapter|qwen_lora_adapter)$"
+        checkpoints_with_steps = []
+        for entry in os.listdir(checkpoint_dir):
+            entry_path = os.path.join(checkpoint_dir, entry)
+            checkpoint_match = re.match(checkpoint_pattern, entry)
+            if checkpoint_match and os.path.isfile(entry_path):
+                checkpoints_with_steps.append((entry, int(checkpoint_match.group(1)), 1))
+                continue
 
-        if not checkpoints:
+            adapter_match = re.match(adapter_pattern, entry)
+            if adapter_match and os.path.isdir(entry_path):
+                checkpoints_with_steps.append((entry, int(adapter_match.group(1)), 0))
+
+        if not checkpoints_with_steps:
             self.accelerator.print(f"No checkpoints found in {checkpoint_dir}")
             return None, 0
 
-        # Extract step numbers and sort
-        try:
-            checkpoints_with_steps = [
-                (ckpt, int(re.search(r"steps_(\d+)_(?:pytorch_model\.pt|model\.safetensors)$", ckpt).group(1)))
-                for ckpt in checkpoints
-            ]
-        except AttributeError as e:
-            self.accelerator.print(f"Error parsing checkpoint filenames: {e}")
-            return None, 0
-
-        # Sort by step number and get the latest checkpoint
-        checkpoints_with_steps.sort(key=lambda x: x[1])
-        latest_checkpoint, completed_steps = checkpoints_with_steps[-1]
+        # Sort by step number, then prefer full checkpoint files over
+        # adapter-only directories when both exist for the same step.
+        checkpoints_with_steps.sort(key=lambda x: (x[1], x[2]))
+        latest_checkpoint, completed_steps, _ = checkpoints_with_steps[-1]
 
         latest_checkpoint_path = os.path.join(checkpoint_dir, latest_checkpoint)
         self.accelerator.print(f"Latest checkpoint found: {latest_checkpoint_path}")


### PR DESCRIPTION
## Description

This PR adds optional PEFT/LoRA support for fine-tuning the StarVLA VLM backbone.

The feature is disabled by default and keeps the existing full fine-tuning, frozen-VLM training, checkpoint loading, and non-LoRA launch behavior unchanged. When enabled, LoRA wraps the configured VLM backbone module and saves PEFT adapters alongside the normal StarVLA checkpoints.

This is intended as a maintained candidate path for memory-constrained adaptation, adapter exchange, and ablation experiments. It is not presented as the default recommendation for best task performance.

## Motivation

Issue [#229](https://github.com/starVLA/starVLA/issues/229) points out a real gap in the current training options:

- freezing the VLM only trains the action side;
- full fine-tuning is expensive and creates large checkpoints;
- the existing adapter path adapts the action head, not the VLM backbone;
- users who want PEFT/LoRA currently need to carry private patches.

Besides its speed and efficiency, LoRA is quite important for methods that inject extra geometric info (like spatial forcing) to avoid corrupting the pre-trained backbone's distribution. We understand the project experience that LoRA fine-tuning may produce poor results, and that users targeting stronger task performance may be better served by the smaller model. This PR keeps that caveat in place. The goal is to make LoRA available as an opt-in, reproducible training mode, not to replace full fine-tuning or the recommended smaller model path.

## Changes

- Added lazy PEFT LoRA utilities for the VLM backbone in `starVLA/model/modules/vlm/lora_utils.py`.
- Added canonical config support under `framework.vlm.lora`, while keeping `framework.qwenvl.lora` as a compatibility fallback.
- Wrapped the configured VLM module before `accelerator.prepare`, so LoRA parameters are visible to optimizer setup.
- Rebuilt optimizer/scheduler setup after PEFT wrapping when LoRA is enabled.
- Added LoRA-aware checkpoint handling:
  - save `vlm_lora_adapter` beside full checkpoints;
  - optional adapter-only save;
  - latest adapter checkpoint discovery;
  - `from_pretrained()` loading for LoRA-shaped checkpoints;
  - legacy `qwen_lora_adapter` fallback.
- Added shared launcher wiring through `examples/common/vlm_lora_args.sh`.
- Wired direct `train_starvla.py` launchers across supported benches to accept `VLM_LORA_*` environment variables.
- Added an optional LoRA-oriented ZeRO-1 DeepSpeed config.
- Added `docs/LoRA.md` with support scope, configuration, launch examples, checkpoint behavior, and smoke checks.

### Support scope

Supported:

- Qwen-series VLM backbones mounted at `qwen_vl_interface.model`.
- Benches that launch `starVLA/training/train_starvla.py`, including Robotwin, LIBERO, SimplerEnv/OXE, DOMINO, Franka, Calvin, Robocasa, Robocasa365, RoboChallenge Table30v2, VLA-Arena, Gemma4, MiniCPM, and NeuralVLA launchers.

Experimental:

- Non-Qwen VLM backbones, if the framework exposes a PEFT-compatible backbone module.
- For non-Qwen models, users can set `framework.vlm.lora.module_path` and use explicit target module names or `target_modules=all-linear`.

Not included:

- WM4A internal world-model LoRA for DiT/T5/VAE. That changes a different part of the stack and should be handled as a separate design decision.

## Testing

- [x] Local training for N steps without errors
- [x] Benchmark evaluation results
- [x] Local LoRA unit/config/checkpoint smoke checks
- [x] Remote NVIDIA LoRA forward/backward/save smoke checks


## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above

Shared-file justification:

- `starVLA/training/train_starvla.py` is touched because LoRA must be injected after checkpoint/freeze setup and before distributed prepare.
- `starVLA/training/trainer_utils/trainer_tools.py` is touched for LoRA adapter-only checkpoint discovery and resume handling.
- `starVLA/config/deepseeds/` is touched only to add an optional LoRA-oriented ZeRO-1 config.