### PR TITLE
[fix] (libero): align eval image views with training metadata

### DIFF
--- a/deployment/model_server/metadata_utils.py
+++ b/deployment/model_server/metadata_utils.py
@@ -1,0 +1,78 @@
+"""Lightweight helpers for policy-server metadata."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+
+def as_string_list(value: Any) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    return None
+
+
+def training_video_keys_from_model_config(model_cfg: Dict[str, Any]) -> Optional[List[str]]:
+    """Return the training video-key order when one data config defines it."""
+    vla_data_cfg = model_cfg.get("datasets", {}).get("vla_data", {})
+    data_mix = vla_data_cfg.get("data_mix", None)
+    if not data_mix:
+        return None
+
+    try:
+        from starVLA.dataloader.gr00t_lerobot.data_config import ROBOT_TYPE_CONFIG_MAP
+        from starVLA.dataloader.gr00t_lerobot.mixtures import DATASET_NAMED_MIXTURES
+    except Exception as exc:  # pragma: no cover - metadata should not block serving
+        logging.warning("Could not import data config metadata: %s", exc)
+        return None
+
+    mix_entries = DATASET_NAMED_MIXTURES.get(data_mix, None)
+    if not mix_entries:
+        return None
+
+    video_key_orders: List[List[str]] = []
+    for _, _, robot_type in mix_entries:
+        robot_cfg = ROBOT_TYPE_CONFIG_MAP.get(robot_type, None)
+        keys = as_string_list(getattr(robot_cfg, "video_keys", None)) if robot_cfg is not None else None
+        if keys:
+            video_key_orders.append(keys)
+
+    if not video_key_orders:
+        return None
+
+    first = video_key_orders[0]
+    if all(keys == first for keys in video_key_orders):
+        return first
+    logging.warning(
+        "Data mix %s uses multiple video-key orders; omitting vla_video_keys metadata: %s",
+        data_mix,
+        video_key_orders,
+    )
+    return None
+
+
+def build_image_metadata_from_model_config(model_cfg: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Build image-contract metadata advertised by the policy server."""
+    vla_data_cfg = model_cfg.get("datasets", {}).get("vla_data", {})
+    vla_data_obs = as_string_list(vla_data_cfg.get("obs", None))
+    vla_video_keys = training_video_keys_from_model_config(model_cfg)
+
+    metadata: Dict[str, List[str]] = {}
+    if vla_video_keys is not None:
+        metadata["vla_video_keys"] = vla_video_keys
+    if vla_data_obs is not None:
+        metadata["vla_data_obs"] = vla_data_obs
+
+    if vla_video_keys is not None and vla_data_obs is not None and len(vla_video_keys) != len(vla_data_obs):
+        logging.warning(
+            "Using derived vla_video_keys over raw vla_data_obs for eval image ordering because they "
+            "describe different image counts: vla_video_keys=%s, vla_data_obs=%s",
+            vla_video_keys,
+            vla_data_obs,
+        )
+
+    return metadata

--- a/deployment/model_server/policy_wrapper.py
+++ b/deployment/model_server/policy_wrapper.py
@@ -30,6 +30,7 @@ import torch
 from starVLA.model.framework.base_framework import baseframework
 from starVLA.model.framework.share_tools import read_mode_config
 
+from deployment.model_server.metadata_utils import build_image_metadata_from_model_config
 from deployment.model_server.policy_norm_processor import PolicyNormProcessor
 
 
@@ -55,6 +56,7 @@ class PolicyServerWrapper:
         # Co-located metadata.
         model_cfg, _ = read_mode_config(self._ckpt_path)
         self._model_cfg = model_cfg
+        self._image_metadata = build_image_metadata_from_model_config(self._model_cfg)
 
         # action_chunk_size = future_action_window_size + 1 (matches old client).
         action_model_cfg = model_cfg["framework"]["action_model"]
@@ -109,6 +111,8 @@ class PolicyServerWrapper:
     @property
     def metadata(self) -> Dict[str, Any]:
         """Model-invariant metadata; sent to client at websocket handshake."""
