### PR TITLE
feat(docker): add training and robocasa eval images

### DIFF
--- a/deployment/docker/Dockerfile.robocasa
+++ b/deployment/docker/Dockerfile.robocasa
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+# Simulator/eval-client image for robocasa-gr1-tabletop-tasks.
+#
+# Build (from the repository root):
+#   docker build -f deployment/docker/Dockerfile.robocasa -t starvla-robocasa-eval .
+#
+# Simulation assets are large and intentionally not baked into the image; mount
+# them or download them once into a host directory/volume.
+FROM python:3.10-slim
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG ROBOSUITE_REF=v1.5.1
+ARG ROBOCASA_REPO=https://github.com/robocasa/robocasa-gr1-tabletop-tasks.git
+
+ENV PIP_DEFAULT_TIMEOUT=120 PIP_RETRIES=8
+
+# EGL/GL runtime for headless MuJoCo rendering; git for source installs; gcc and
+# Python headers for small C/C++ sdists in the robocasa dependency tree.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libegl1 \
+        libgl1 \
+        libglib2.0-0 \
+        libopengl0 \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+
+WORKDIR /workspace
+
+# robocasa-gr1-tabletop needs robosuite/examples for WholeBodyMinkIK, which is
+# missing from the PyPI wheel. Keep this source install pinned.
+RUN git clone --depth 1 --branch ${ROBOSUITE_REF} https://github.com/ARISE-Initiative/robosuite.git \
+    && python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} -e robosuite \
+    && python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} mink==0.0.5 robosuite_models
+
+RUN git clone --depth 1 ${ROBOCASA_REPO} robocasa-gr1-tabletop-tasks \
+    && python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} -e robocasa-gr1-tabletop-tasks
+
+# Client-side deps for starVLA's eval scripts. The policy model itself runs in
+# the policy-server container; this image drives simulation and websocket calls.
+RUN python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} \
+        av \
+        matplotlib \
+        mediapy \
+        msgpack \
+        opencv-python \
+        pydantic \
+        tyro \
+        typing_extensions \
+        websocket-client \
+        websockets
+
+COPY . /workspace/starVLA
+WORKDIR /workspace/starVLA
+
+ENV PYTHONPATH=/workspace/starVLA
+ENV MUJOCO_GL=egl PYOPENGL_PLATFORM=egl
+# EGL rendering inside containers needs graphics capabilities, not just compute.
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
+CMD ["/bin/bash"]

--- a/deployment/docker/Dockerfile.train
+++ b/deployment/docker/Dockerfile.train
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# Training image for starVLA.
+#
+# Build (from the repository root):
+#   docker build -f deployment/docker/Dockerfile.train -t starvla-train .
+# Behind a slow PyPI route:
+#   docker build -f deployment/docker/Dockerfile.train \
+#     --build-arg PIP_INDEX_URL=https://your-mirror/simple \
+#     -t starvla-train .
+#
+# The default FLASH_ATTN_WHEEL matches torch 2.6 + cu12 + cp310 +
+# cxx11abiFALSE, which is the combination resolved by requirements.txt.
+# Override it when changing the torch pin.
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG FLASH_ATTN_WHEEL=https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_DEFAULT_TIMEOUT=120 PIP_RETRIES=8
+
+# DeepSpeed JIT ops need a compiler toolchain at runtime; ninja keeps those
+# builds fast. OpenCV imports need libGL/glib.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libgl1 \
+        libglib2.0-0 \
+        ninja-build \
+        python-is-python3 \
+        python3-dev \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+
+WORKDIR /workspace/starVLA
+
+# torch in its own layer: it dominates download size and rarely changes.
+RUN python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} torch==2.6.0 torchvision==0.21.0
+
+COPY requirements.txt .
+RUN python -m pip install --no-cache-dir -i ${PIP_INDEX_URL} -r requirements.txt \
+    && python -m pip install --no-cache-dir ${FLASH_ATTN_WHEEL}
+
+COPY . .
+RUN python -m pip install --no-cache-dir --no-deps -e .
+
+ENV PYTHONPATH=/workspace/starVLA
+
+# Training entrypoints differ per benchmark; mount datasets/checkpoints under
+# playground/ or results/ and launch the script you need.
+CMD ["/bin/bash"]

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,15 +1,23 @@
-# Docker policy server
+# Docker images
 
-This directory contains a Docker image and compose example for the starVLA
-websocket policy server (`deployment/model_server/server_policy.py`).
+This directory contains Docker images for serving, training, and robocasa
+tabletop evaluation.
 
