### PR TITLE
[feature] Make dataloader worker settings configurable

### DIFF
--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -44,17 +44,23 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
             balance_dataset_weights=vla_dataset_cfg.get("balance_dataset_weights", False),
             balance_trajectory_weights=vla_dataset_cfg.get("balance_trajectory_weights", False),
         )
-        
+
+        num_workers = int(vla_dataset_cfg.get("num_workers", 4))
+        dataloader_kwargs = {
+            "batch_size": cfg.datasets.vla_data.per_device_batch_size,
+            "collate_fn": collate_fn,
+            "num_workers": num_workers,
+            "pin_memory": bool(vla_dataset_cfg.get("pin_memory", True)),
+            # shuffle=True
+        }
+        if num_workers > 0:
+            dataloader_kwargs["persistent_workers"] = bool(vla_dataset_cfg.get("persistent_workers", True))
+            dataloader_kwargs["prefetch_factor"] = int(vla_dataset_cfg.get("prefetch_factor", 2))
+
         vla_train_dataloader = DataLoader(
             vla_dataset,
-            batch_size=cfg.datasets.vla_data.per_device_batch_size,
-            collate_fn=collate_fn,
-            num_workers=16,
-            pin_memory=True,
-            persistent_workers=True,
-            prefetch_factor=4,
-            # shuffle=True
-        )        
+            **dataloader_kwargs,
+        )
         if dist.get_rank() == 0: 
             
             output_dir = Path(cfg.output_dir)


### PR DESCRIPTION
## Summary

  This PR removes hardcoded dataloader worker settings and restores them to be configurable from cfg.datasets.vla_data.

  ## Problem

  The VLA dataloader currently hardcodes:

  - num_workers=16
  - pin_memory=True
  - persistent_workers=True
  - prefetch_factor=4

  This makes the training setup less portable across different machines and ignores user configuration.

  ## Fix

  Read dataloader settings from cfg.datasets.vla_data instead:

  - num_workers
  - pin_memory
  - persistent_workers
  - prefetch_factor

  Also only set persistent_workers and prefetch_factor when num_workers > 0.

  ## Files changed

  - starVLA/dataloader/__init__.py