### PR TITLE
  Fix single-process distributed safety for single-GPU training

### DIFF
--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -55,7 +55,7 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
             prefetch_factor=4,
             # shuffle=True
         )        
-        if dist.get_rank() == 0: 
+        if not dist.is_initialized() or dist.get_rank() == 0:
             
             output_dir = Path(cfg.output_dir)
             vla_dataset.save_dataset_statistics(output_dir / "dataset_statistics.json")

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -80,7 +80,8 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     vla_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vla_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    if dist.is_initialized():
+        dist.barrier()
     return vla_train_dataloader
 
 
@@ -273,7 +274,8 @@ class VLATrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and rank == 0:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -362,7 +364,8 @@ class VLATrainer(TrainerUtils):
             step_metrics["mse_score"] = score / num_pots
 
         del examples
-        dist.barrier()
+        if dist.is_initialized():
+            dist.barrier()
         return step_metrics
 
     def _log_training_config(self):
@@ -449,8 +452,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -72,7 +72,8 @@ def prepare_data(cfg, accelerator, output_dir) -> Tuple[DataLoader, DataLoader]:
     vlm_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vlm_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    if dist.is_initialized():
+        dist.barrier()
     return vla_train_dataloader, vlm_train_dataloader
 
 
@@ -213,7 +214,8 @@ class VLAMTrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and rank == 0:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -289,7 +291,8 @@ class VLAMTrainer(TrainerUtils):
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
                 self._save_checkpoint()
-                dist.barrier()
+                if dist.is_initialized():
+                    dist.barrier()
 
             if self.completed_steps >= self.config.trainer.max_train_steps:
                 break
@@ -310,7 +313,8 @@ class VLAMTrainer(TrainerUtils):
             score = TrainerUtils.euclidean_distance(normalized_actions, actions)
             step_metrics["mse_score"] = score / num_pots
 
-        dist.barrier()
+        if dist.is_initialized():
+            dist.barrier()
         return step_metrics
 
     def _log_training_config(self):
@@ -406,8 +410,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -68,7 +68,8 @@ def prepare_data(cfg, accelerator, output_dir) -> DataLoader:
     vlm_train_dataloader = build_dataloader(cfg=cfg, dataset_py=cfg.datasets.vlm_data.dataset_py)
 
     accelerator.dataloader_config.dispatch_batches = False
-    dist.barrier()
+    if dist.is_initialized():
+        dist.barrier()
     return vlm_train_dataloader
 
 
@@ -197,7 +198,8 @@ class VLAMTrainer(TrainerUtils):
 
     def _log_metrics(self, metrics):
         """Record training metrics."""
-        if self.completed_steps % self.config.trainer.logging_frequency == 0 and dist.get_rank() == 0:
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        if self.completed_steps % self.config.trainer.logging_frequency == 0 and rank == 0:
             last_lrs = self.lr_scheduler.get_last_lr()
             for i, group in enumerate(self.optimizer.param_groups):
                 group_name = group.get("name", str(i))
@@ -248,7 +250,8 @@ class VLAMTrainer(TrainerUtils):
 
             if self.completed_steps % self.config.trainer.save_interval == 0 and self.completed_steps > 0:
                 self._save_checkpoint()
-                dist.barrier()
+                if dist.is_initialized():
+                    dist.barrier()
 
             if self.completed_steps >= self.config.trainer.max_train_steps:
                 break
@@ -339,8 +342,9 @@ def main(cfg) -> None:
     trainer.train()
 
     logger.info("... and that's all, folks!")
-    dist.barrier()
-    dist.destroy_process_group()
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/starVLA/training/trainer_utils/trainer_tools.py
+++ b/starVLA/training/trainer_utils/trainer_tools.py
@@ -18,6 +18,10 @@ from accelerate.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _dist_rank() -> int:
+    return dist.get_rank() if dist.is_initialized() else 0
+
+
 # === Define Tracker Interface ===
 #
 
@@ -225,7 +229,7 @@ class TrainerUtils:
                     continue
 
         # accelerator.wait_for_everyone()  # synchronize when distributed training
-        if dist.get_rank == 0:
+        if _dist_rank() == 0:
             print(f"🔒 Frozen modules with re pattern: {frozen}")
         return model
 
@@ -235,7 +239,7 @@ class TrainerUtils:
         print the total number of parameters and trainable parameters of the model
         :param model: PyTorch model instance
         """
-        if dist.get_rank() != 0:
+        if _dist_rank() != 0:
             return
         print("📊 model parameter statistics:")
         num_params = sum(p.numel() for p in model.parameters())
@@ -257,7 +261,7 @@ class TrainerUtils:
         """
         if not checkpoint_path:
             return []
-        if dist.get_rank() == 0:
+        if _dist_rank() == 0:
             print(f"📦 loading checkpoint: {checkpoint_path}")
         try:
             if _is_safetensors_path(checkpoint_path):
@@ -283,7 +287,7 @@ class TrainerUtils:
                     sub_state_dict = {k[len(prefix) :]: v for k, v in checkpoint.items() if k.startswith(prefix)}
                     if sub_state_dict:
                         module.load_state_dict(sub_state_dict, strict=True)
-                        if dist.get_rank() == 0:
+                        if _dist_rank() == 0:
                             print(f"✅ parameters loaded to module '{path}'")
                         loaded_modules.append(path)
                     else:
