### PR TITLE
[chore] docs(eval): warn about train/test observation consistency at eval ent…

### DIFF
--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -28,6 +28,29 @@ def main(args) -> None:
     local_ip = socket.gethostbyname(hostname)
     logging.info("Creating server (host: %s, ip: %s)", hostname, local_ip)
 
+    # =========================================================================
+    # !!! TRAIN / TEST CONSISTENCY — READ BEFORE SERVING !!!
+    # -------------------------------------------------------------------------
+    # This server replays the *training-time* observation contract. The eval
+    # client MUST feed observations exactly as the model saw them at TRAIN time,
+    # otherwise the success rate silently drops (no error is raised):
+    #   - state   : is proprioceptive state used? (use_state) and its dim/order
+    #   - img size: resize / crop resolution (e.g. 224x224)
+    #   - img num : how many camera views are fed
+    #   - img order: the ordering of those camera views
+    #   - action normalization: unnorm_key / dataset stats must match training
+    # `wrapper.metadata` (logged below and sent at handshake) exposes
+    # action_chunk_size / state_keys / action_keys — cross-check these against
+    # the training config used to produce `args.ckpt_path`.
+    # =========================================================================
+    logging.warning(
+        "[TRAIN/TEST CONSISTENCY CHECK] serving ckpt=%s — verify eval observations "
+        "(state / image size / image count / image order / action normalization) match "
+        "the training config. metadata=%s",
+        args.ckpt_path,
+        wrapper.metadata,
+    )
+
     # start websocket server; wrapper.metadata is sent at handshake.
     server = WebsocketPolicyServer(
         policy=wrapper,

--- a/deployment/model_server/tools/websocket_policy_client.py
+++ b/deployment/model_server/tools/websocket_policy_client.py
@@ -12,6 +12,32 @@ from typing_extensions import override
 
 from . import msgpack_numpy
 
+# =============================================================================
+# TRAIN / TEST CONSISTENCY REMINDER (shown at every eval entry point)
+# -----------------------------------------------------------------------------
+# Every eval benchmark under `examples/` connects to the policy server through
+# this client, so this banner is emitted once per eval run. Embodied policies
+# are extremely sensitive to the gap between how observations are built during
+# TRAINING versus INFERENCE. A silent mismatch will NOT raise an error, it will
+# only quietly degrade the success rate.
+# =============================================================================
+_CONSISTENCY_REMINDER = (
+    "\n"
+    "============================================================\n"
+    "  [TRAIN/TEST CONSISTENCY CHECK] read before trusting results\n"
+    "------------------------------------------------------------\n"
+    "  Make sure the EVAL observation matches TRAINING for:\n"
+    "    - state    : whether proprioceptive state is fed (use_state)\n"
+    "                 and its dimension / ordering\n"
+    "    - img size : resize / crop resolution (e.g. 224x224)\n"
+    "    - img count: how many camera views are fed to the model\n"
+    "    - img order: the ordering of those camera views\n"
+    "    - horizon  : action chunk size / action horizon\n"
+    "  A mismatch on ANY of these silently lowers the success rate.\n"
+    "  Cross-check the values below against your training config.\n"
+    "============================================================"
+)
+
 
 class WebsocketClientPolicy:
     """Implements the Policy interface by communicating with a server over websocket.
@@ -27,6 +53,11 @@ class WebsocketClientPolicy:
         self._packer = msgpack_numpy.Packer()
         self._api_key = api_key
         self._ws, self._server_metadata = self._wait_for_server()
+
+        # Remind the user to keep the eval-time observation pipeline aligned with
+        # training, and echo the server metadata so the values can be verified.
+        logging.warning(_CONSISTENCY_REMINDER)
+        logging.warning("[TRAIN/TEST CONSISTENCY CHECK] server metadata: %s", self._server_metadata)
 
     def get_server_metadata(self) -> Dict:
         return self._server_metadata

--- a/examples/Behavior/model2behavior_interface.py
+++ b/examples/Behavior/model2behavior_interface.py
@@ -227,6 +227,16 @@ class M1Inference:
         if self.current_step % action_chunk_size == 0:
             if self.current_step % 100 == 0:
                 print("Step:", self.current_step)
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization)
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.infer(vla_input)
 
             # Check if the response indicates an error

--- a/examples/DOMINO/eval_files/model2robotwin_interface.py
+++ b/examples/DOMINO/eval_files/model2robotwin_interface.py
@@ -330,6 +330,16 @@ class ModelClient:
         action_chunk_size = self.action_chunk_size
 
         if step % action_chunk_size == 0 or self.raw_actions is None:
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.predict_action(vla_input)
             # server already un-normalized via training-time transform
             raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)

--- a/examples/LIBERO-plus/eval_files/model2libero_interface.py
+++ b/examples/LIBERO-plus/eval_files/model2libero_interface.py
@@ -135,6 +135,16 @@ class ModelClient:
 
         action_chunk_size = self.action_chunk_size
         if step % action_chunk_size == 0:
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.predict_action(vla_input)
             # server already un-normalized via training-time transform
             self.raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)

--- a/examples/LIBERO/eval_files/model2libero_interface.py
+++ b/examples/LIBERO/eval_files/model2libero_interface.py
@@ -136,6 +136,16 @@ class ModelClient:
                 "use_ddim": self.use_ddim,
                 "num_ddim_steps": self.num_ddim_steps,
             }
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.predict_action(vla_input)
             try:
                 actions_batch = response["data"]["actions"]  # (B, T, D), unnormalized server-side

--- a/examples/Robocasa_365/eval_files/model2robocasa365_interface.py
+++ b/examples/Robocasa_365/eval_files/model2robocasa365_interface.py
@@ -116,6 +116,16 @@ class PolicyWarper:
             "num_ddim_steps": self.num_ddim_steps,
         }
         vla_input["unnorm_key"] = self.unnorm_key
+        # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+        # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+        # differs from what the model saw during TRAINING. Verify these match the
+        # training config used for this checkpoint:
+        #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+        #   - image size  : resize / crop resolution (e.g. 224x224)
+        #   - image count : how many camera views are fed
+        #   - image order : the ordering of those camera views
+        #   - action normalization: unnorm_key must match the training dataset stats
+        # ==============================================================================
         response = self.client.predict_action(vla_input)
         # server already un-normalized via training-time transform
         raw_actions = np.array(response["data"]["actions"])  # (B, chunk, D)

--- a/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
+++ b/examples/Robocasa_tabletop/eval_files/model2robocasa_interface.py
@@ -177,6 +177,16 @@ class PolicyWarper:
         }
         vla_input["unnorm_key"] = self.unnorm_key
 
+        # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+        # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+        # differs from what the model saw during TRAINING. Verify these match the
+        # training config used for this checkpoint:
+        #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+        #   - image size  : resize / crop resolution (e.g. 224x224)
+        #   - image count : how many camera views are fed
+        #   - image order : the ordering of those camera views
+        #   - action normalization: unnorm_key must match the training dataset stats
+        # ==============================================================================
         response = self.client.predict_action(vla_input)
         # server already un-normalized via training-time transform
         raw_actions = np.array(response["data"]["actions"])  # (B, chunk, D)

--- a/examples/Robotwin/eval_files/model2robotwin_interface.py
+++ b/examples/Robotwin/eval_files/model2robotwin_interface.py
@@ -127,6 +127,16 @@ class ModelClient:
         action_chunk_size = self.action_chunk_size
 
         if step % action_chunk_size == 0 or self.raw_actions is None:
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.predict_action(vla_input)
             # server already un-normalized via training-time transform
             raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)

--- a/examples/SimplerEnv/eval_files/model2simpler_interface.py
+++ b/examples/SimplerEnv/eval_files/model2simpler_interface.py
@@ -146,6 +146,16 @@ class ModelClient:
         }
 
         vla_input["unnorm_key"] = self.unnorm_key
+        # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+        # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+        # differs from what the model saw during TRAINING. Verify these match the
+        # training config used for this checkpoint:
+        #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+        #   - image size  : resize / crop resolution (e.g. 224x224)
+        #   - image count : how many camera views are fed
+        #   - image order : the ordering of those camera views
+        #   - action normalization: unnorm_key must match the training dataset stats
+        # ==============================================================================
         response = self.client.predict_action(vla_input)
 
         # server already un-normalized via training-time transform

--- a/examples/VLA-Arena/eval_files/model2vla_arena_interface.py
+++ b/examples/VLA-Arena/eval_files/model2vla_arena_interface.py
@@ -115,6 +115,16 @@ class ModelClient:
 
         action_chunk_size = self.action_chunk_size
         if step % action_chunk_size == 0:
+            # === TRAIN/TEST CONSISTENCY: keep the observation below aligned with training ===
+            # Embodied policies degrade SILENTLY (no error) when the eval-time observation
+            # differs from what the model saw during TRAINING. Verify these match the
+            # training config used for this checkpoint:
+            #   - state       : whether proprioceptive state is included (and its dim/order/normalization))
+            #   - image size  : resize / crop resolution (e.g. 224x224)
+            #   - image count : how many camera views are fed
+            #   - image order : the ordering of those camera views
+            #   - action normalization: unnorm_key must match the training dataset stats
+            # ==============================================================================
             response = self.client.predict_action(vla_input)
             # server already un-normalized via training-time transform
             self.raw_actions = np.array(response["data"]["actions"][0])  # (chunk, D)


### PR DESCRIPTION
## Motivation

Embodied policies are extremely sensitive to the gap between how observations
are built at TRAINING vs INFERENCE. When they mismatch, no error is raised —
the success rate just silently drops. The most common culprits are: whether
proprioceptive state is used, image size, image count, image order, and action
normalization. This PR adds prominent, hard-to-miss reminders at every eval
entry point so users cross-check their eval setup against the training config.

## Changes

- **Eval client** (`deployment/model_server/tools/websocket_policy_client.py`):
  log a `TRAIN/TEST CONSISTENCY CHECK` banner + the server metadata right after
  the websocket handshake. Every benchmark under `examples/` connects through
  this client, so the reminder fires once per eval run.
- **Server startup** (`deployment/model_server/server_policy.py`): add a
  prominent note block and a warning log before `serve_forever()`.
- **Eval adapters**: add an inline reminder comment above the inference call in
  each `examples/*/model2*_interface.py` (LIBERO, LIBERO-plus, SimplerEnv,
  Behavior, DOMINO, Robotwin, VLA-Arena, Robocasa_365, Robocasa_tabletop).

## Testing

- [x] Ran `black --check` on the files this PR touches — my added lines pass
  (the only Black diffs are pre-existing historical backlog, left untouched to
  avoid unrelated changes per PR_readme).
- [x] Comments/logging only — no behavior or model output changes.

## Breaking Changes

None.