### PR TITLE
fix(Robocasa_tabletop): make state input and unnorm_key configurable in eval client

### DIFF
--- a/examples/Robocasa_tabletop/README.md
+++ b/examples/Robocasa_tabletop/README.md
@@ -61,18 +61,22 @@ python examples/Robocasa_tabletop/eval_files/simulation_env.py\
    --args.n_envs 1 \
    --args.max_episode_steps 720 \
    --args.n_action_steps 12 \
+   --args.no_send_state \
    --args.video_out_path ${video_out_path} \
    --args.pretrained_path ${your_ckpt}
 ```
 
+⚠️ **Note on the state input:** `--args.no_send_state` is required for the **Qwen3VL-OFT** checkpoint, which takes only language + image as input — sending the proprioceptive state makes the eval prompt diverge from the training format and drops the success rate to ~0 (see issue #355). For the **Qwen3VL-GR00T** checkpoint, keep the default (state enabled): its action head consumes the state input.
+
+If your checkpoint's `dataset_statistics.json` contains multiple keys, select the embodiment with `--args.unnorm_key <key>` (e.g. `gr1`). With a single key (both released checkpoints), it is auto-selected.
 
 ### Optional: Batch Evaluation
 
 If you have more GPU, you can use the batch evaluation script:
 ```bash
-bash examples/Robocasa_tabletop/batch_eval_args.sh
+bash examples/Robocasa_tabletop/eval_files/batch_eval_args.sh
 ```
-⚠️ **Note:** Please ensure that you specify the correct checkpoint path in `batch_eval_args.sh`  
+⚠️ **Note:** Please ensure that you specify the correct checkpoint path in `batch_eval_args.sh`. The fifth argument is forwarded to `simulation_env.py` and defaults to `--args.no_send_state` (matching the default Qwen3VL-OFT checkpoint); pass `""` when evaluating the Qwen3VL-GR00T checkpoint.
 
 ---
 ## 📊 Experimental Results

--- a/examples/Robocasa_tabletop/README.md
+++ b/examples/Robocasa_tabletop/README.md
@@ -66,7 +66,7 @@ python examples/Robocasa_tabletop/eval_files/simulation_env.py\
    --args.pretrained_path ${your_ckpt}
 ```
 
-⚠️ **Note on the state input:** `--args.no_send_state` is required for the **Qwen3VL-OFT** checkpoint, which takes only language + image as input — sending the proprioceptive state makes the eval prompt diverge from the training format and drops the success rate to ~0 (see issue #355). For the **Qwen3VL-GR00T** checkpoint, keep the default (state enabled): its action head consumes the state input.
+⚠️ **Note on the state input:** use `--args.no_send_state` for the **Qwen3VL-OFT** checkpoint, which takes only language + image as input — when a `state` key is present, QwenOFT appends discretized state tokens to the instruction, deviating from the training-time prompt format (see issue #355 for measurements). For the **Qwen3VL-GR00T** checkpoint, keep the default (state enabled): its action head consumes the state input.
 
 If your checkpoint's `dataset_statistics.json` contains multiple keys, select the embodiment with `--args.unnorm_key <key>` (e.g. `gr1`). With a single key (both released checkpoints), it is auto-selected.
 

--- a/examples/Robocasa_tabletop/eval_files/batch_eval_args.sh
+++ b/examples/Robocasa_tabletop/eval_files/batch_eval_args.sh
@@ -29,6 +29,10 @@ CKPT_PATH=${1:-$CKPT_DEFAULT}
 N_ENVS=${2:-$N_ENVS_DEFAULT}
 MAX_EPISODE_STEPS=${3:-$MAX_EPISODE_STEPS_DEFAULT}
 N_ACTION_STEPS=${4:-$N_ACTION_STEPS_DEFAULT}
+# Extra flags forwarded to simulation_env.py. The default matches CKPT_DEFAULT
+# (Qwen3-VL-OFT-Robocasa, trained without state input). Pass "" for checkpoints
+# that consume state (e.g. Qwen3-VL-GR00T-Robocasa-gr1).
+EXTRA_EVAL_ARGS=${5-"--args.no_send_state"}
 
 
 echo "=== Evaluation Configuration ==="
@@ -36,6 +40,7 @@ echo "Checkpoint Path      : ${CKPT_PATH}"
 echo "Number of Envs       : ${N_ENVS}"
 echo "Max Episode Steps    : ${MAX_EPISODE_STEPS}"
 echo "Action Chunk Length  : ${N_ACTION_STEPS}"
+echo "Extra Eval Args      : ${EXTRA_EVAL_ARGS}"
 echo "================================"
 
 # ============================================================
@@ -70,6 +75,7 @@ EvalEnv() {
         --args.n_action_steps "${N_ACTION_STEPS}" \
         --args.video_out_path "${VIDEO_OUT_PATH}" \
         --args.pretrained_path "${CKPT_PATH}" \
+        ${EXTRA_EVAL_ARGS} \
         > "${LOG_DIR}/eval_env_${ENV_NAME//\//_}_gpu${GPU_ID}.log" 2>&1
 }
 

--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -25,12 +25,17 @@ class PolicyWarper:
         host="0.0.0.0",
         port=10095,
         n_action_steps=2,
+        send_state: bool = True,
     ) -> None:
 
         # build client to connect server policy
         self.client = WebsocketClientPolicy(host, port)
         self.policy_setup = policy_setup
         self.unnorm_key = unnorm_key
+        # Checkpoints trained without proprioceptive state (e.g. Qwen3-VL-OFT-Robocasa)
+        # must not receive a `state` key: QwenOFT appends discretized state tokens to
+        # the instruction whenever `state` is present, corrupting the prompt format.
+        self.send_state = send_state
 
         print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key} ***")
         self.use_ddim = use_ddim