@@ -293,7 +297,7 @@ class TrainerUtils:
         else:  # full load
             try:
                 model.load_state_dict(checkpoint, strict=False)
-                if dist.get_rank() == 0:
+                if _dist_rank() == 0:
                     print("✅ loaded <full_model> model parameters")
                 loaded_modules = ["<full_model>"]
             except Exception as e:

--- a/tests/test_single_process_dist_safety.py
+++ b/tests/test_single_process_dist_safety.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from starVLA.training.trainer_utils.trainer_tools import TrainerUtils
+
+
+class SingleProcessDistSafetyTest(unittest.TestCase):
+    def test_trainer_utils_safe_without_process_group(self):
+        self.assertFalse(dist.is_initialized())
+
+        model = nn.Linear(2, 3)
+        num_params, num_trainable = TrainerUtils.print_trainable_parameters(model)
+        self.assertEqual(num_params, num_trainable)
+
+        with tempfile.NamedTemporaryFile(suffix=".pt") as checkpoint_file:
+            torch.save(model.state_dict(), checkpoint_file.name)
+            loaded_model = TrainerUtils.load_pretrained_backbones(nn.Linear(2, 3), checkpoint_file.name)
+
+        self.assertIsInstance(loaded_model, nn.Module)
+
+    def _run_prepare_data_subprocess(self, code: str):
+        env = os.environ.copy()
+        env.setdefault("STARVLA_USE_DEEPSPEED", "0")
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=os.getcwd(),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + "\n" + result.stderr)
+
+    def test_train_starvla_prepare_data_safe_without_process_group(self):
+        self._run_prepare_data_subprocess(
+            """
+import importlib
+import types
+from unittest import mock
+
+module = importlib.import_module("starVLA.training.train_starvla")
+cfg = types.SimpleNamespace(
+    datasets=types.SimpleNamespace(
+        vla_data=types.SimpleNamespace(data_mix="dummy", dataset_py="dummy")
+    )
+)
+fake_accelerator = types.SimpleNamespace(dataloader_config=types.SimpleNamespace(dispatch_batches=None))
+with mock.patch.object(module, "build_dataloader", return_value=[1, 2, 3]):
+    dataloader = module.prepare_data(cfg, fake_accelerator, output_dir=None)
+assert dataloader == [1, 2, 3]
+""",
+        )
+
+    def test_train_starvlm_prepare_data_safe_without_process_group(self):
+        self._run_prepare_data_subprocess(
+            """
+import importlib
+import types
+from unittest import mock
+
+module = importlib.import_module("starVLA.training.train_starvlm")
+cfg = types.SimpleNamespace(
+    datasets=types.SimpleNamespace(
+        vlm_data=types.SimpleNamespace(dataset_use="dummy", dataset_py="dummy")
+    )
+)
+fake_accelerator = types.SimpleNamespace(dataloader_config=types.SimpleNamespace(dispatch_batches=None))
+with mock.patch.object(module, "build_dataloader", return_value=[1]):
+    dataloader = module.prepare_data(cfg, fake_accelerator, output_dir=None)
+assert dataloader == [1]
+""",
+        )
+
+    def test_train_starvla_cotrain_prepare_data_safe_without_process_group(self):
+        self._run_prepare_data_subprocess(
+            """
+import importlib
+import types
+from unittest import mock
+
+module = importlib.import_module("starVLA.training.train_starvla_cotrain")
+cfg = types.SimpleNamespace(
+    datasets=types.SimpleNamespace(
+        vla_data=types.SimpleNamespace(data_mix="dummy", dataset_py="dummy"),
+        vlm_data=types.SimpleNamespace(dataset_py="dummy"),
+    )
+)
+fake_accelerator = types.SimpleNamespace(dataloader_config=types.SimpleNamespace(dispatch_batches=None))
+with mock.patch.object(module, "build_dataloader", side_effect=[[1], [2]]):
+    vla_dataloader, vlm_dataloader = module.prepare_data(cfg, fake_accelerator, output_dir=None)
+assert vla_dataloader == [1]
+assert vlm_dataloader == [2]
+""",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## Summary

  This PR fixes single-process / single-GPU training failures caused by unconditional torch.distributed calls when the default process group is not initialized.

  ## Problem

  In single-process runs, several training paths directly call:

  - dist.get_rank()
  - dist.barrier()
  - dist.destroy_process_group()

  This can raise:

  ValueError: Default process group has not been initialized

  As a result, single-GPU training may fail before training actually starts.

  ## Fix

  Add single-process-safe guards across training utilities and training entrypoints:

  - check dist.is_initialized() before distributed synchronization calls
  - fall back to rank 0 behavior when distributed is not initialized

  Updated files:

  - starVLA/dataloader/__init__.py
  - starVLA/training/train_starvla.py
  - starVLA/training/train_starvlm.py
  - starVLA/training/train_starvla_cotrain.py
  - starVLA/training/trainer_utils/trainer_tools.py

  ## Validation

  Added regression tests in:

  - tests/test_single_process_dist_safety.py

  Verified with:

  python -m unittest discover -s tests -p 'test_single_process_dist_safety.py'

  Result:

  - Ran 4 tests ... OK