-The image uses `python:3.10-slim` and does not install a CUDA toolkit. The VLM
-interfaces run inference with sdpa, and torch's pip wheels bundle the CUDA 12.4
-runtime. The host only needs an NVIDIA driver and the
+| Image | Dockerfile | What it runs |
+| --- | --- | --- |
+| `starvla-policy-server` | `Dockerfile.server` | The websocket policy server (`deployment/model_server/server_policy.py`) |
+| `starvla-train` | `Dockerfile.train` | Training environments that need CUDA build tools, DeepSpeed, and flash-attn |
+| `starvla-robocasa-eval` | `Dockerfile.robocasa` | The robocasa-gr1-tabletop simulator and starVLA eval client |
+
+The serving image uses `python:3.10-slim` and does not install a CUDA toolkit.
+The VLM interfaces run inference with sdpa, and torch's pip wheels bundle the
+CUDA 12.4 runtime. The host only needs an NVIDIA driver and the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
-The image accepts `--build-arg PIP_INDEX_URL=...` for pip mirrors and honors the
-standard `HTTP_PROXY`/`HTTPS_PROXY` build args on restricted networks.
+All images accept `--build-arg PIP_INDEX_URL=...` for pip mirrors and honor the
+standard `HTTP_PROXY`/`HTTPS_PROXY` build args on restricted networks. Large
+runtime assets, checkpoints, datasets, and outputs are mounted instead of baked
+into images.
 
 ## Build
 
@@ -17,6 +25,8 @@ From the repository root:
 
 ```bash
 docker build -f deployment/docker/Dockerfile.server -t starvla-policy-server .
+docker build -f deployment/docker/Dockerfile.train -t starvla-train .
+docker build -f deployment/docker/Dockerfile.robocasa -t starvla-robocasa-eval .
 ```
 
 Behind a slow PyPI route, add:
@@ -48,13 +58,45 @@ shuts it down after 30 idle minutes.
 
 Evaluation clients (LIBERO, Robocasa_tabletop, SimplerEnv, ...) connect to the
 published port exactly as described in each benchmark's README. This Docker
-setup only containerizes the policy server; simulators can keep running on the
-host or in their own environments.
+setup can run only the policy server, or it can also run the robocasa eval
+client through the compose `eval` profile.
+
+## Train
+
+The training image is a reusable environment rather than a one-shot entrypoint.
+Mount the project data/output directories and launch the benchmark script you
+need:
+
+```bash
+docker run --gpus all -it --shm-size 16g \
+  -v /abs/path/to/playground:/workspace/starVLA/playground \
+  -v /abs/path/to/results:/workspace/starVLA/results \
+  starvla-train \
+  bash examples/Robocasa_tabletop/train_files/run_robocasa.sh
+```
+
+The default `FLASH_ATTN_WHEEL` build arg matches the torch pin used here
+(torch 2.6 / CUDA 12 / Python 3.10). Override it if you change torch or Python.
+
+## Robocasa tabletop evaluation
+
+The robocasa image installs `robosuite` from source at `v1.5.1`. The PyPI wheel
+does not ship `robosuite/examples`, where the GR1 whole-body mink IK controller
+lives, so this is intentionally pinned in the Dockerfile.
+
+Download the simulation assets once on the host (they are large and should not
+be baked into the image):
+
+```bash
+docker run --rm \
+  -v /abs/path/to/assets:/workspace/robocasa-gr1-tabletop-tasks/robocasa/models/assets \
+  starvla-robocasa-eval \
+  python /workspace/robocasa-gr1-tabletop-tasks/robocasa/scripts/download_tabletop_assets.py -y
+```
 
 ## Docker compose
 
