### PR TITLE
[fix] Restore self-attention interleaving in layer-wise FM DiT forward

### DIFF
--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader.py
@@ -329,20 +329,16 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
             else torch.cat((future_tokens, action_features), dim=1)
         )
 
-        # Encode timesteps
-        temb = self.model.timestep_encoder(t_discretized)
+        # Layer-wise DiT forward. DiT handles cross/self-attention interleaving.
+        model_output = self.model(
+            hidden_states=sa_embs,
+            encoder_hidden_states=vl_embs_list,
+            timestep=t_discretized,
+            encoder_attention_mask=encoder_attention_mask,
+            return_pre_output=True,
+        )
 
-        # Layerwise cross-attention with vl_embs
-        model_output = sa_embs
-        for layer_idx, layer in enumerate(self.model.transformer_blocks):
-            model_output = layer(
-                hidden_states=model_output,
-                encoder_hidden_states=vl_embs_list[layer_idx],  # Use layer-specific vl_embs
-                encoder_attention_mask=encoder_attention_mask,
-                temb=temb,
-            )
-
-        # TODO miss self att and _process_output, but work well
+        # Decode only the action-token positions.
         pred = self.action_decoder(model_output)
         pred_actions = pred[:, -actions.shape[1] :]
 
@@ -395,19 +391,15 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
                 else torch.cat((future_tokens, action_features), dim=1)
             )
 
-            # Encode timestep
-            temb = self.model.timestep_encoder(timesteps_tensor)
-
-            # Layerwise cross-attention with vl_embs_list
-            model_output = sa_embs
-            for layer_idx, layer in enumerate(self.model.transformer_blocks):
-                model_output = layer(
-                    hidden_states=model_output,
-                    encoder_hidden_states=vl_embs_list[layer_idx],
-                    encoder_attention_mask=encoder_attention_mask,
-                    temb=temb,
-                )
-            # TODO miss self att and _process_output
+            # Layer-wise DiT forward. DiT handles cross/self-attention interleaving.
+            model_output = self.model(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs_list,
+                timestep=timesteps_tensor,
+                encoder_attention_mask=encoder_attention_mask,
+                return_pre_output=True,
+            )
+            # Decode only the action-token positions.
             pred = self.action_decoder(model_output)
             pred_velocity = pred[:, -self.action_horizon :]
 
@@ -489,14 +481,12 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
                 if state_features is not None
                 else torch.cat((future_tokens, action_features), dim=1)
             )
-            temb = self.model.timestep_encoder(timesteps)
-            model_output = sa_embs
-            for layer_idx, layer in enumerate(self.model.transformer_blocks):
-                model_output = layer(
-                    hidden_states=model_output,
-                    encoder_hidden_states=vl_embs_list[layer_idx],
-                    temb=temb,
-                )
+            model_output = self.model(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs_list,
+                timestep=timesteps,
+                return_pre_output=True,
+            )
             pred = self.action_decoder(model_output)
             return pred[:, -self.action_horizon :]
 
@@ -617,15 +607,12 @@ class LayerwiseFlowmatchingActionHead(nn.Module):
                     device=device,
                     dtype=torch.long,
                 )
-                temb = self.model.timestep_encoder(temb_tensor)
-
-                model_output = sa_embs
-                for layer_idx, layer in enumerate(self.model.transformer_blocks):
-                    model_output = layer(
-                        hidden_states=model_output,
-                        encoder_hidden_states=vl_embs_list[layer_idx],
-                        temb=temb,
-                    )
+                model_output = self.model(
+                    hidden_states=sa_embs,
+                    encoder_hidden_states=vl_embs_list,
+                    timestep=temb_tensor,
+                    return_pre_output=True,
+                )
 
                 pred = self.action_decoder(model_output)
                 pred_velocity = pred[:, -self.action_horizon :]

--- a/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit.py
+++ b/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Optional
 
 import torch
@@ -209,10 +210,17 @@ class DiT(ModelMixin, ConfigMixin):
         final_dropout: bool = True,
         positional_embeddings: Optional[str] = "sinusoidal",
         interleave_self_attention=False,
+        use_canonical_forward: bool = True,  # False restores the legacy all-cross-attention forward (old checkpoints)
         cross_attention_dim: Optional[int] = None,
         **kwargs,
     ):
         super().__init__()
