### PR TITLE
Fix per-environment instructions in RoboCasa vectorized evaluation

### DIFF
--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -68,6 +68,10 @@ class PolicyWarper:
 
     @staticmethod
     def _select_instruction(instructions, batch_index: int):
+        if isinstance(instructions, np.ndarray):
+            instructions = instructions.tolist()
+        if isinstance(instructions, tuple):
+            instructions = list(instructions)
         if not isinstance(instructions, list):
             return instructions
         if len(instructions) == 0:
@@ -79,6 +83,26 @@ class PolicyWarper:
         raise IndexError(
             f"instructions has length {len(instructions)}, but batch index {batch_index} was requested"
         )
+
+    @staticmethod
+    def _normalize_task_descriptions(task_descriptions):
+        if isinstance(task_descriptions, np.ndarray):
+            task_descriptions = task_descriptions.tolist()
+        if isinstance(task_descriptions, tuple):
+            task_descriptions = list(task_descriptions)
+        if not isinstance(task_descriptions, list):
+            return task_descriptions
+
+        normalized = []
+        for item in task_descriptions:
+            if isinstance(item, np.ndarray):
+                item = item.tolist()
+            if isinstance(item, tuple):
+                item = list(item)
+            if isinstance(item, list) and len(item) == 1:
+                item = item[0]
+            normalized.append(item)
+        return normalized
 
     def reset(self, task_description: str or tuple) -> None:
 
@@ -101,7 +125,9 @@ class PolicyWarper:
         :return: (raw_actions, processed_actions)
         """
 
-        task_description = observations["annotation.human.coarse_action"][0]  # tuple
+        task_description = self._normalize_task_descriptions(
+            observations["annotation.human.coarse_action"]
+        )
         ego_view = observations["video.ego_view"]  # (N, 1, H, W, 3)
         images = ego_view
 


### PR DESCRIPTION
## Summary

This PR fixes RoboCasa GR1 vectorized evaluation when `n_envs > 1`.

Previously, the policy adapter selected only the first environment's language instruction:

```python
task_description = observations["annotation.human.coarse_action"][0]
```

As a result, all samples in a batched policy call could be conditioned on environment 0's instruction. This is especially problematic for `PosttrainPnPNovel...SplitA` tasks, where different parallel environments may sample different object instances and therefore have different language instructions.

This PR preserves the full batch of `annotation.human.coarse_action` and selects the corresponding instruction for each batch element.

## Changes

- Normalize batched task descriptions from `np.ndarray`, `tuple`, or `list`.
- Preserve per-environment instructions instead of taking index 0.
- Keep existing single-instruction broadcast behavior for non-vectorized or shared-instruction cases.
- Keep `n_envs=1` behavior unchanged.

## Validation

I tested the released RoboCasa GR1 checkpoint:

```text
StarVLA/Qwen3-VL-GR00T-Robocasa-gr1
```

On:

```text
PosttrainPnPNovelFromCuttingboardToBasketSplitA_GR1ArmsAndWaistFourierHands_Env
n_envs = 25
episodes = 50
```

Before this fix:

```text
Success rate: 0.08
```

After this fix:

```text
Success rate: 0.74
Collecting 50 episodes took 757.47 seconds
```

I also checked that the adapter now preserves batch instructions correctly, e.g. `["task-a", "task-b", "task-c"]` remains mapped to the corresponding batch samples instead of being collapsed to `"task-a"`.

## Notes

This bug has little effect on fixed-object tasks where all environments share the same instruction, but it can severely underestimate success rates on novel split tasks when `n_envs > 1`.

Related issue: #400