-The compose file builds the same server image and mounts the checkpoint and base
-VLM directories:
+The compose file starts the policy server by default:
 
 ```bash
 export MODEL_DIR=/abs/path/to/Qwen3-VL-OFT-Robocasa
@@ -64,3 +106,41 @@ docker compose -f deployment/docker/docker-compose.yml up
 
 `CKPT_FILE` is overridable via environment variable when the checkpoint file name
 differs from `checkpoints/steps_90000_pytorch_model.pt`.
+
+Run the server plus robocasa eval client with the `eval` profile:
+
+```bash
+export MODEL_DIR=/abs/path/to/Qwen3-VL-OFT-Robocasa
+export PRETRAINED_DIR=/abs/path/to/Pretrained_models
+export ROBOCASA_ASSETS_DIR=/abs/path/to/assets
+docker compose -f deployment/docker/docker-compose.yml --profile eval up
+```
+
+The compose eval command defaults to the released
+`StarVLA/Qwen3-VL-OFT-Robocasa` input contract (`--args.no_send_state`). For
+state-conditioned checkpoints such as Qwen3VL-GR00T, remove that flag or run an
+equivalent command that keeps the default `send_state=True`.
+
+`ROBOCASA_ASSETS_DIR` defaults to `./robocasa_assets` only so the compose file
+can render without the eval profile's assets present. Set it explicitly before
+running real robocasa evaluations.
+
+Useful robocasa overrides:
+
+| Variable | Default |
+| --- | --- |
+| `ROBOCASA_ENV_NAME` | `gr1_unified/PnPCanToDrawerClose_GR1ArmsAndWaistFourierHands_Env` |
+| `ROBOCASA_N_EPISODES` | `50` |
+| `ROBOCASA_N_ENVS` | `1` |
+| `ROBOCASA_MAX_EPISODE_STEPS` | `720` |
+| `ROBOCASA_N_ACTION_STEPS` | `12` |
+| `UNNORM_KEY` | `gr1` |
+| `EVAL_OUT_DIR` | `./eval_out` |
+
+Run an interactive training container with the `train` profile:
+
+```bash
+export PLAYGROUND_DIR=/abs/path/to/playground
+export RESULTS_DIR=/abs/path/to/results
+docker compose -f deployment/docker/docker-compose.yml --profile train run --rm train
+```

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -1,4 +1,5 @@
-# Example wiring for the starVLA policy server.
+# Example wiring for the starVLA policy server, plus optional train and
+# robocasa eval-client profiles.
 #
 #   export MODEL_DIR=/abs/path/to/Qwen3-VL-OFT-Robocasa
 #   export PRETRAINED_DIR=/abs/path/to/Pretrained_models
@@ -22,6 +23,70 @@ services:
       - "--use_bf16"
       - "--idle_timeout"
       - "-1"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  robocasa-eval:
+    profiles: ["eval"]
+    build:
+      context: ../..
+      dockerfile: deployment/docker/Dockerfile.robocasa
+    image: starvla-robocasa-eval:latest
+    depends_on:
+      - policy-server
+    volumes:
+      - ${MODEL_DIR:?Set MODEL_DIR to the checkpoint snapshot directory}:/models:ro
+      - ${ROBOCASA_ASSETS_DIR:-./robocasa_assets}:/workspace/robocasa-gr1-tabletop-tasks/robocasa/models/assets
+      - ${EVAL_OUT_DIR:-./eval_out}:/workspace/eval_out
+    command:
+      - "python"
+      - "examples/Robocasa_tabletop/eval_files/simulation_env.py"
+      - "--args.host"
+      - "policy-server"
+      - "--args.port"
+      - "5678"
+      - "--args.env_name"
+      - "${ROBOCASA_ENV_NAME:-gr1_unified/PnPCanToDrawerClose_GR1ArmsAndWaistFourierHands_Env}"
+      - "--args.n_episodes"
+      - "${ROBOCASA_N_EPISODES:-50}"
+      - "--args.n_envs"
+      - "${ROBOCASA_N_ENVS:-1}"
+      - "--args.max_episode_steps"
+      - "${ROBOCASA_MAX_EPISODE_STEPS:-720}"
+      - "--args.n_action_steps"
+      - "${ROBOCASA_N_ACTION_STEPS:-12}"
+      - "--args.video_out_path"
+      - "/workspace/eval_out"
+      - "--args.pretrained_path"
+      - "/models/${CKPT_FILE:-checkpoints/steps_90000_pytorch_model.pt}"
+      - "--args.unnorm_key"
+      - "${UNNORM_KEY:-gr1}"
+      - "--args.no_send_state"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  train:
+    profiles: ["train"]
+    build:
+      context: ../..
+      dockerfile: deployment/docker/Dockerfile.train
+    image: starvla-train:latest
+    working_dir: /workspace/starVLA
+    volumes:
+      - ${PLAYGROUND_DIR:-../../playground}:/workspace/starVLA/playground
+      - ${RESULTS_DIR:-../../results}:/workspace/starVLA/results
+    shm_size: ${TRAIN_SHM_SIZE:-16g}
+    command: ${TRAIN_COMMAND:-bash}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Description

Follow-up to #376. Adds the two Docker images that were intentionally left out of the first policy-server-only PR:

- `starvla-train`: a CUDA 12.4 devel image for training workflows that need the compiler toolchain, DeepSpeed JIT ops, ninja, and the flash-attn wheel matching torch 2.6 / CUDA 12 / Python 3.10.
- `starvla-robocasa-eval`: a robocasa-gr1-tabletop simulator/eval-client image with source-installed `robosuite==1.5.1`, `mink==0.0.5`, EGL rendering defaults, and the starVLA websocket eval client.

The default compose behavior is unchanged: `docker compose up` still starts only the policy server. The new images sit behind explicit `train` and `eval` profiles, so this is additive and should not change existing serving usage.

## Motivation

Related to #375

The policy-server image landed first to keep review focused. This PR finishes the containerized workflow around it:

- training needs a CUDA devel base and runtime compiler tools for DeepSpeed ops;
- robocasa tabletop eval needs the source `robosuite` checkout because the PyPI wheel does not include `robosuite/examples/third_party_controller`, where the GR1 mink IK controller and config live;
- compose can now wire the policy server and robocasa eval client together without baking checkpoints, base VLMs, simulation assets, datasets, or outputs into images.

## Changes

- `deployment/docker/Dockerfile.train`: CUDA devel training image with upgraded pip/setuptools/wheel, build toolchain, torch/torchvision cache layer, requirements, and flash-attn wheel.
- `deployment/docker/Dockerfile.robocasa`: robocasa eval-client image with pinned robosuite source install, robocasa-gr1-tabletop-tasks, EGL runtime libraries, and eval client dependencies.
- `deployment/docker/docker-compose.yml`: adds `eval` and `train` profiles while preserving the policy-server default service.
- `deployment/docker/README.md`: documents all three images, build commands, asset/checkpoint mounts, compose profiles, and robocasa overrides.

## Testing

- [x] Compose renders for all profiles:

```powershell
$env:MODEL_DIR='./tmp/model'
$env:PRETRAINED_DIR='./tmp/pretrained'
docker compose -f deployment/docker/docker-compose.yml config