+        if not use_canonical_forward:
+            logging.getLogger(__name__).warning(
+                "use_canonical_forward=False: running the legacy all-cross-attention DiT forward. "
+                "Old checkpoints may have degraded performance due to state-conditioning issues. "
+                "Please retrain with the updated forward path when possible."
+            )
         self.attention_head_dim = attention_head_dim
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
         self.gradient_checkpointing = False
@@ -264,23 +272,29 @@ class DiT(ModelMixin, ConfigMixin):
     def forward(
         self,
         hidden_states: torch.Tensor,  # Shape: (B, T, D)
-        encoder_hidden_states: torch.Tensor,  # Shape: (B, S, D)
+        encoder_hidden_states: torch.Tensor,  # Shape: (B, S, D) or list of layer-wise tensors
         timestep: Optional[torch.LongTensor] = None,
         return_all_hidden_states: bool = False,
         encoder_attention_mask=None,
+        return_pre_output: bool = False,
     ):
         # Encode timesteps
         temb = self.timestep_encoder(timestep)
 
         # Process through transformer blocks - single pass through the blocks
         hidden_states = hidden_states.contiguous()
-        encoder_hidden_states = encoder_hidden_states.contiguous()
+        is_layerwise_encoder = isinstance(encoder_hidden_states, (list, tuple))
+        encoder_hidden_states = (
+            [state.contiguous() for state in encoder_hidden_states]
+            if is_layerwise_encoder
+            else encoder_hidden_states.contiguous()
+        )
 
         all_hidden_states = [hidden_states]
 
         # Process through transformer blocks
         for idx, block in enumerate(self.transformer_blocks):
-            if idx % 2 == 1 and self.config.interleave_self_attention:
+            if idx % 2 == 1 and self.config.interleave_self_attention and self.config.use_canonical_forward:
                 hidden_states = block(
                     hidden_states,
                     attention_mask=None,
@@ -289,14 +303,23 @@ class DiT(ModelMixin, ConfigMixin):
                     temb=temb,
                 )
             else:
+                if is_layerwise_encoder:
+                    block_encoder_hidden_states = encoder_hidden_states[idx]
+                else:
+                    block_encoder_hidden_states = encoder_hidden_states
                 hidden_states = block(
                     hidden_states,
                     attention_mask=None,
-                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_hidden_states=block_encoder_hidden_states,
                     encoder_attention_mask=encoder_attention_mask,
                     temb=temb,
                 )
             all_hidden_states.append(hidden_states)
+
+        if return_pre_output:
+            if return_all_hidden_states:
+                return hidden_states, all_hidden_states
+            return hidden_states
 
         # Output processing
         conditioning = temb


### PR DESCRIPTION
Fixes #372

## Problem

`LayerwiseFlowmatchingActionHead` bypassed `DiT.forward` with a hand-written block loop that fed `encoder_hidden_states` to **every** block. With `interleave_self_attention=True`, odd blocks are constructed as self-attention blocks (`cross_attention_dim=None`), but diffusers' `Attention` silently runs cross-attention when `encoder_hidden_states` is passed and dims match — so all 36 layers ran cross-attention and **no self-attention existed anywhere** (the old `# TODO miss self att` comment).

Consequence: tokens in `[state | future_tokens | actions]` never exchange information. The state token cannot influence action predictions at all — `pred[:, -action_horizon:]` discards its output position, and no gradient reaches `state_encoder`. State conditioning only "worked" when state was also encoded into the instruction (entering via cross-attention K/V).

## Fix

- `DiT.forward` now accepts a list of layer-wise `encoder_hidden_states` (tensor input unchanged for other heads) and a `return_pre_output` flag that skips the final output projection (the head has its own `action_decoder`).
- The head routes all 4 call sites (train `forward`, `predict_action`, RTC ΠGDM, simulated-delay) through `DiT.forward`, restoring the intended cross/self-attention interleaving.

## Backward compatibility

New `use_canonical_forward` flag on `DiT` (registered to config, so it can be set via `diffusion_model_cfg.use_canonical_forward: false` in YAML):

- `True` (default): fixed forward path.
- `False`: exactly reproduces the legacy all-cross-attention behavior for old checkpoints (weight shapes are unchanged either way), and logs a warning recommending retraining.

## Verification

- With interleaving disabled (and likewise with `use_canonical_forward=False`), the new path is bit-for-bit identical to the old hand-written loop.
- Under the old path, replacing the state token leaves action outputs unchanged; under the fixed path, state influences action outputs and `state_encoder` receives gradients (verified with a small CPU-only repro test).