@@ -99,18 +104,21 @@ class PolicyWarper:
         task_description = observations["annotation.human.coarse_action"][0]  # tuple
         ego_view = observations["video.ego_view"]  # (N, 1, H, W, 3)
         images = ego_view
-        state = {}
-        state["left_arm"] = observations["state.left_arm"]
-        state["right_arm"] = observations["state.right_arm"]  # (N, 1, 7)
-        state["left_hand"] = observations["state.left_hand"]  # (N, 1, 6)
-        state["right_hand"] = observations["state.right_hand"]  # (N, 1, 6)
-        state["waist"] = observations["state.waist"]  # (N, 1, 3)
 
-        state = self.normalize_state(state)
-        input_state = []
-        for key in state.keys():
-            input_state.append(state[key])
-        input_state = np.concatenate(input_state, axis=-1)
+        input_state = None
+        if self.send_state:
+            state = {}
+            state["left_arm"] = observations["state.left_arm"]
+            state["right_arm"] = observations["state.right_arm"]  # (N, 1, 7)
+            state["left_hand"] = observations["state.left_hand"]  # (N, 1, 6)
+            state["right_hand"] = observations["state.right_hand"]  # (N, 1, 6)
+            state["waist"] = observations["state.waist"]  # (N, 1, 3)
+
+            state = self.normalize_state(state)
+            input_state = []
+            for key in state.keys():
+                input_state.append(state[key])
+            input_state = np.concatenate(input_state, axis=-1)
 
         if task_description is not None:
             if task_description != self.task_description:
@@ -119,7 +127,8 @@ class PolicyWarper:
         # image: Image.Image = Image.fromarray(image)
 
         images = [[self._resize_image(img) for img in sample] for sample in images]  # (B, N_view, H, W, 3)
-        input_state = [input_s for input_s in input_state]  # B, state_dim*(sin, cos)
+        if input_state is not None:
+            input_state = [input_s for input_s in input_state]  # B, state_dim*(sin, cos)
 
         # prepare vla input
         examples = []
@@ -129,8 +138,9 @@ class PolicyWarper:
             example = {
                 "image": images[b],  # A list of multi-view images for a single sample
                 "lang": self._select_instruction(instructions, b),
-                "state": input_state[b],  # N_history, 58 #Hack BUG
             }
