### PR TITLE
feat(docker): add policy server image and compose example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Keep the build context small: only source code is needed inside the image.
+.git
+.github
+.vscode
+assets
+playground
+wheels
+results
+experiments
+wandb
+tf-logs
+**/__pycache__
+*.pyc
+*.pt
+*.ckpt
+*.egg-info

--- a/deployment/docker/Dockerfile.server
+++ b/deployment/docker/Dockerfile.server
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+# Serving image for the starVLA websocket policy server.
+#
+# Build (from the repository root):
+#   docker build -f deployment/docker/Dockerfile.server -t starvla-policy-server .
+# Behind a slow PyPI route, point pip at a mirror:
+#   docker build -f deployment/docker/Dockerfile.server \
+#     --build-arg PIP_INDEX_URL=https://your-mirror/simple \
+#     -t starvla-policy-server .
+FROM python:3.10-slim
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+# Tolerate slow links; pip honors these directly.
+ENV PIP_DEFAULT_TIMEOUT=120 PIP_RETRIES=8
+
+# libGL/glib are required by OpenCV; gcc builds the few pure-C sdists in
+# requirements.txt (e.g. accumulation-tree, via tdigest). Everything CUDA ships
+# inside the torch wheels, so no CUDA toolkit is needed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgl1 libglib2.0-0 gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/starVLA
+
+# torch in its own layer: it dominates download size and almost never changes,
+# so build retries and requirement bumps reuse the cached layer. The pin must
+# match what requirements.txt resolves to (torchvision==0.21.0 -> torch==2.6.0).
+RUN pip install --no-cache-dir -i ${PIP_INDEX_URL} torch==2.6.0 torchvision==0.21.0
+
+# Remaining dependencies, so source edits do not invalidate this layer.
+# flash-attn is intentionally absent: the VLM interfaces run inference with
+# sdpa, so the serving image stays free of any CUDA build toolchain.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -i ${PIP_INDEX_URL} -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache-dir --no-deps -e .
+
+ENV PYTHONPATH=/workspace/starVLA
+EXPOSE 5678
+
+# Run with --gpus all and mount:
+#   /models                                        checkpoint snapshot (config.yaml,
+#                                                  dataset_statistics.json, checkpoints/*.pt)
+#   /workspace/starVLA/playground/Pretrained_models base VLM referenced by the
+#                                                  checkpoint's framework.qwenvl.base_vlm
+ENTRYPOINT ["python", "deployment/model_server/server_policy.py"]
+CMD ["--help"]

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,0 +1,66 @@
+# Docker policy server
+
+This directory contains a Docker image and compose example for the starVLA
+websocket policy server (`deployment/model_server/server_policy.py`).
+
+The image uses `python:3.10-slim` and does not install a CUDA toolkit. The VLM
+interfaces run inference with sdpa, and torch's pip wheels bundle the CUDA 12.4
+runtime. The host only needs an NVIDIA driver and the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+
+The image accepts `--build-arg PIP_INDEX_URL=...` for pip mirrors and honors the
+standard `HTTP_PROXY`/`HTTPS_PROXY` build args on restricted networks.
+
+## Build
+
+From the repository root:
+
+```bash
+docker build -f deployment/docker/Dockerfile.server -t starvla-policy-server .
+```
+
+Behind a slow PyPI route, add:
+
+```bash
+  --build-arg PIP_INDEX_URL=https://your-mirror/simple
+```
+
+## Serve a checkpoint
+
+The server needs two mounts:
+
+| Mount target | Content |
+| --- | --- |
+| `/models` | A checkpoint snapshot directory: `config.yaml`, `dataset_statistics.json`, `checkpoints/steps_XXXXX_pytorch_model.pt` (the layout of the released HF repos, e.g. [StarVLA/Qwen3-VL-OFT-Robocasa](https://huggingface.co/StarVLA/Qwen3-VL-OFT-Robocasa)) |
+| `/workspace/starVLA/playground/Pretrained_models` | The base VLM referenced by the checkpoint's `framework.qwenvl.base_vlm` (e.g. `Qwen3-VL-4B-Instruct`) |
+
+```bash
+docker run --gpus all -p 5678:5678 \
+  -v /abs/path/to/Qwen3-VL-OFT-Robocasa:/models:ro \
+  -v /abs/path/to/Pretrained_models:/workspace/starVLA/playground/Pretrained_models:ro \
+  starvla-policy-server \
+  --ckpt_path /models/checkpoints/steps_90000_pytorch_model.pt \
+  --port 5678 --use_bf16 --idle_timeout -1
+```
+
+`--idle_timeout -1` keeps the server alive indefinitely; the default (1800 s)
+shuts it down after 30 idle minutes.
+
+Evaluation clients (LIBERO, Robocasa_tabletop, SimplerEnv, ...) connect to the
+published port exactly as described in each benchmark's README. This Docker
+setup only containerizes the policy server; simulators can keep running on the
+host or in their own environments.
+
+## Docker compose
+
+The compose file builds the same server image and mounts the checkpoint and base
+VLM directories:
+
+```bash
+export MODEL_DIR=/abs/path/to/Qwen3-VL-OFT-Robocasa
+export PRETRAINED_DIR=/abs/path/to/Pretrained_models
+docker compose -f deployment/docker/docker-compose.yml up
+```
+
+`CKPT_FILE` is overridable via environment variable when the checkpoint file name
+differs from `checkpoints/steps_90000_pytorch_model.pt`.

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+# Example wiring for the starVLA policy server.
+#
+#   export MODEL_DIR=/abs/path/to/Qwen3-VL-OFT-Robocasa
+#   export PRETRAINED_DIR=/abs/path/to/Pretrained_models
+#   docker compose -f deployment/docker/docker-compose.yml up
+services:
+  policy-server:
+    build:
+      context: ../..
+      dockerfile: deployment/docker/Dockerfile.server
+    image: starvla-policy-server:latest
+    ports:
+      - "5678:5678"
+    volumes:
+      - ${MODEL_DIR:?Set MODEL_DIR to the checkpoint snapshot directory}:/models:ro
+      - ${PRETRAINED_DIR:?Set PRETRAINED_DIR to your Pretrained_models directory}:/workspace/starVLA/playground/Pretrained_models:ro
+    command:
+      - "--ckpt_path"
+      - "/models/${CKPT_FILE:-checkpoints/steps_90000_pytorch_model.pt}"
+      - "--port"
+      - "5678"
+      - "--use_bf16"
+      - "--idle_timeout"
+      - "-1"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
## Description

Adds Docker support under `deployment/docker/` for the starVLA websocket policy server.

The image is intentionally server-only: it runs `deployment/model_server/server_policy.py`, mounts checkpoints and base VLMs at runtime, and leaves benchmark simulators/eval clients in their existing host environments. This keeps the first Docker PR focused on the policy-server setup requested in #375 and avoids changing any training or evaluation code paths.

The image uses `python:3.10-slim`, installs torch/torchvision in a separate cacheable layer, and does not install a CUDA toolkit or flash-attn. The VLM inference path uses sdpa, while torch's pip wheels provide the CUDA 12.4 runtime libraries.

## Motivation

Closes #375

Setting up the policy server by hand requires several environment details that are easy to miss: matching the torch/torchvision pins, installing the repo into the container, mounting the released checkpoint layout, mounting `playground/Pretrained_models`, and keeping the websocket server alive for long evaluation sessions. This PR captures that setup in one Dockerfile plus a compose example.

## Changes

- `deployment/docker/Dockerfile.server`: policy-server image for `server_policy.py`
- `deployment/docker/docker-compose.yml`: example service with checkpoint and base-VLM mounts
- `deployment/docker/README.md`: build, run, compose, and mount instructions
- `.dockerignore`: keeps model/checkpoint/result directories out of the Docker build context

## Testing

- [x] Compose file renders with required mounts set:

```powershell
$env:MODEL_DIR='D:\dummy\model'
$env:PRETRAINED_DIR='D:\dummy\pretrained'
docker compose -f deployment/docker/docker-compose.yml config
```

- [x] Server image builds on Docker Desktop, Windows host. Local container egress could not reliably fetch the multi-GB torch/CUDA wheel set from public mirrors, so this validation build used the same torch 2.6.0 / torchvision 0.21.0 wheels from a predownloaded local wheel context. The source install, runtime entrypoint, and remaining dependency layers match the committed image path.

```powershell
docker build -f D:\Code\PR\_remote\Dockerfile.server.localtest `
  --build-context wheels=D:\Code\PR\starVLA\wheels `
  --build-arg HTTP_PROXY=http://host.docker.internal:7897 `
  --build-arg HTTPS_PROXY=http://host.docker.internal:7897 `
  -t starvla-policy-server D:\Code\PR\starVLA
```

- [x] Entrypoint help smoke test:

```powershell
docker run --rm starvla-policy-server
```

Result: `server_policy.py` prints argparse help for `--ckpt_path`, `--port`, `--use_bf16`, and `--idle_timeout`.

- [x] Runtime import smoke test:

```powershell
docker run --rm --entrypoint python starvla-policy-server -c "import torch; from deployment.model_server.policy_wrapper import PolicyServerWrapper; print('imports ok | torch', torch.__version__)"
```

Result: `imports ok | torch 2.6.0+cu124`

- [ ] Local training for N steps without errors (N/A: this PR only adds the policy-server deployment image)
- [ ] Benchmark evaluation results (N/A: this PR does not add or modify a benchmark)

| Benchmark | Metric | Result |
|-----------|--------|--------|
| N/A | N/A | N/A |

- **Checkpoint**: N/A
- **Config**: `deployment/docker/docker-compose.yml`
- **Reproduce**: see `deployment/docker/README.md`

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` (N/A: deployment example lives in `deployment/docker/docker-compose.yml`)
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above (`.dockerignore` only limits Docker build context)
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public) (N/A)

## Screenshots / Logs (optional)

Smoke-test logs are summarized in the Testing section.