+        action_model_cfg = self._model_cfg.get("framework", {}).get("action_model", {})
+
         base = {
             "env": "starvla_policy_server",
             "ckpt_path": self._ckpt_path,
@@ -116,6 +120,10 @@ class PolicyServerWrapper:
             "available_unnorm_keys": self._available_unnorm_keys,
             "default_unnorm_key": self._default_unnorm_key,
         }
+        base.update(self._image_metadata)
+        if "num_inference_timesteps" in action_model_cfg:
+            base["num_inference_timesteps"] = action_model_cfg["num_inference_timesteps"]
+
         # Enrich with per-embodiment keys when a default processor already exists.
         if self._default_unnorm_key is not None:
             proc = self._get_processor(self._default_unnorm_key)

--- a/examples/simBenchmarks/LIBERO/eval_files/model2libero_interface.py
+++ b/examples/simBenchmarks/LIBERO/eval_files/model2libero_interface.py
@@ -25,6 +25,44 @@ from deployment.model_server.tools.websocket_policy_client import WebsocketClien
 from examples.simBenchmarks.SimplerEnv.eval_files.adaptive_ensemble import AdaptiveEnsembler
 
 
+def _image_index_from_training_key(key: str) -> Optional[int]:
+    """Map common training image-key names to the LIBERO eval image list index."""
+    name = str(key).lower().replace("-", "_")
+    leaf = name.split(".")[-1]
+
+    if leaf in {"image_0", "primary", "primary_image", "agentview", "agentview_image", "image"}:
+        return 0
+    if "primary" in name or "agentview" in name:
+        return 0
+
+    if leaf in {"image_1", "wrist", "wrist_image", "eye_in_hand", "robot0_eye_in_hand_image"}:
+        return 1
+    if "wrist" in name or "eye_in_hand" in name:
+        return 1
+
+    return None
+
+
+def _image_indices_from_metadata(meta: dict) -> Optional[list[int]]:
+    """Return the requested eval image order from server metadata when available."""
+    requested = meta.get("vla_video_keys", None)
+    if requested is None:
+        requested = meta.get("vla_data_obs", None)
+    if not requested:
+        return None
+    if isinstance(requested, str):
+        requested = [requested]
+
+    indices: list[int] = []
+    for key in requested:
+        idx = _image_index_from_training_key(key)
+        if idx is None:
+            return None
+        if idx not in indices:
+            indices.append(idx)
+    return indices or None
+
+
 class ModelClient:
     def __init__(
         self,
@@ -45,6 +83,7 @@ class ModelClient:
         meta = self.client.get_server_metadata()
         self.action_chunk_size = int(meta["action_chunk_size"])
         self._server_metadata = meta
+        self._image_indices = _image_indices_from_metadata(meta)
 
         self.image_size: tuple = tuple(image_size)
         self.policy_setup = policy_setup
@@ -82,6 +121,21 @@ class ModelClient:
         # Cached unnormalized chunk; refreshed every `action_chunk_size` steps.
         self.raw_actions: Optional[np.ndarray] = None
 
+    def _align_images_to_training_config(self, example: dict) -> dict:
+        images = example.get("image")
+        if self._image_indices is None or not isinstance(images, (list, tuple)):
+            return example
+
+        selected = []
+        for idx in self._image_indices:
+            if idx >= len(images):
+                raise ValueError(
+                    f"Checkpoint metadata requested image index {idx}, but eval example only has "
+                    f"{len(images)} image(s). server_meta={self._server_metadata}"
+                )
+            selected.append(images[idx])
+        return {**example, "image": selected}
+
     def _add_image_to_history(self, image: np.ndarray) -> None:
         self.image_history.append(image)
         self.num_image_history = min(self.num_image_history + 1, self.horizon)
@@ -111,6 +165,8 @@ class ModelClient:
         task_description = example.get("lang", None)
         if task_description != self.task_description:
             self.reset(task_description)
+
+        example = self._align_images_to_training_config(example)
 
         # Resize images to self.image_size if needed.
         if self.image_size and example.get("image"):

--- a/tests/test_libero_eval_client.py
+++ b/tests/test_libero_eval_client.py
@@ -1,0 +1,104 @@
+"""Tests for LIBERO eval client request shaping."""
+
+import unittest
+from unittest import mock
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+repo_root = Path(__file__).resolve().parents[1]
+examples_pkg = types.ModuleType("examples")
+examples_pkg.__path__ = [str(repo_root / "examples")]
+sys.modules["examples"] = examples_pkg
+
+from examples.simBenchmarks.LIBERO.eval_files import model2libero_interface as m2l
+
+
+class _FakeClient:
+    metadata = {}
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+        _FakeClient.last_instance = self
+
+    def get_server_metadata(self) -> dict:
+        return dict(self.metadata)
+
+    def predict_action(self, vla_input: dict) -> dict:
+        self.requests.append(vla_input)
+        return {"data": {"actions": np.zeros((1, 8, 7), dtype=np.float32)}}
+
+
+def _make_example() -> dict:
+    primary = np.full((32, 32, 3), 11, dtype=np.uint8)
+    wrist = np.full((32, 32, 3), 22, dtype=np.uint8)
+    return {"image": [primary, wrist], "lang": "put the bowl on the plate"}
+
+
+class LiberoModelClientRequestTest(unittest.TestCase):
+    def _make_client(self, metadata: dict) -> m2l.ModelClient:
+        _FakeClient.metadata = metadata
+        with mock.patch.object(m2l, "WebsocketClientPolicy", _FakeClient):
+            return m2l.ModelClient(action_ensemble=False, image_size=(32, 32))
+
+    def test_single_view_video_metadata_sends_primary_image_only(self):
+        client = self._make_client({"action_chunk_size": 8, "vla_video_keys": ["video.primary_image"]})
+
+        client.step(_make_example(), step=0)
+
+        sent_images = _FakeClient.last_instance.requests[-1]["examples"][0]["image"]
+        self.assertEqual(len(sent_images), 1)
+        np.testing.assert_array_equal(sent_images[0], _make_example()["image"][0])
+
+    def test_two_view_video_metadata_preserves_requested_order(self):
+        client = self._make_client(
+            {"action_chunk_size": 8, "vla_video_keys": ["video.wrist_image", "video.primary_image"]}
+        )
+
+        client.step(_make_example(), step=0)
+
+        sent_images = _FakeClient.last_instance.requests[-1]["examples"][0]["image"]
+        self.assertEqual(len(sent_images), 2)
+
+        np.testing.assert_array_equal(sent_images[0], _make_example()["image"][1])
+        np.testing.assert_array_equal(sent_images[1], _make_example()["image"][0])
+
+    def test_video_metadata_takes_precedence_over_raw_vla_data_obs(self):
+        client = self._make_client(
+            {
+                "action_chunk_size": 8,
+                "vla_video_keys": ["video.primary_image", "video.wrist_image"],
+                "vla_data_obs": ["image_0"],
+            }
+        )
+
+        client.step(_make_example(), step=0)
+
+        sent_images = _FakeClient.last_instance.requests[-1]["examples"][0]["image"]
+        self.assertEqual(len(sent_images), 2)
+        np.testing.assert_array_equal(sent_images[0], _make_example()["image"][0])
+        np.testing.assert_array_equal(sent_images[1], _make_example()["image"][1])
+
+    def test_raw_vla_data_obs_fallback_still_supports_single_view_metadata(self):
+        client = self._make_client({"action_chunk_size": 8, "vla_data_obs": ["image_0"]})
+
+        client.step(_make_example(), step=0)
+
+        sent_images = _FakeClient.last_instance.requests[-1]["examples"][0]["image"]
+        self.assertEqual(len(sent_images), 1)
+        np.testing.assert_array_equal(sent_images[0], _make_example()["image"][0])
+
+    def test_missing_checkpoint_metadata_keeps_existing_two_view_behavior(self):
+        client = self._make_client({"action_chunk_size": 8})
+
+        client.step(_make_example(), step=0)
+
+        sent_images = _FakeClient.last_instance.requests[-1]["examples"][0]["image"]
+        self.assertEqual(len(sent_images), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_policy_wrapper_metadata.py
+++ b/tests/test_policy_wrapper_metadata.py
@@ -1,0 +1,115 @@
+"""Tests for policy-server training metadata helpers."""
+
+import sys
+import types
+
+from deployment.model_server.metadata_utils import (
+    build_image_metadata_from_model_config,
+    training_video_keys_from_model_config,
+)
+
+
+def _install_fake_data_config(monkeypatch, robot_configs, mixtures_by_name):
+    data_config = types.ModuleType("starVLA.dataloader.gr00t_lerobot.data_config")
+    data_config.ROBOT_TYPE_CONFIG_MAP = robot_configs
+
+    mixtures = types.ModuleType("starVLA.dataloader.gr00t_lerobot.mixtures")
+    mixtures.DATASET_NAMED_MIXTURES = mixtures_by_name
+
+    monkeypatch.setitem(sys.modules, data_config.__name__, data_config)
+    monkeypatch.setitem(sys.modules, mixtures.__name__, mixtures)
+
+
+def test_libero_mix_metadata_uses_data_config_video_keys(monkeypatch):
+    class FakeRobotConfig:
+        video_keys = ["video.primary_image", "video.wrist_image"]
+
+    _install_fake_data_config(
+        monkeypatch,
+        {"libero_franka": FakeRobotConfig()},
+        {
+            "libero_all": [
+                ("libero_object", 1.0, "libero_franka"),
+                ("libero_goal", 1.0, "libero_franka"),
+            ]
+        },
+    )
+
+    model_cfg = {
+        "datasets": {
+            "vla_data": {
+                "data_mix": "libero_all",
+                "obs": ["image_0"],
+            }
+        }
+    }
+
+    assert training_video_keys_from_model_config(model_cfg) == [
+        "video.primary_image",
+        "video.wrist_image",
+    ]
+
+
+def test_missing_data_mix_has_no_video_key_metadata():
+    model_cfg = {"datasets": {"vla_data": {"obs": ["image_0"]}}}
+
+    assert training_video_keys_from_model_config(model_cfg) is None
+
+
+def test_unknown_data_mix_has_no_video_key_metadata(monkeypatch):
+    _install_fake_data_config(monkeypatch, {}, {})
+    model_cfg = {"datasets": {"vla_data": {"data_mix": "unknown_mix"}}}
+
+    assert training_video_keys_from_model_config(model_cfg) is None
+
+
+def test_mixed_video_key_orders_omit_video_key_metadata(monkeypatch):
+    class PrimaryOnlyConfig:
+        video_keys = ["video.primary_image"]
+
+    class DualViewConfig:
+        video_keys = ["video.primary_image", "video.wrist_image"]
+
+    _install_fake_data_config(
+        monkeypatch,
+        {
+            "primary_only": PrimaryOnlyConfig(),
+            "dual_view": DualViewConfig(),
+        },
+        {
+            "mixed_views": [
+                ("primary_dataset", 1.0, "primary_only"),
+                ("dual_dataset", 1.0, "dual_view"),
+            ]
+        },
+    )
+    model_cfg = {"datasets": {"vla_data": {"data_mix": "mixed_views"}}}
+
+    assert training_video_keys_from_model_config(model_cfg) is None
+
+
+def test_image_metadata_warns_when_derived_video_keys_override_raw_obs_count(monkeypatch, caplog):
+    class FakeRobotConfig:
+        video_keys = ["video.primary_image", "video.wrist_image"]
+
+    _install_fake_data_config(
+        monkeypatch,
+        {"libero_franka": FakeRobotConfig()},
+        {"libero_all": [("libero_goal", 1.0, "libero_franka")]},
+    )
+    model_cfg = {
+        "datasets": {
+            "vla_data": {
+                "data_mix": "libero_all",
+                "obs": ["image_0"],
+            }
+        }
+    }
+
+    metadata = build_image_metadata_from_model_config(model_cfg)
+
+    assert metadata == {
+        "vla_video_keys": ["video.primary_image", "video.wrist_image"],
+        "vla_data_obs": ["image_0"],
+    }
+    assert "Using derived vla_video_keys over raw vla_data_obs" in caplog.text


### PR DESCRIPTION
## Description

Align LIBERO eval image payloads with the policy server's training metadata. The server now exposes a derived `vla_video_keys` field from the checkpoint's `data_mix -> robot_type -> DataConfig.video_keys` contract, while also preserving the raw `datasets.vla_data.obs` value as `vla_data_obs` for diagnostics.

The LIBERO client uses `vla_video_keys` first and falls back to `vla_data_obs` only when no derived training video keys are available. Checkpoints without either field keep the existing two-view behavior.

## Related Issue

Related to #402

## Motivation and Context

For QwenVL-style policies, image count and order change the visual token sequence and can silently change benchmark behavior. During validation, the released `StarVLA/Qwen3-VL-PI-LIBERO-4in1` checkpoint had raw config metadata `datasets.vla_data.obs: [image_0]`, but the LIBERO `libero_all` data config defines the training video order as `video.primary_image`, `video.wrist_image`. Blindly using the raw `obs` field would incorrectly drop the wrist image for this checkpoint.

This PR makes the training video-key contract explicit in server metadata and lets eval clients align to it when it is unambiguous. If the derived video-key count differs from the raw `vla_data_obs` count, the server logs a warning and uses the derived video keys for eval image ordering.

## Changes

- Add lightweight policy-server metadata helpers for deriving training video-key order from dataset mix metadata.
- Add `vla_video_keys`, raw `vla_data_obs`, and `num_inference_timesteps` to policy server handshake metadata when available.
- Warn when derived `vla_video_keys` and raw `vla_data_obs` describe different image counts.
- Update the LIBERO client to order/select images from `vla_video_keys`, with backward-compatible fallback behavior.
- Add request-shaping tests for single-view, reordered two-view, raw `vla_data_obs` fallback, and metadata-free behavior.
- Add metadata-helper tests for LIBERO video-key derivation, unknown/mixed data mixes, and the warning path.

## How Has This Been / Can This Be Tested?

Focused tests:

```text
python -m pytest tests/test_libero_eval_client.py tests/test_policy_wrapper_metadata.py tests/test_robocasa_tabletop_interface.py -q
14 passed
```

Remote RTX 4090 LIBERO validation with `StarVLA/Qwen3-VL-PI-LIBERO-4in1`, `libero_goal`:

| Revision | Eval size | Metadata image contract | Result |
| --- | --- | --- | --- |
| parent `600701f` | 1 task x 5 trials | no image metadata; existing two-view client behavior | 3/5 success, 60% |
| this PR `a2c0a11` | 1 task x 5 trials | `vla_video_keys=['video.primary_image', 'video.wrist_image']`, raw `vla_data_obs=['image_0']` | 3/5 success, 60% |
| this PR `a2c0a11` | 3 tasks x 5 trials | same as above | 9/15 success, 60%; per-task 3/5, 5/5, 1/5 |

Server log confirms the diagnostic warning path for the released checkpoint:

```text
Using derived vla_video_keys over raw vla_data_obs for eval image ordering because they describe different image counts: vla_video_keys=['video.primary_image', 'video.wrist_image'], vla_data_obs=['image_0']
```

This confirms the updated policy server + LIBERO rollout runs end to end and preserves the two-view LIBERO behavior for the released 4-in-1 checkpoint. It does **not** establish a success-rate improvement for #402; the validation did not reproduce a before/after lift.

Environment notes for the remote rollout:

- GPU: RTX 4090 24GB
- Python: 3.12 venv, PyTorch 2.5.1+cu124
- Transformers: 4.57.0
- Simulator stack: LIBERO source checkout, robosuite 1.4.0, mujoco 3.2.7, EGL rendering
- Deviation from the checkpoint config: `flash_attention_2` was changed to `sdpa` because `flash_attn` was not installed in the rented environment

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` - N/A
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated - no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public) - N/A