+            if input_state is not None:
+                example["state"] = input_state[b]  # N_history, 58 #Hack BUG
             examples.append(example)
 
         vla_input = {

--- a/examples/Robocasa_tabletop/eval_files/simulation_env.py
+++ b/examples/Robocasa_tabletop/eval_files/simulation_env.py
@@ -254,7 +254,9 @@ def run_evaluation(
 class Args:
     host: str = "127.0.0.1"
     port: int = 5678
-    resize_size = [224, 224]
+    resize_size: tuple = (224, 224)
+    unnorm_key: Optional[str] = None  # dataset_statistics.json key; auto-picked when the ckpt has a single key
+    send_state: bool = True  # --args.no_send_state for ckpts trained without state (e.g. Qwen3-VL-OFT-Robocasa)
 
     #################################################################################################################
     # LIBERO environment-specific parameters
@@ -288,10 +290,12 @@ def eval_gr1_unified(args: Args) -> None:
 
     model = PolicyWarper(
         policy_ckpt_path=args.pretrained_path,  # to get unnormalization stats
+        unnorm_key=args.unnorm_key,
         host=args.host,
         port=args.port,
         image_size=args.resize_size,
         n_action_steps=args.n_action_steps,
+        send_state=args.send_state,
     )
     run_evaluation(
         env_name=args.env_name,

--- a/tests/test_robocasa_tabletop_interface.py
+++ b/tests/test_robocasa_tabletop_interface.py
@@ -1,0 +1,84 @@
+"""Tests for the Robocasa_tabletop eval client (PolicyWarper).
+
+Covers the state-input toggle and request plumbing from
+``examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py``:
+
+- ``send_state=False`` must omit the ``state`` key from the request so that
+  prompt-augmenting frameworks (e.g. QwenOFT) see the same prompt format as
+  during state-less training (issue #355).
+- The default keeps the current behavior (sin/cos-encoded state included),
+  which the Qwen3-VL-GR00T checkpoint relies on.
+
+These tests mock the websocket client only; no policy server or robocasa
+simulator is required.
+"""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from examples.Robocasa_tabletop.eval_files import model2robocasa_interface as m2r
+
+
+def _fake_observations(batch_size: int = 1, image_hw: tuple = (256, 256)) -> dict:
+    """Build observations shaped like GrootRoboCasaEnv GR1 output."""
+    h, w = image_hw
+    return {
+        "annotation.human.coarse_action": ("pick the milk",) * batch_size,
+        "video.ego_view": np.zeros((batch_size, 1, h, w, 3), dtype=np.uint8),
+        "state.left_arm": np.zeros((batch_size, 1, 7), dtype=np.float32),
+        "state.right_arm": np.zeros((batch_size, 1, 7), dtype=np.float32),
+        "state.left_hand": np.zeros((batch_size, 1, 6), dtype=np.float32),
+        "state.right_hand": np.zeros((batch_size, 1, 6), dtype=np.float32),
+        "state.waist": np.zeros((batch_size, 1, 3), dtype=np.float32),
+    }
+
+
+class _FakeClient:
+    """Stands in for WebsocketClientPolicy and records every request."""
+
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+
+    def get_server_metadata(self) -> dict:
+        return {"env": "test"}
+
+    def predict_action(self, vla_input: dict) -> dict:
+        self.requests.append(vla_input)
+        batch = len(vla_input["examples"])
+        return {"data": {"actions": np.zeros((batch, 16, 29)).tolist()}}
+
+
+class PolicyWarperRequestTest(unittest.TestCase):
+    def _make_warper(self, **kwargs) -> "m2r.PolicyWarper":
+        with mock.patch.object(m2r, "WebsocketClientPolicy", _FakeClient):
+            return m2r.PolicyWarper(policy_ckpt_path="unused", **kwargs)
+
+    def test_send_state_false_omits_state_key(self):
+        warper = self._make_warper(send_state=False)
+        warper.step(_fake_observations())
+        example = warper.client.requests[-1]["examples"][0]
+        self.assertNotIn("state", example)
+
+    def test_send_state_default_keeps_sincos_state(self):
+        warper = self._make_warper()
+        warper.step(_fake_observations())
+        example = warper.client.requests[-1]["examples"][0]
+        self.assertIn("state", example)
+        self.assertEqual(np.asarray(example["state"]).shape, (1, 58))
+
+    def test_unnorm_key_forwarded_in_request(self):
+        warper = self._make_warper(unnorm_key="gr1", send_state=False)
+        warper.step(_fake_observations())
+        self.assertEqual(warper.client.requests[-1]["unnorm_key"], "gr1")
+
+    def test_images_resized_to_224(self):
+        warper = self._make_warper(send_state=False)
+        warper.step(_fake_observations(image_hw=(256, 256)))
+        example = warper.client.requests[-1]["examples"][0]
+        self.assertEqual(np.asarray(example["image"][0]).shape[:2], (224, 224))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The Robocasa_tabletop eval client always packed a sin/cos-encoded proprioceptive `state` into every request. `QwenOFT.predict_action` treats the presence of a `state` key as a trigger for `add_discretized_state_to_instruction()`, which appends `[STATE] <bin indices> [ACTION]` to the language instruction — a prompt format that diverges from how the released `StarVLA/Qwen3-VL-OFT-Robocasa` checkpoint is meant to be queried (language + image only, per the maintainers in #355).

This PR makes the state input and `unnorm_key` configurable in the eval client. All defaults preserve current behavior, so Qwen3-VL-GR00T evaluation (whose DiT action head consumes the 58-dim state, `state_dim: 58` in its config) is unchanged.

## Motivation

Related to #355

While preparing this PR I ran the full README workflow end to end (details below), which clarified the picture:

- **The 0% reported in #355 does not reproduce on current `starVLA_dev`** — I measure 70–80% with the released checkpoint either way. The reporter's commit `8904c06` sits between the v3 client refactor (#314) and the server-side norm processor (#318): at that commit `server_policy.py` serves the raw framework with **no action un-normalization at all**, which produces exactly the reported "purposeful movement, zero success" and ignores `unnorm_key`. Updating past #318 resolves that.
- The state input still measurably shifts the policy off its documented input contract: with the same image + instruction, the mere presence of the `state` key changes the predicted action by a mean |diff| of **0.183** (normalized scale), because the prompt is rewritten with `[STATE]` tokens. Over 50 episodes per setting this lands at 43/50 (state sent) vs 42/50 (state off) — statistically indistinguishable on this task. The flag is input-contract hygiene (the README command now queries the checkpoint the way it was trained), not a success-rate rescue.
- `unnorm_key` is exposed for parity with the `Robocasa_365` eval script and for multi-key checkpoints; both released checkpoints have a single `gr1` key, which the server auto-selects.

## Changes

- `PolicyWarper` (`examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py`): new `send_state: bool = True` parameter; when disabled, the request example contains no `state` key
- `Args` (`examples/Robocasa_tabletop/eval_files/simulation_env.py`): expose `unnorm_key` and `send_state`; annotate `resize_size` so it is a real dataclass/tyro CLI field instead of an un-annotated class attribute
- README: add `--args.no_send_state` to the OFT eval command, document which released checkpoint needs which flags, and fix the `batch_eval_args.sh` path (the script lives under `eval_files/`)
- `batch_eval_args.sh`: forward an optional 5th argument to `simulation_env.py`, defaulting to `--args.no_send_state` to match the default OFT checkpoint; pass `""` for state-consuming checkpoints
- `tests/test_robocasa_tabletop_interface.py`: unit tests for the request payload contract using a mocked websocket client — no simulator, server, or GPU required

## Testing

- [x] Benchmark evaluation results

Full end-to-end run of the README workflow on a fresh machine (RTX 4090 24 GB, Ubuntu 22.04, Python 3.10, robosuite v1.5.1 from source, robocasa-gr1-tabletop-tasks, released `Qwen3-VL-OFT-Robocasa/steps_90000` checkpoint, `MUJOCO_GL=egl`):

| Benchmark | Metric | Result |
|-----------|--------|--------|
| PnPCanToDrawerClose (state sent, current behavior) | success rate, 50 episodes | 43/50 (86%) |
| PnPCanToDrawerClose (`--args.no_send_state`, this PR) | success rate, 50 episodes | 42/50 (84%) |

Reference from the README table for this task: 76.0 (50 rollouts). A preliminary 10-episode pass (7/10 vs 8/10) was consistent with the 50-episode numbers.

- **Checkpoint**: https://huggingface.co/StarVLA/Qwen3-VL-OFT-Robocasa (released; no new checkpoint involved)
- **Config**: `examples/Robocasa_tabletop/`
- **Reproduce**:

```bash
# terminal 1 (starVLA env)
python deployment/model_server/server_policy.py --ckpt_path .../steps_90000_pytorch_model.pt --port 5678 --use_bf16 --idle_timeout -1
# terminal 2 (robocasa env)
python examples/Robocasa_tabletop/eval_files/simulation_env.py \
  --args.env_name gr1_unified/PnPCanToDrawerClose_GR1ArmsAndWaistFourierHands_Env \
  --args.port 5678 --args.n_episodes 10 --args.n_envs 1 \
  --args.max_episode_steps 720 --args.n_action_steps 12 \
  --args.no_send_state \
  --args.video_out_path <out> --args.pretrained_path <ckpt>
```

Model-level check (no simulator needed): same image + instruction sent twice, with and without a zero `state` — mean |action diff| 0.183, confirming the `state` key alone rewrites the prompt.

- [x] Unit tests pass (no simulator/server needed):

```bash
PYTHONPATH=. python tests/test_robocasa_tabletop_interface.py
# Ran 4 tests ... OK  (Python 3.10.12, WSL Ubuntu 22.04)
```

Covered behaviors: `send_state=False` omits the `state` key; default keeps the `(1, 58)` sin/cos state (GR00T compatibility); `unnorm_key` forwarded; 256→224 resize.

Additional checks: tyro CLI parsing of the updated `Args` verified for the README command and bare defaults; `ruff check` introduces no new findings; `bash -n` passes for `batch_eval_args.sh`; `git diff --check` clean.

## Type of Change

- [x] Bug fix (non-breaking)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` (N/A — eval-client fix)
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public) (N/A)
