### PR TITLE
[fix] (training): wire gradient accumulation config

### DIFF
--- a/examples/modelExtensions/Gemma4/_make_accelerate_config.py
+++ b/examples/modelExtensions/Gemma4/_make_accelerate_config.py
@@ -2,14 +2,10 @@
 """
 Generate accelerate + DeepSpeed configs with the requested gradient accumulation steps.
 
-starVLA's `trainer.gradient_accumulation_steps` is dead config — the actual value
-is read from `starVLA/config/deepseeds/ds_config.yaml` at module-import time
-because `train_starvla.py` constructs `Accelerator(deepspeed_plugin=...)` before
-`cfg` is parsed (and DeepSpeed grad_accum can only come from its own JSON).
-
-Instead of patching upstream, this helper writes a temp pair of config files with
-the right value, and prints the path to the generated accelerate yaml so the
-launcher can pass it via `--config_file`.
+StarVLA now passes `trainer.gradient_accumulation_steps` into `Accelerator`.
+This helper still writes a temp pair of config files for launchers that need
+per-run DeepSpeed files, keeping the generated DeepSpeed value aligned with the
+trainer CLI override.
 
 Usage:
   python _make_accelerate_config.py --grad-accum 4

--- a/examples/modelExtensions/Gemma4/submit_hpc3_libero.sh
+++ b/examples/modelExtensions/Gemma4/submit_hpc3_libero.sh
@@ -57,9 +57,8 @@ export NCCL_TIMEOUT=10000
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
 # === Generate accelerate + DeepSpeed config ===
-# Note: starVLA's trainer.gradient_accumulation_steps is not wired to the
-# Accelerator at construction time (see issue #41). Real grad-accum must come
-# from the DeepSpeed JSON, generated here.
+# Keep the per-run DeepSpeed file and the trainer CLI override aligned so
+# gradient accumulation is consistent across Accelerate and DeepSpeed.
 ACCEL_CONFIG=$(python3 examples/modelExtensions/Gemma4/_make_accelerate_config.py \
     --grad-accum "${GRAD_ACCUM}" \
     --num-processes 8 \

--- a/examples/modelExtensions/MiniCPM/submit_hpc3_libero.sh
+++ b/examples/modelExtensions/MiniCPM/submit_hpc3_libero.sh
@@ -9,10 +9,10 @@
 #
 # Slurm submission for MiniCPM-V 4.6 LIBERO training (8×GPU).
 # Aligned with upstream starVLA run_libero_train.sh:
-#   - Uses static deepspeed_zero2.yaml (GA hard-coded to 1 in ds_config.yaml)
+#   - Uses static deepspeed_zero2.yaml
 #   - Per-device BS=16, num_processes=8 -> effective BS = 128
-#   - Note: upstream's `trainer.gradient_accumulation_steps` in YAML is dead config;
-#     real GA is whatever ds_config.yaml says (1). We do NOT pass --grad-accum.
+#   - Passes GRAD_ACCUM explicitly so this script keeps GA=1 by default even
+#     when the shared LIBERO YAML uses a different value.
 #
 # Usage:
 #   sbatch examples/modelExtensions/MiniCPM/submit_hpc3_libero.sh
@@ -24,6 +24,7 @@
 #   DATA_MIX      - libero_all / libero_spatial / ...
 #   MAX_STEPS     - default 80000 (upstream guideline)
 #   PER_DEVICE_BS - default 16  (matches upstream run_libero_train.sh)
+#   GRAD_ACCUM    - default 1
 #   ATTN_IMPL     - default sdpa
 #   FREEZE_MODULES - default '' (unfreeze VLM, matches upstream)
 
@@ -38,6 +39,7 @@ BASE_VLM="${BASE_VLM:-openbmb/MiniCPM-V-4.6}"
 DATA_MIX="${DATA_MIX:-libero_all}"
 MAX_STEPS="${MAX_STEPS:-80000}"
 PER_DEVICE_BS="${PER_DEVICE_BS:-16}"
+GRAD_ACCUM="${GRAD_ACCUM:-1}"
 ATTN_IMPL="${ATTN_IMPL:-sdpa}"
 ENABLE_GRAD_CKPT="${ENABLE_GRAD_CKPT:-true}"
 FREEZE_MODULES="${FREEZE_MODULES:-}"
@@ -58,7 +60,7 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
 echo "[minicpm-vla] FRAMEWORK=${FRAMEWORK}  BASE_VLM=${BASE_VLM}"
 echo "[minicpm-vla] DATA_MIX=${DATA_MIX}  STEPS=${MAX_STEPS}  PER_DEVICE_BS=${PER_DEVICE_BS}"
-echo "[minicpm-vla] effective BS = ${PER_DEVICE_BS}×8×1 (GA=1 from ds_config.yaml)"
+echo "[minicpm-vla] GRAD_ACCUM=${GRAD_ACCUM}  effective BS = ${PER_DEVICE_BS}×8×${GRAD_ACCUM}"
 echo "[minicpm-vla] FREEZE_MODULES='${FREEZE_MODULES}'  RUN_ID=${RUN_ID}"
 
 accelerate launch \
@@ -75,6 +77,7 @@ accelerate launch \
   --datasets.vla_data.data_root_dir "${LIBERO_DATA_ROOT}" \
   --datasets.vla_data.data_mix "${DATA_MIX}" \
   --datasets.vla_data.per_device_batch_size "${PER_DEVICE_BS}" \
+  --trainer.gradient_accumulation_steps "${GRAD_ACCUM}" \
   --trainer.max_train_steps "${MAX_STEPS}" \
   --trainer.freeze_modules "${FREEZE_MODULES}" \
   --trainer.save_interval 10000 \

--- a/starVLA/config/deepseeds/ds_config.yaml
+++ b/starVLA/config/deepseeds/ds_config.yaml
@@ -7,7 +7,7 @@
     },
     "train_micro_batch_size_per_gpu": "auto",
     "train_batch_size": "auto",
-    "gradient_accumulation_steps": 1,
+    "gradient_accumulation_steps": "auto",
     "zero_optimization": {
         "stage": 2,
         "allgather_partitions": true,

--- a/starVLA/training/accelerator_utils.py
+++ b/starVLA/training/accelerator_utils.py
@@ -1,0 +1,32 @@
+def _config_get(config, key: str, default=None):
+    if config is None:
+        return default
+    if hasattr(config, "get"):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def get_gradient_accumulation_steps(cfg) -> int:
+    value = _config_get(_config_get(cfg, "trainer"), "gradient_accumulation_steps", 1)
+    try:
+        steps = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("trainer.gradient_accumulation_steps must be a positive integer") from exc
+    if steps < 1:
+        raise ValueError("trainer.gradient_accumulation_steps must be a positive integer")
+    return steps
+
+
+def load_accelerate_classes():
+    from accelerate import Accelerator, DeepSpeedPlugin
+
+    return Accelerator, DeepSpeedPlugin
+
+
+def create_accelerator(cfg):
+    accelerator_cls, deepspeed_plugin_cls = load_accelerate_classes()
+    deepspeed_plugin = deepspeed_plugin_cls()
+    return accelerator_cls(
+        deepspeed_plugin=deepspeed_plugin,
+        gradient_accumulation_steps=get_gradient_accumulation_steps(cfg),
+    )

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -13,6 +13,7 @@ Conventions:
 # Standard Library
 import argparse
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -32,8 +33,6 @@ except ImportError:
     pass
 
 import wandb
-from accelerate import Accelerator, DeepSpeedPlugin
-from accelerate.logging import get_logger
 from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
@@ -44,18 +43,15 @@ from transformers import AutoProcessor, get_scheduler
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.model.framework.share_tools import apply_config_compat
+from starVLA.training.accelerator_utils import create_accelerator
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
 from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
-
-deepspeed_plugin = DeepSpeedPlugin()
-accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
-accelerator.print(accelerator.state)
 
 # Sane Defaults
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Initialize logger
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def load_fast_tokenizer():
@@ -458,6 +454,8 @@ def main(cfg) -> None:
 
     cfg = wrap_config(cfg)
     logger.info("✅ Configuration wrapped for access tracking")
+    accelerator = create_accelerator(cfg)
+    accelerator.print(accelerator.state)
 
     output_dir = setup_directories(cfg=cfg)
     vla = build_framework(cfg)

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -13,6 +13,7 @@ Conventions:
 # Standard Library
 import argparse
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -23,8 +24,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import wandb
-from accelerate import Accelerator, DeepSpeedPlugin
-from accelerate.logging import get_logger
 from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
@@ -35,18 +34,15 @@ from transformers import AutoProcessor, get_scheduler
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
 from starVLA.model.framework.share_tools import apply_config_compat
+from starVLA.training.accelerator_utils import create_accelerator
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
 from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
-
-deepspeed_plugin = DeepSpeedPlugin()
-accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
-accelerator.print(accelerator.state)
 
 # Sane Defaults
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Initialize logger
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def load_fast_tokenizer():
@@ -456,6 +452,8 @@ def main(cfg) -> None:
 
     cfg = wrap_config(cfg)
     logger.info("✅ Configuration wrapped for access tracking")
+    accelerator = create_accelerator(cfg)
+    accelerator.print(accelerator.state)
 
     output_dir = setup_directories(cfg=cfg)
     vla = build_framework(cfg)

--- a/starVLA/training/train_starvlm.py
+++ b/starVLA/training/train_starvlm.py
@@ -13,6 +13,7 @@ Conventions:
 # Standard Library
 import argparse
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Tuple
@@ -21,8 +22,6 @@ from typing import Tuple
 import torch
 import torch.distributed as dist
 import wandb
-from accelerate import Accelerator, DeepSpeedPlugin
-from accelerate.logging import get_logger
 from accelerate.utils import set_seed
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
@@ -32,18 +31,15 @@ from transformers import AutoProcessor, get_scheduler
 # Local Modules
 from starVLA.dataloader import build_dataloader
 from starVLA.model.framework.base_framework import build_framework
+from starVLA.training.accelerator_utils import create_accelerator
 from starVLA.training.trainer_utils.config_tracker import AccessTrackedConfig, wrap_config
 from starVLA.training.trainer_utils.trainer_tools import TrainerUtils, build_param_lr_groups, setup_optimizer_and_scheduler, normalize_dotlist_args
-
-deepspeed_plugin = DeepSpeedPlugin()
-accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)
-accelerator.print(accelerator.state)
 
 # Sane Defaults
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Initialize logger
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def load_fast_tokenizer():
@@ -323,6 +319,8 @@ def main(cfg) -> None:
 
     cfg = wrap_config(cfg)
     logger.info("✅ Configuration wrapped for access tracking")
+    accelerator = create_accelerator(cfg)
+    accelerator.print(accelerator.state)
 
     output_dir = setup_directories(cfg=cfg)
     vlm = build_framework(cfg)

--- a/tests/test_single_process_dist_safety.py
+++ b/tests/test_single_process_dist_safety.py
@@ -19,9 +19,10 @@ class SingleProcessDistSafetyTest(unittest.TestCase):
         num_params, num_trainable = TrainerUtils.print_trainable_parameters(model)
         self.assertEqual(num_params, num_trainable)
 
-        with tempfile.NamedTemporaryFile(suffix=".pt") as checkpoint_file:
-            torch.save(model.state_dict(), checkpoint_file.name)
-            loaded_model = TrainerUtils.load_pretrained_backbones(nn.Linear(2, 3), checkpoint_file.name)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_path = os.path.join(tmpdir, "checkpoint.pt")
+            torch.save(model.state_dict(), checkpoint_path)
+            loaded_model = TrainerUtils.load_pretrained_backbones(nn.Linear(2, 3), checkpoint_path)
 
         self.assertIsInstance(loaded_model, nn.Module)
 

--- a/tests/test_training_accelerator_config.py
+++ b/tests/test_training_accelerator_config.py
@@ -1,0 +1,78 @@
+import ast
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+TRAINING_ENTRYPOINTS = [
+    REPO_ROOT / "starVLA" / "training" / "train_starvla.py",
+    REPO_ROOT / "starVLA" / "training" / "train_starvla_cotrain.py",
+    REPO_ROOT / "starVLA" / "training" / "train_starvlm.py",
+]
+
+
+class AcceleratorConfigTest(unittest.TestCase):
+    def test_create_accelerator_uses_trainer_gradient_accumulation_steps(self):
+        try:
+            accelerator_utils = importlib.import_module("starVLA.training.accelerator_utils")
+        except ImportError as exc:
+            self.fail(f"starVLA.training.accelerator_utils is missing: {exc}")
+
+        cfg = SimpleNamespace(trainer=SimpleNamespace(gradient_accumulation_steps=7))
+        fake_plugin = object()
+        fake_accelerator = object()
+        plugin_cls = mock.Mock(return_value=fake_plugin)
+        accelerator_cls = mock.Mock(return_value=fake_accelerator)
+
+        with mock.patch.object(
+            accelerator_utils,
+            "load_accelerate_classes",
+            return_value=(accelerator_cls, plugin_cls),
+        ):
+            accelerator = accelerator_utils.create_accelerator(cfg)
+
+        self.assertIs(accelerator, fake_accelerator)
+        accelerator_cls.assert_called_once_with(
+            deepspeed_plugin=fake_plugin,
+            gradient_accumulation_steps=7,
+        )
+
+    def test_training_entrypoints_create_accelerator_after_config_load(self):
+        for script_path in TRAINING_ENTRYPOINTS:
+            with self.subTest(script=script_path.name):
+                tree = ast.parse(script_path.read_text(encoding="utf-8"))
+                top_level_accelerator_calls = []
+                main_create_calls = 0
+
+                for node in tree.body:
+                    if isinstance(node, ast.Assign):
+                        for target in node.targets:
+                            if isinstance(target, ast.Name) and target.id == "accelerator":
+                                if isinstance(node.value, ast.Call):
+                                    func = node.value.func
+                                    if isinstance(func, ast.Name) and func.id == "Accelerator":
+                                        top_level_accelerator_calls.append(node.lineno)
+                    if isinstance(node, ast.FunctionDef) and node.name == "main":
+                        for child in ast.walk(node):
+                            if isinstance(child, ast.Call):
+                                func = child.func
+                                if isinstance(func, ast.Name) and func.id == "create_accelerator":
+                                    main_create_calls += 1
+
+                self.assertEqual(top_level_accelerator_calls, [])
+                self.assertEqual(main_create_calls, 1)
+
+    def test_deepspeed_config_defers_gradient_accumulation_to_accelerate(self):
+        ds_config_path = REPO_ROOT / "starVLA" / "config" / "deepseeds" / "ds_config.yaml"
+        self.assertIn('"gradient_accumulation_steps": "auto"', ds_config_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Wires `trainer.gradient_accumulation_steps` into Accelerate initialization for the VLA, VLA/VLM co-training, and VLM training entry points. The accelerator is now created inside `main(cfg)` after the merged trainer config is available, so YAML and CLI overrides affect `accelerator.gradient_accumulation_steps` and the total batch-size calculation.

The shared ZeRO-2 DeepSpeed config now defers gradient accumulation to Accelerate with `"auto"`. The Gemma4 and MiniCPM launch notes were updated accordingly, and MiniCPM now passes `GRAD_ACCUM=1` by default to preserve its documented effective batch size.

## Motivation

Closes #366

`trainer.gradient_accumulation_steps` was present in YAML and launch examples, but the training modules created `Accelerator(deepspeed_plugin=...)` at module import time before config parsing. That made the trainer-side setting ineffective for Accelerate, while the shared DeepSpeed config also pinned gradient accumulation to `1`.

## Changes

- Add `starVLA.training.accelerator_utils.create_accelerator(cfg)` to read and validate `trainer.gradient_accumulation_steps`.
- Move accelerator creation from module import time into `main(cfg)` for VLA, co-training, and VLM training entry points.
- Change `starVLA/config/deepseeds/ds_config.yaml` to `"gradient_accumulation_steps": "auto"`.
- Update Gemma4/MiniCPM launcher comments and preserve MiniCPM's GA=1 default explicitly.
- Add focused coverage for accelerator config wiring and keep the single-process checkpoint test Windows-safe.

## Testing

- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
| N/A | N/A | Not a framework or benchmark change |

- **Checkpoint**: N/A
- **Config**: `starVLA/config/deepseeds/ds_config.yaml`
- **Reproduce**:
  - `python tests/test_training_accelerator_config.py`
  - `PYTHONPATH=. PYTHONUTF8=1 python tests/test_single_process_dist_safety.py`
  - `python -m py_compile starVLA/training/accelerator_utils.py starVLA/training/train_starvla.py starVLA/training/train_starvla_cotrain.py starVLA/training/train_starvlm.py tests/test_training_accelerator_config.py tests/test_single_process_dist_safety.py`
  - `git diff --check`
  - `docker run --rm -v "${PWD}:/workspace/starVLA" -w /workspace/starVLA starvla-train:latest bash -lc "python tests/test_training_accelerator_config.py"`
  - `docker run --rm -v "${PWD}:/workspace/starVLA" -w /workspace/starVLA starvla-train:latest bash -lc "python - <<'PY' ... PY"` verified `gradient_accumulation_steps 3` and `DistributedType.DEEPSPEED`.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [ ] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

## Screenshots / Logs (optional)

Unit and compile checks pass locally in the Python 3.11 environment with torch 2.7.1+cu128 and accelerate 1.5.2.

Docker smoke with the `starvla-train:latest` image also passes for the accelerator config path and confirms the real DeepSpeed-backed accelerator reads `gradient_accumulation_steps=3`. A full local GPU training step was not run because the local RTX 5070 Laptop GPU is reported as CUDA capability `sm_120`, while the current training image's PyTorch build supports up to `sm_90`.