$env:ROBOCASA_ASSETS_DIR='./tmp/assets'
docker compose -f deployment/docker/docker-compose.yml --profile eval config

$env:PLAYGROUND_DIR='./tmp/playground'
$env:RESULTS_DIR='./tmp/results'
docker compose -f deployment/docker/docker-compose.yml --profile train config
```

- [x] Dockerfile syntax/build checks pass:

```powershell
docker build --check -f deployment/docker/Dockerfile.server .
docker build --check -f deployment/docker/Dockerfile.train .
docker build --check -f deployment/docker/Dockerfile.robocasa .
```

- [x] `starvla-train` builds on Docker Desktop, Windows host, using the same layer structure as `Dockerfile.train` and a local torch/torchvision wheel context for the torch layer to avoid re-downloading multi-GB CUDA wheels over the local container route.

Runtime smoke:

```powershell
docker run --rm starvla-train python -c "import torch, flash_attn, deepspeed; print(torch.__version__, flash_attn.__version__, deepspeed.__version__)"
```

Result: `torch 2.6.0+cu124`, `flash_attn 2.7.4.post1`, `deepspeed 0.16.9`

- [x] `starvla-robocasa-eval` builds on Docker Desktop, Windows host. The local validation variant pre-seeded torch wheels before the robocasa dependency install to avoid local egress issues; the submitted Dockerfile does not require torch for the eval-client import path.

Runtime smoke:

```powershell
docker run --rm starvla-robocasa-eval python -c "import robosuite, mink, robocasa; from robocasa.utils.gym_utils import GrootRoboCasaEnv; from examples.Robocasa_tabletop.eval_files.model2robocasa_interface import PolicyWarper; print(robosuite.__version__)"
```

Result: `robosuite 1.5.1`

Additional source-install check:

```powershell
docker run --rm starvla-robocasa-eval python -c "from robosuite.examples.third_party_controller.mink_controller import WholeBodyMinkIK; import pathlib; assert pathlib.Path('/workspace/robosuite/robosuite/examples/third_party_controller/default_mink_ik_gr1.json').exists(); print(WholeBodyMinkIK.__name__)"
```

Result: `WholeBodyMinkIK`

- [x] Confirmed the robocasa eval import path does not import torch:

```powershell
docker run --rm -i starvla-robocasa-eval python -
```

with an import guard around `torch`, then importing `PolicyWarper` and `Args`.

- [x] Confirmed the compose robocasa flags are exposed by the Tyro CLI:

```powershell
docker run --rm starvla-robocasa-eval sh -lc "python examples/Robocasa_tabletop/eval_files/simulation_env.py --help | grep -E -- '--args\.(host|no-send-state|unnorm-key|n-action-steps)'"
```

Result includes `--args.host`, `--args.unnorm-key`, `--args.send-state, --args.no-send-state`, and `--args.n-action-steps`.

- [x] `starvla-robocasa-eval` dependency check:

```powershell
docker run --rm starvla-robocasa-eval python -m pip check
```

Result: `No broken requirements found.`

- [ ] Local training for N steps without errors (not run; image smoke only)
- [ ] Benchmark evaluation results (not run; this PR adds deployment images, not benchmark logic)

| Benchmark | Metric | Result |
|-----------|--------|--------|
| N/A | N/A | N/A |

- **Checkpoint**: N/A
- **Config**: `deployment/docker/docker-compose.yml`
- **Reproduce**: see `deployment/docker/README.md`

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` (N/A: deployment examples live in `deployment/docker/docker-compose.yml`)
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above (`deployment/docker` deployment docs/compose only)
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public) (N/A)

## Screenshots / Logs (optional)

Smoke-test results are summarized above.
