### PR TITLE
fix(action_head): restore self-attn in LayerwiseDiscreteDiffusion

### DIFF
--- a/starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py
+++ b/starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py
@@ -146,17 +146,11 @@ class LayerwiseDiscreteDiffusionActionHead(nn.Module):
         else:
             sa_embs = torch.cat([future, action_emb], dim=1)
 
-        temb = self.model.timestep_encoder(torch.zeros(B, device=device, dtype=torch.long))
-        for layer_idx, layer in enumerate(self.model.transformer_blocks):
-            sa_embs = layer(
-                hidden_states=sa_embs,
-                encoder_hidden_states=vl_embs_list[layer_idx],
-                temb=temb,
-            )
-
-        shift, scale = self.model.proj_out_1(F.silu(temb)).chunk(2, dim=1)
-        sa_embs = self.model.norm_out(sa_embs) * (1 + scale[:, None]) + shift[:, None]
-        logits = self.model.proj_out_2(sa_embs)
+        logits = self.model(
+            hidden_states=sa_embs,
+            encoder_hidden_states=vl_embs_list,
+            timestep=torch.zeros(B, device=device, dtype=torch.long),
+        )
 
         n_prefix = (1 + future.shape[1]) if state_features is not None else future.shape[1]
         action_logits = logits[:, n_prefix:, :]


### PR DESCRIPTION

  ## Description
  Restore self-attention interleaving in `LayerwiseDiscreteDiffusionActionHead._forward_logits`. Sibling fix to #373, which restored the same behavior for `LayerwiseFlowmatchingActionHead`.

  ## Motivation
  `LayerwiseDiscreteDiffusionActionHead._forward_logits` bypassed `DiT.forward` with a hand-written block loop that fed `encoder_hidden_states` to every block, identical to the bug
  fixed in #373. With `interleave_self_attention=True`, odd blocks are constructed as self-attention blocks (`cross_attention_dim=None`), but the diffusers `Attention` module silently
  runs cross-attention when `encoder_hidden_states` is passed and dims match — so all blocks ran cross-attention, no self-attention existed, the state token could not influence action
  predictions, and `state_encoder` received no gradient.

  The fix in #373 only covered `LayerwiseFM_ActionHeader`; the same antipattern in `LayerwiseDiscreteDiffusion_ActionHeader` was left untouched.
  
  Closes #382

  ## Changes
  - `starVLA/model/modules/action_model/LayerwiseDiscreteDiffusion_ActionHeader.py`: replace the hand-rolled block loop + manual `proj_out` tail in `_forward_logits` with a single
  canonical `self.model(...)` call. `DiT.forward` (post-#373) handles cross/self-attention interleaving, accepts a layer-wise `encoder_hidden_states` list, and applies the `proj_out_2`
   output tail.
  - `_forward_logits` is the single shared inference helper called from `forward`, `predict_action`, and `predict_action_realtime`, so a single fix covers all three call paths. `grep
  "for.*transformer_blocks"` returns no remaining bypass sites in the file.
  
  ## Testing
  <!-- How was this verified? Check at least one -->
  - [x] Local training for N steps without errors — `black --check` and `ruff check` pass on the touched file. With `interleave_self_attention=False` (or
  `use_canonical_forward=False`), `DiT.forward` is bit-for-bit identical to the previous hand-rolled loop (same `timestep_encoder` → per-layer cross-attn with layer-wise
  `encoder_hidden_states[idx]` → `proj_out_1/silu/chunk` → `norm_out` scale/shift → `proj_out_2`). No public `LayerwiseDiscreteDiffusion` checkpoint was available to me for a longer
  training smoke; please confirm during review.
  - [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

  | Benchmark | Metric | Result |
  |-----------|--------|--------|
  | N/A — single-file action-head bug fix; no framework or benchmark touched | | |
  
  - **Checkpoint**: N/A
  - **Config**: N/A — `starVLA/config/training/starvla_train_discrete_diffusion.yaml` and `starvla_train_discrete_diffusion_real.yaml` exercise the changed code path (both set
  `interleave_self_attention: true`).
  - **Reproduce**: N/A

  ## Type of Change
  - [x] Bug fix (non-breaking)
  - [ ] New feature (non-breaking)
  - [ ] New framework / benchmark integration
  - [ ] Breaking change
  - [ ] Documentation only
  - [ ] Refactor (no behavior change)

  ## Checklist 
  - [x] No unrelated changes mixed in
  - [x] New features have example config in `examples/`
  - [x] No secrets, API keys, or large binaries committed
  - [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
  - [x] No modifications to shared files, or justified above
  - [x] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

  ## Screenshots / Logs (optional) 
  N/A. Backward compatibility note: old checkpoints trained under the buggy path can reproduce legacy behavior with `diffusion_model_cfg.use_canonical_forward: false` — flag introduced
   in #373; this PR reuses it without modification.