### PR TITLE
feat: add MetaWorld MT50 evaluation and training support

### DIFF
--- a/examples/simBenchmarks/MetaWorld/README.md
+++ b/examples/simBenchmarks/MetaWorld/README.md
@@ -2,7 +2,7 @@
 
 This document provides instructions for evaluating starVLA on the [MetaWorld MT50](https://github.com/Farama-Foundation/Metaworld) benchmark (50 manipulation tasks across 4 difficulty buckets).
 
-The evaluation uses the same client-server architecture as LIBERO: the starVLA policy server handles inference, while the MetaWorld client drives the simulation.
+The evaluation uses a client-server architecture: the starVLA policy server handles inference, while the MetaWorld client drives the simulation.
 
 ---
 
@@ -37,6 +37,8 @@ CKPT=/path/to/your/checkpoint.pt PORT=10095 GPU_ID=0 \
   bash examples/simBenchmarks/MetaWorld/eval_files/run_policy_server.sh
 ```
 
+> Don't have a checkpoint yet? Grab a reference checkpoint from Section 4.
+
 ### Step 2. Run the evaluation (MetaWorld environment)
 
 ```bash
@@ -57,17 +59,17 @@ python examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py \
 
 ---
 
-## 2. Key Differences from LIBERO
+## 2. Benchmark Specifics
 
-| Aspect | LIBERO | MetaWorld MT50 |
-|--------|--------|----------------|
-| Action space | 7D (xyz + rotation + gripper) | 4D (xyz + gripper) |
-| Camera views | 2 (primary + wrist) | 1 (corner2) |
-| Image preprocessing | `[::-1, ::-1]` flip | ROT180 + center\_crop(2/3) + resize 224 |
-| Tasks | 4 suites x 10 tasks | 50 tasks, 4 difficulty buckets |
-| Episodes/task | 50 | 10 |
-| Max steps | 220-520 (per suite) | 400 |
-| Gripper | Binarized | Continuous, clipped to `[-1, 1]` |
+| Aspect | MetaWorld MT50 |
+|--------|----------------|
+| Action space | 4D (xyz + gripper) |
+| Camera views | 1 (corner2) |
+| Image preprocessing | ROT180 + center\_crop(2/3) + resize 224 |
+| Tasks | 50 tasks, 4 difficulty buckets |
+| Episodes/task | 10 |
+| Max steps | 400 |
+| Gripper | Continuous, clipped to `[-1, 1]` |
 
 ---
 
@@ -76,3 +78,99 @@ python examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py \
 - **Videos**: One `.mp4` per episode saved to `--video-out-path`
 - **Summary**: `summary.json` with per-bucket and overall success rates
 - **Metrics**: Overall SR = mean of per-bucket SRs (easy, medium, hard, very\_hard)
+
+---
+
+## 4. Reference Checkpoints & Results
+
+We release two reference checkpoints for this benchmark. Both are QwenPI_v3
+(base VLM: Qwen2.5-VL-3B-Instruct) finetuned on the MetaWorld MT50 LeRobot
+dataset with the identical recipe:
+
+| Checkpoint | Initialization |
+|------------|----------------|
+| [starvla_metaworld_qwenpiv3_baseline_finetune](https://huggingface.co/MINT-SJTU/starvla_metaworld_qwenpiv3_baseline_finetune) | direct finetune from the base VLM |
+| [starvla_metaworld_qwenpiv3_la_finetune](https://huggingface.co/MINT-SJTU/starvla_metaworld_qwenpiv3_la_finetune) | finetune from an **LA-pretrained (LA4VLA)** backbone — [Language-Action pretraining](https://arxiv.org/abs/2606.27295), learning action prediction from language instructions and robot states |
+
+```bash
+# Download a checkpoint (keeps the layout the policy server expects;
+# swap the repo id for the other checkpoint)
+huggingface-cli download MINT-SJTU/starvla_metaworld_qwenpiv3_la_finetune \
+  --local-dir ./ckpts/starvla_metaworld_qwenpiv3_la_finetune
+
+# Serve it (Step 1 of the workflow above)
+CKPT=./ckpts/starvla_metaworld_qwenpiv3_la_finetune/checkpoints/steps_60000_pytorch_model.pt \
+  PORT=10095 GPU_ID=0 bash examples/simBenchmarks/MetaWorld/eval_files/run_policy_server.sh
+```
+
+Each repo contains the single evaluated weight plus the files the server resolves
+from the run directory:
+
+```
+checkpoints/steps_60000_pytorch_model.pt   # evaluated weight (~8.8 GB)
+config.yaml                                # model/run config
+config.full.yaml
+dataset_statistics.json                    # action de-normalization stats
+```
+
+Results, both checkpoints at `steps_60000`, evaluated with the exact workflow in
+Section 1 (all 50 tasks × 10 episodes = 500 episodes, seed 4042, max 400 steps
+per episode; overall SR = mean over the four difficulty buckets):
+
+| Checkpoint | easy (28) | medium (11) | hard (6) | very_hard (5) | **Overall** |
+|------------|-----------|-------------|----------|---------------|-------------|
+| `la_finetune` | 0.846 | 0.673 | 0.517 | 0.800 | **0.709** |
+| `baseline_finetune` | 0.857 | 0.600 | 0.467 | 0.440 | 0.591 |
+
+**Per-task success rates** (10 episodes each; `la_ft` = la_finetune, `base_ft` = baseline_finetune):
+
+**easy** (`la_ft` 0.846 / `base_ft` 0.857)
+
+| Task | la_ft | base_ft | Task | la_ft | base_ft |
+|------|-------|---------|------|-------|---------|
+| button-press-topdown-v3 | 1.0 | 1.0 | handle-press-side-v3 | 1.0 | 1.0 |
+| button-press-topdown-wall-v3 | 1.0 | 1.0 | handle-press-v3 | 1.0 | 1.0 |
+| button-press-v3 | 1.0 | 1.0 | handle-pull-side-v3 | 0.1 | 0.4 |
+| button-press-wall-v3 | 1.0 | 1.0 | handle-pull-v3 | 0.1 | 0.2 |
+| coffee-button-v3 | 1.0 | 1.0 | lever-pull-v3 | 0.8 | 0.8 |
+| dial-turn-v3 | 0.4 | 0.9 | plate-slide-v3 | 0.9 | 0.9 |
+| door-close-v3 | 1.0 | 1.0 | plate-slide-side-v3 | 1.0 | 1.0 |
+| door-lock-v3 | 1.0 | 0.3 | plate-slide-back-v3 | 0.7 | 0.8 |
+| door-v3 | 1.0 | 1.0 | plate-slide-back-side-v3 | 0.9 | 1.0 |
+| door-unlock-v3 | 1.0 | 1.0 | peg-unplug-side-v3 | 0.6 | 0.7 |
+| drawer-close-v3 | 1.0 | 1.0 | reach-v3 | 0.4 | 0.1 |
+| drawer-open-v3 | 1.0 | 1.0 | reach-wall-v3 | 0.9 | 0.9 |
+| faucet-open-v3 | 1.0 | 1.0 | window-open-v3 | 1.0 | 1.0 |
+| faucet-close-v3 | 0.9 | 1.0 | window-close-v3 | 1.0 | 1.0 |
+
+**medium** (`la_ft` 0.673 / `base_ft` 0.600)
+
+| Task | la_ft | base_ft | Task | la_ft | base_ft |
+|------|-------|---------|------|-------|---------|
+| basketball-v3 | 0.3 | 0.2 | peg-insertion-side-v3 | 0.5 | 0.3 |
+| bin-picking-v3 | 0.5 | 0.7 | soccer-v3 | 0.3 | 0.0 |
+| box-close-v3 | 0.7 | 0.7 | push-wall-v3 | 1.0 | 0.9 |
+| coffee-pull-v3 | 0.8 | 0.9 | sweep-into-goal-v3 | 1.0 | 0.8 |
+| coffee-push-v3 | 0.7 | 0.5 | sweep-v3 | 0.8 | 0.6 |
+| hammer-v3 | 0.8 | 1.0 | | | |
+
+**hard** (`la_ft` 0.517 / `base_ft` 0.467)
+
+| Task | la_ft | base_ft | Task | la_ft | base_ft |
+|------|-------|---------|------|-------|---------|
+| nut-assembly-v3 | 0.6 | 0.7 | pick-place-v3 | 0.2 | 0.4 |
+| hand-insert-v3 | 1.0 | 0.6 | push-v3 | 1.0 | 0.6 |
+| pick-out-of-hole-v3 | 0.0 | 0.0 | push-back-v3 | 0.3 | 0.5 |
+
+**very_hard** (`la_ft` 0.800 / `base_ft` 0.440)
+
+| Task | la_ft | base_ft | Task | la_ft | base_ft |
+|------|-------|---------|------|-------|---------|
+| nut-disassemble-v3 | 0.8 | 0.5 | stick-pull-v3 | 0.7 | 0.3 |
+| pick-place-wall-v3 | 0.9 | 0.7 | shelf-place-v3 | 0.6 | 0.3 |
+| stick-push-v3 | 1.0 | 0.4 | | | |
+
+> Reproduction notes: keep the client-side image preprocessing unchanged
+> (ROT180 + center-crop 2/3 + resize to 224×224 — already built into
+> `eval_metaworld.py`); the policy server must be started with the matching
+> `dataset_statistics.json` from the checkpoint directory.

--- a/examples/simBenchmarks/MetaWorld/README.md
+++ b/examples/simBenchmarks/MetaWorld/README.md
@@ -1,0 +1,78 @@
+# MetaWorld MT50 Evaluation
+
+This document provides instructions for evaluating starVLA on the [MetaWorld MT50](https://github.com/Farama-Foundation/Metaworld) benchmark (50 manipulation tasks across 4 difficulty buckets).
+
+The evaluation uses the same client-server architecture as LIBERO: the starVLA policy server handles inference, while the MetaWorld client drives the simulation.
+
+---
+
+## 0. Environment Setup
+
+### MetaWorld environment
+
+```bash
+pip install metaworld gymnasium
+pip install tyro imageio opencv-python-headless numpy
+```
+
+> MetaWorld requires MuJoCo. If not already installed:
+> ```bash
+> pip install mujoco
+> ```
+
+### starVLA server environment
+
+Follow the main starVLA installation instructions. The policy server (`deployment/model_server/server_policy.py`) is shared across all benchmarks.
+
+---
+
+## 1. Evaluation Workflow
+
+Run from the **repository root** using **two separate terminals**.
+
+### Step 1. Start the policy server (starVLA environment)
+
+```bash
+CKPT=/path/to/your/checkpoint.pt PORT=10095 GPU_ID=0 \
+  bash examples/simBenchmarks/MetaWorld/eval_files/run_policy_server.sh
+```
+
+### Step 2. Run the evaluation (MetaWorld environment)
+
+```bash
+HOST=127.0.0.1 PORT=10095 EPISODES_PER_TASK=10 \
+  bash examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.sh
+```
+
+Or call the Python script directly for finer control:
+
+```bash
+python examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py \
+  --args.host 127.0.0.1 \
+  --args.port 10095 \
+  --args.episodes-per-task 10 \
+  --args.levels easy,medium,hard,very_hard \
+  --args.video-out-path experiments/metaworld/logs
+```
+
+---
+
+## 2. Key Differences from LIBERO
+
+| Aspect | LIBERO | MetaWorld MT50 |
+|--------|--------|----------------|
+| Action space | 7D (xyz + rotation + gripper) | 4D (xyz + gripper) |
+| Camera views | 2 (primary + wrist) | 1 (corner2) |
+| Image preprocessing | `[::-1, ::-1]` flip | ROT180 + center\_crop(2/3) + resize 224 |
+| Tasks | 4 suites x 10 tasks | 50 tasks, 4 difficulty buckets |
+| Episodes/task | 50 | 10 |
+| Max steps | 220-520 (per suite) | 400 |
+| Gripper | Binarized | Continuous, clipped to `[-1, 1]` |
+
+---
+
+## 3. Output
+
+- **Videos**: One `.mp4` per episode saved to `--video-out-path`
+- **Summary**: `summary.json` with per-bucket and overall success rates
+- **Metrics**: Overall SR = mean of per-bucket SRs (easy, medium, hard, very\_hard)

--- a/examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py
+++ b/examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py
@@ -1,0 +1,297 @@
+"""MetaWorld MT50 evaluation script for starVLA.
+
+Evaluates a starVLA policy on all 50 MetaWorld tasks, reporting per-task and
+per-difficulty-bucket success rates.  Follows the same tyro CLI pattern as
+``eval_libero.py``.
+
+Usage::
+
+    python examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py \
+        --args.host 127.0.0.1 --args.port 10095 \
+        --args.video-out-path experiments/metaworld/logs
+"""
+
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import shutil
+import tempfile
+
+import gymnasium as gym
+import imageio
+import metaworld  # noqa: F401  ensures Meta-World envs are registered
+import numpy as np
+import tqdm
+import tyro
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ.setdefault("MUJOCO_GL", "egl")
+gym.logger.min_level = gym.logger.ERROR
+
+from examples.simBenchmarks.MetaWorld.eval_files.model2metaworld_interface import (
+    ModelClient,
+    preprocess_metaworld_image,
+)
+
+
+# ---------------------------------------------------------------------------
+# MT50 task definitions (index, slug, prompt, difficulty bucket)
+# ---------------------------------------------------------------------------
+MT50_TASKS = [
+    (0, "nut-assembly-v3", "Pick up a nut and place it onto a peg", "hard"),
+    (1, "basketball-v3", "Dunk the basketball into the basket", "medium"),
+    (2, "bin-picking-v3", "Grasp the puck from one bin and place it into another bin", "medium"),
+    (3, "box-close-v3", "Grasp the cover and close the box with it", "medium"),
+    (4, "button-press-topdown-v3", "Press a button from the top", "easy"),
+    (5, "button-press-topdown-wall-v3", "Bypass a wall and press a button from the top", "easy"),
+    (6, "button-press-v3", "Press a button", "easy"),
+    (7, "button-press-wall-v3", "Bypass a wall and press a button", "easy"),
+    (8, "coffee-button-v3", "Push a button on the coffee machine", "easy"),
+    (9, "coffee-pull-v3", "Pull a mug from a coffee machine", "medium"),
+    (10, "coffee-push-v3", "Push a mug under a coffee machine", "medium"),
+    (11, "dial-turn-v3", "Rotate a dial 180 degrees", "easy"),
+    (12, "nut-disassemble-v3", "Pick a nut out of a peg", "very_hard"),
+    (13, "door-close-v3", "Close a door with a revolving joint", "easy"),
+    (14, "door-lock-v3", "Lock the door by rotating the lock clockwise", "easy"),
+    (15, "door-v3", "Open a door with a revolving joint", "easy"),
+    (16, "door-unlock-v3", "Unlock the door by rotating the lock counter-clockwise", "easy"),
+    (17, "hand-insert-v3", "Insert the gripper into a hole", "hard"),
+    (18, "drawer-close-v3", "Push and close a drawer", "easy"),
+    (19, "drawer-open-v3", "Open a drawer", "easy"),
+    (20, "faucet-open-v3", "Rotate the faucet counter-clockwise", "easy"),
+    (21, "faucet-close-v3", "Rotate the faucet clockwise", "easy"),
+    (22, "hammer-v3", "Hammer a screw on the wall", "medium"),
+    (23, "handle-press-side-v3", "Press a handle down sideways", "easy"),
+    (24, "handle-press-v3", "Press a handle down", "easy"),
+    (25, "handle-pull-side-v3", "Pull a handle up sideways", "easy"),
+    (26, "handle-pull-v3", "Pull a handle up", "easy"),
+    (27, "lever-pull-v3", "Pull a lever down 90 degrees", "easy"),
+    (28, "pick-place-wall-v3", "Pick a puck, bypass a wall and place the puck", "very_hard"),
+    (29, "pick-out-of-hole-v3", "Pick up a puck from a hole", "hard"),
+    (30, "pick-place-v3", "Pick and place a puck to a goal", "hard"),
+    (31, "plate-slide-v3", "Slide a plate into a cabinet", "easy"),
+    (32, "plate-slide-side-v3", "Slide a plate into a cabinet sideways", "easy"),
+    (33, "plate-slide-back-v3", "Get a plate from the cabinet", "easy"),
+    (34, "plate-slide-back-side-v3", "Get a plate from the cabinet sideways", "easy"),
+    (35, "peg-insertion-side-v3", "Insert a peg sideways", "medium"),
+    (36, "peg-unplug-side-v3", "Unplug a peg sideways", "easy"),
+    (37, "soccer-v3", "Kick a soccer into the goal", "medium"),
+    (38, "stick-push-v3", "Grasp a stick and push a box using the stick", "very_hard"),
+    (39, "stick-pull-v3", "Grasp a stick and pull a box with the stick", "very_hard"),
+    (40, "push-v3", "Push the puck to a goal", "hard"),
+    (41, "push-wall-v3", "Bypass a wall and push a puck to a goal", "medium"),
+    (42, "push-back-v3", "Push the puck back to a goal", "hard"),
+    (43, "reach-v3", "Reach a goal position", "easy"),
+    (44, "reach-wall-v3", "Bypass a wall and reach a goal", "easy"),
+    (45, "shelf-place-v3", "Pick and place a puck onto a shelf", "very_hard"),
+    (46, "sweep-into-goal-v3", "Sweep a puck into a hole", "medium"),
+    (47, "sweep-v3", "Sweep a puck off the table", "medium"),
+    (48, "window-open-v3", "Push and open a window", "easy"),
+    (49, "window-close-v3", "Push and close a window", "easy"),
+]
+
+DIFFICULTY_BUCKETS = ["easy", "medium", "hard", "very_hard"]
+CAMERA_NAME = "corner2"
+
+
+@dataclasses.dataclass
+class Args:
+    host: str = "127.0.0.1"
+    port: int = 10095
+
+    # MetaWorld evaluation parameters
+    seed: int = 4042
+    episodes_per_task: int = 10  # Number of rollouts per task
+    max_steps: int = 400  # Maximum steps per episode
+    max_tasks: int = -1  # If > 0, limit tasks evaluated per bucket (smoke test). -1 = all.
+    levels: str = "easy,medium,hard,very_hard"  # Comma-separated difficulty buckets
+
+    # Output
+    video_out_path: str = "experiments/metaworld/logs"
+
+    # Dataset key for un-normalization. None = auto.
+    unnorm_key: str | None = None
+
+
+def eval_metaworld(args: Args) -> None:
+    logging.info(f"Arguments: {json.dumps(dataclasses.asdict(args), indent=4)}")
+
+    np.random.seed(args.seed)
+
+    # Parse difficulty levels.
+    levels = [s.strip().lower() for s in args.levels.split(",") if s.strip()]
+    for lv in levels:
+        if lv not in DIFFICULTY_BUCKETS:
+            raise ValueError(f"Unknown difficulty level: {lv}. Must be one of {DIFFICULTY_BUCKETS}")
+
+    # Group tasks by difficulty.
+    bucket_tasks = {b: [] for b in DIFFICULTY_BUCKETS}
+    for idx, slug, prompt, difficulty in MT50_TASKS:
+        bucket_tasks[difficulty].append((idx, slug, prompt))
+
+    pathlib.Path(args.video_out_path).mkdir(parents=True, exist_ok=True)
+
+    # Build MT50 env.
+    envs = gym.make_vec(
+        "Meta-World/MT50",
+        vector_strategy="sync",
+        seed=args.seed,
+        render_mode="rgb_array",
+        camera_name=CAMERA_NAME,
+    )
+    total_envs = len(envs.envs)
+
+    # Connect to server.
+    client = ModelClient(
+        host=args.host,
+        port=args.port,
+        unnorm_key=args.unnorm_key,
+    )
+
+    # Accumulators per bucket.
+    bucket_successes = {b: 0 for b in DIFFICULTY_BUCKETS}
+    bucket_trials = {b: 0 for b in DIFFICULTY_BUCKETS}
+    total_episodes, total_successes = 0, 0
+
+    for level in levels:
+        tasks = bucket_tasks[level]
+        if not tasks:
+            logging.info(f"Skip bucket {level} (0 tasks)")
+            continue
+
+        if args.max_tasks > 0:
+            tasks = tasks[: args.max_tasks]
+
+        logging.info(f"\n==== Bucket: {level} ({len(tasks)} tasks) ====")
+
+        for task_idx, slug, prompt in tqdm.tqdm(tasks, desc=level):
+            if task_idx >= total_envs:
+                logging.warning(f"Task index {task_idx} ({slug}) out of range, skipping")
+                continue
+
+            sub_env = envs.envs[task_idx]
+            task_successes = 0
+
+            for ep in tqdm.tqdm(range(args.episodes_per_task), desc=slug, leave=False):
+                # Randomize goal position each episode.
+                for obj in (sub_env, getattr(sub_env, "unwrapped", None)):
+                    fn = getattr(obj, "iterate_goal_position", None)
+                    if callable(fn):
+                        try:
+                            fn()
+                        except Exception:
+                            pass
+                        break
+
+                obs, _ = sub_env.reset(seed=args.seed + ep)
+                client.reset(task_description=prompt)
+
+                # Initial no-op step for environment stabilization.
+                try:
+                    a0 = np.zeros(sub_env.action_space.shape, dtype=np.float32)
+                    a0 = np.clip(a0, sub_env.action_space.low, sub_env.action_space.high)
+                    obs, _, _, _, _ = sub_env.step(a0)
+                except Exception:
+                    pass
+
+                replay_images = []
+                step = 0
+                done = False
+
+                while step < args.max_steps and not done:
+                    img_rgb = preprocess_metaworld_image(sub_env.render())
+                    replay_images.append(img_rgb)
+
+                    action = client.step(image=img_rgb, prompt=prompt, step=step)
+                    action = np.clip(action, sub_env.action_space.low, sub_env.action_space.high)
+                    obs, _, terminated, truncated, info = sub_env.step(action)
+                    step += 1
+
+                    if isinstance(info, dict) and info.get("success", 0) == 1:
+                        task_successes += 1
+                        done = True
+                        break
+                    if terminated or truncated:
+                        done = True
+                        break
+
+                total_episodes += 1
+                bucket_trials[level] += 1
+
+                # Save replay video.
+                suffix = "success" if done and info.get("success", 0) == 1 else "failure"
+                _save_video(
+                    replay_images,
+                    pathlib.Path(args.video_out_path)
+                    / f"task{task_idx:02d}_{slug}_ep{ep + 1:03d}_{suffix}.mp4",
+                )
+
+            bucket_successes[level] += task_successes
+            total_successes += task_successes
+            task_rate = task_successes / args.episodes_per_task
+            logging.info(
+                f"[Task {task_idx} {slug}] SR={task_rate:.3f} "
+                f"({task_successes}/{args.episodes_per_task})"
+            )
+
+        bsr = bucket_successes[level] / max(1, bucket_trials[level])
+        logging.info(f"==== Bucket {level}: SR={bsr:.3f} ({bucket_successes[level]}/{bucket_trials[level]}) ====")
+
+    # Final summary.
+    logging.info("\n==== Per-bucket success rates ====")
+    evaluated_rates = []
+    for lv in levels:
+        if bucket_trials[lv] > 0:
+            rate = bucket_successes[lv] / bucket_trials[lv]
+            evaluated_rates.append(rate)
+            logging.info(f"  {lv:10s}: {rate:.3f} ({bucket_successes[lv]}/{bucket_trials[lv]})")
+
+    overall = (sum(evaluated_rates) / len(evaluated_rates)) if evaluated_rates else 0.0
+    logging.info(f"\n==== Overall (mean of bucket SRs): {overall:.3f} ====")
+    logging.info(f"Total episodes: {total_episodes}, total successes: {total_successes}")
+
+    envs.close()
+
+    # Save summary JSON.
+    summary = {
+        "overall": overall,
+        "per_bucket": {lv: bucket_successes[lv] / max(1, bucket_trials[lv]) for lv in levels},
+        "episodes_per_task": args.episodes_per_task,
+        "seed": args.seed,
+        "max_steps": args.max_steps,
+    }
+    summary_path = pathlib.Path(args.video_out_path) / "summary.json"
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    logging.info(f"Summary saved to {summary_path}")
+
+
+def _save_video(frames: list, path: pathlib.Path) -> None:
+    """Encode mp4 via a local temp file (avoids OSSFS seek-back issues)."""
+    if not frames:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".mp4")
+    os.close(tmp_fd)
+    try:
+        imageio.mimsave(tmp_path, [np.asarray(f) for f in frames], fps=10)
+        shutil.copyfile(tmp_path, str(path))
+    except Exception as e:
+        logging.warning(f"Failed to save video {path}: {e}")
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s  %(levelname)-8s | %(message)s",
+        datefmt="%m/%d [%H:%M:%S]",
+        force=True,
+    )
+    tyro.cli(eval_metaworld)

--- a/examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.sh
+++ b/examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+METAWORLD_PYTHON="${METAWORLD_PYTHON:-python}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-10095}"
+EPISODES_PER_TASK="${EPISODES_PER_TASK:-10}"
+SEED="${SEED:-4042}"
+LEVELS="${LEVELS:-easy,medium,hard,very_hard}"
+MUJOCO_GL_VALUE="${MUJOCO_GL_VALUE:-egl}"
+PYOPENGL_PLATFORM_VALUE="${PYOPENGL_PLATFORM_VALUE:-egl}"
+CKPT="${CKPT:-${STARVLA_DIR}/playground/Checkpoints/metaworld_example/checkpoints/steps_50000_pytorch_model.pt}"
+
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${PYTHONPATH:-}:${STARVLA_DIR}"
+export MUJOCO_GL="${MUJOCO_GL_VALUE}"
+export PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM_VALUE}"
+
+FOLDER_NAME="$(echo "${CKPT}" | awk -F'/' '{print $(NF-2)"_"$(NF-1)"_"$NF}')"
+MODEL_ROOT="$(echo "${CKPT}" | awk -F'/checkpoints/' '{print $1}')"
+VIDEO_OUT_PATH="${MODEL_ROOT}/results/metaworld_mt50/${FOLDER_NAME}"
+
+"${METAWORLD_PYTHON}" ./examples/simBenchmarks/MetaWorld/eval_files/eval_metaworld.py \
+  --args.host "${HOST}" \
+  --args.port "${PORT}" \
+  --args.episodes-per-task "${EPISODES_PER_TASK}" \
+  --args.seed "${SEED}" \
+  --args.levels "${LEVELS}" \
+  --args.video-out-path "${VIDEO_OUT_PATH}"

--- a/examples/simBenchmarks/MetaWorld/eval_files/model2metaworld_interface.py
+++ b/examples/simBenchmarks/MetaWorld/eval_files/model2metaworld_interface.py
@@ -1,0 +1,121 @@
+# Copyright 2025 starVLA community. All rights reserved.
+# Licensed under the MIT License.
+"""MetaWorld env-side adapter (thin client).
+
+Mirrors the LIBERO ``ModelClient`` interface but tailored for MetaWorld MT50:
+  - Single camera view (``corner2``, preprocessed: ROT180 + center-crop + resize 224).
+  - 4-D continuous action (xyz + gripper), no gripper binarization.
+  - Action chunk caching: refreshed every ``action_chunk_size`` steps.
+
+The websocket *server* returns already-unnormalized actions (see
+``deployment/model_server/policy_wrapper.py``).
+"""
+
+from typing import Optional, Sequence
+
+import cv2
+import numpy as np
+
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
+
+
+# Image preprocessing constants — must match MetaWorld training data pipeline.
+CAMERA_NAME = "corner2"
+APPLY_ROT_180 = True
+APPLY_CENTER_CROP = True
+CROP_KEEP_RATIO = 2 / 3
+IMG_SIZE = (224, 224)
+
+
+def preprocess_metaworld_image(rgb: np.ndarray) -> np.ndarray:
+    """Render output -> ROT180 -> center_crop(2/3) -> resize 224x224 -> RGB uint8 HWC."""
+    rgb = np.ascontiguousarray(rgb, dtype=np.uint8)
+
+    if APPLY_ROT_180:
+        rgb = cv2.rotate(rgb, cv2.ROTATE_180)
+
+    if APPLY_CENTER_CROP and (0.0 < CROP_KEEP_RATIO < 1.0):
+        h, w = rgb.shape[:2]
+        new_h = max(1, int(round(h * CROP_KEEP_RATIO)))
+        new_w = max(1, int(round(w * CROP_KEEP_RATIO)))
+        y0 = (h - new_h) // 2
+        x0 = (w - new_w) // 2
+        rgb = rgb[y0 : y0 + new_h, x0 : x0 + new_w, :].copy()
+
+    if IMG_SIZE is not None:
+        rgb = cv2.resize(rgb, IMG_SIZE, interpolation=cv2.INTER_LINEAR)
+
+    return np.ascontiguousarray(rgb)
+
+
+class ModelClient:
+    """MetaWorld evaluation client that talks to the starVLA policy server."""
+
+    def __init__(
+        self,
+        unnorm_key: Optional[str] = None,
+        host: str = "0.0.0.0",
+        port: int = 10095,
+        use_ddim: bool = True,
+        num_ddim_steps: int = 10,
+    ) -> None:
+        # Connect & receive handshake metadata (action_chunk_size, etc.)
+        self.client = WebsocketClientPolicy(host, port)
+        meta = self.client.get_server_metadata()
+        self.action_chunk_size = int(meta["action_chunk_size"])
+        self._server_metadata = meta
+
+        self.unnorm_key = unnorm_key
+        self.use_ddim = use_ddim
+        self.num_ddim_steps = num_ddim_steps
+
+        print(
+            f"*** MetaWorld client: unnorm_key={unnorm_key}, "
+            f"action_chunk_size={self.action_chunk_size}, "
+            f"server_meta={meta} ***"
+        )
+
+        self.task_description: Optional[str] = None
+        # Cached unnormalized action chunk; refreshed every `action_chunk_size` steps.
+        self.raw_actions: Optional[np.ndarray] = None
+
+    def reset(self, task_description: str) -> None:
+        self.task_description = task_description
+        self.raw_actions = None
+
+    def step(self, image: np.ndarray, prompt: str, step: int = 0) -> np.ndarray:
+        """One env step.
+
+        Args:
+            image: Preprocessed RGB uint8 HWC image (224x224x3).
+            prompt: Task language instruction.
+            step: Env step counter; used for chunk caching.
+
+        Returns:
+            4-D action ``np.ndarray`` of shape ``(4,)`` (xyz + gripper).
+        """
+        if prompt != self.task_description:
+            self.reset(prompt)
+
+        # Refresh chunk if needed.
+        if step % self.action_chunk_size == 0 or self.raw_actions is None:
+            example = {"image": [image], "lang": prompt}
+            vla_input = {
+                "examples": [example],
+                "unnorm_key": self.unnorm_key,
+                "do_sample": False,
+                "use_ddim": self.use_ddim,
+                "num_ddim_steps": self.num_ddim_steps,
+            }
+            response = self.client.predict_action(vla_input)
+            try:
+                actions_batch = response["data"]["actions"]  # (B, T, D)
+            except KeyError:
+                raise KeyError(
+                    f"Key 'actions' not found in response: "
+                    f"keys={list(response.get('data', {}).keys())}"
+                )
+            self.raw_actions = np.asarray(actions_batch)[0]  # (T, D)
+
+        action = self.raw_actions[step % self.action_chunk_size]
+        return np.asarray(action[:4], dtype=np.float32)

--- a/examples/simBenchmarks/MetaWorld/eval_files/run_policy_server.sh
+++ b/examples/simBenchmarks/MetaWorld/eval_files/run_policy_server.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+STARVLA_PYTHON="${STARVLA_PYTHON:-python}"
+CKPT="${CKPT:-${STARVLA_DIR}/playground/Checkpoints/metaworld_example/checkpoints/steps_50000_pytorch_model.pt}"
+GPU_ID="${GPU_ID:-0}"
+PORT="${PORT:-10095}"
+USE_BF16="${USE_BF16:-1}"
+
+cd "${STARVLA_DIR}"
+export PYTHONPATH="${STARVLA_DIR}:${PYTHONPATH:-}"
+
+CMD=(
+  "${STARVLA_PYTHON}" deployment/model_server/server_policy.py
+  --ckpt_path "${CKPT}"
+  --port "${PORT}"
+)
+
+if [[ "${USE_BF16}" == "1" ]]; then
+  CMD+=(--use_bf16)
+fi
+
+CUDA_VISIBLE_DEVICES="${GPU_ID}" "${CMD[@]}"

--- a/examples/simBenchmarks/MetaWorld/train_files/data_registry/data_config.py
+++ b/examples/simBenchmarks/MetaWorld/train_files/data_registry/data_config.py
@@ -1,0 +1,77 @@
+"""MetaWorld MT50 benchmark — data config, embodiment tags, and mixtures."""
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionToTensor, StateActionTransform
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+
+
+# ---------------------------------------------------------------------------
+# DataConfig
+# ---------------------------------------------------------------------------
+class MetaWorldRobotDataConfig:
+    """MetaWorld MT50: 4-DOF delta EEF (Δx, Δy, Δz, gripper), single corner2 camera."""
+
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
+    video_keys = [
+        "video.primary_image",
+    ]
+    state_keys = [
+        "state.joint_pos_x",
+        "state.joint_pos_y",
+        "state.joint_pos_z",
+        "state.gripper",
+    ]
+    action_keys = [
+        "action.delta_x",
+        "action.delta_y",
+        "action.delta_z",
+        "action.gripper",
+    ]
+    language_keys = ["annotation.human.action.task_description"]
+    observation_indices = [0]
+    action_indices = list(range(8))
+    state_indices = [0]
+
+    def modality_config(self):
+        return {
+            "video": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
+            "state": ModalityConfig(delta_indices=self.state_indices, modality_keys=self.state_keys),
+            "action": ModalityConfig(delta_indices=self.action_indices, modality_keys=self.action_keys),
+            "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
+        }
+
+    def transform(self):
+        return ComposedModalityTransform(transforms=[
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={
+                    "action.delta_x": "min_max",
+                    "action.delta_y": "min_max",
+                    "action.delta_z": "min_max",
+                    "action.gripper": "min_max",
+                },
+            ),
+        ])
+
+
+ROBOT_TYPE_CONFIG_MAP = {
+    "metaworld_robot": MetaWorldRobotDataConfig(),
+}
+
+
+# ---------------------------------------------------------------------------
+# Embodiment Tags
+# ---------------------------------------------------------------------------
+ROBOT_TYPE_TO_EMBODIMENT_TAG = {}
+
+
+# ---------------------------------------------------------------------------
+# Mixtures
+# ---------------------------------------------------------------------------
+DATASET_NAMED_MIXTURES = {
+    "metaworld_mt50": [
+        ("metaworld_mt50_lerobot", 1.0, "metaworld_robot"),
+    ],
+}

--- a/examples/simBenchmarks/MetaWorld/train_files/starvla_qwenpiv3_metaworld_mt50.yaml
+++ b/examples/simBenchmarks/MetaWorld/train_files/starvla_qwenpiv3_metaworld_mt50.yaml
@@ -1,0 +1,48 @@
+# MetaWorld MT50 training config for starVLA (QwenPI_v3)
+run_id: starvla_qwenpiv3_metaworld_mt50
+run_root_dir: results/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_metaworld
+is_debug: false
+
+framework:
+  name: QwenPI_v3
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen2.5-VL-3B-Instruct
+    attn_implementation: sdpa
+  action_model:
+    action_dim: 4
+    state_dim: 4
+    action_horizon: 8
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: playground/Datasets/metaworld_starvla
+    data_mix: metaworld_mt50
+    per_device_batch_size: 2
+    obs_image_size: [224, 224]
+    video_backend: torchvision_av
+
+trainer:
+  max_train_steps: 100
+  num_warmup_steps: 10
+  save_interval: 100
+  eval_interval: 1000
+  learning_rate:
+    base: 2.5e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 1.0e-06
+  freeze_modules: ''
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+  optimizer:
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08

--- a/starVLA/dataloader/gr00t_lerobot/data_config.py
+++ b/starVLA/dataloader/gr00t_lerobot/data_config.py
@@ -1079,74 +1079,6 @@ class VLAArenaFrankaDataConfig:
 
 ###########################################################################################
 
-
-class MetaWorldRobotDataConfig:
-    """MetaWorld MT50: 4-DOF delta EEF (Δx, Δy, Δz, gripper), single corner2 camera."""
-
-    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
-    video_keys = [
-        "video.primary_image",
-    ]
-    state_keys = [
-        "state.joint_pos_x",
-        "state.joint_pos_y",
-        "state.joint_pos_z",
-        "state.gripper",
-    ]
-    action_keys = [
-        "action.delta_x",
-        "action.delta_y",
-        "action.delta_z",
-        "action.gripper",
-    ]
-
-    language_keys = ["annotation.human.action.task_description"]
-
-    observation_indices = [0]
-    action_indices = list(range(8))
-
-    def modality_config(self):
-        video_modality = ModalityConfig(
-            delta_indices=self.observation_indices,
-            modality_keys=self.video_keys,
-        )
-        state_modality = ModalityConfig(
-            delta_indices=self.observation_indices,
-            modality_keys=self.state_keys,
-        )
-        action_modality = ModalityConfig(
-            delta_indices=self.action_indices,
-            modality_keys=self.action_keys,
-        )
-        language_modality = ModalityConfig(
-            delta_indices=self.observation_indices,
-            modality_keys=self.language_keys,
-        )
-        return {
-            "video": video_modality,
-            "state": state_modality,
-            "action": action_modality,
-            "language": language_modality,
-        }
-
-    def transform(self):
-        transforms = [
-            StateActionToTensor(apply_to=self.action_keys),
-            StateActionTransform(
-                apply_to=self.action_keys,
-                normalization_modes={
-                    "action.delta_x": "min_max",
-                    "action.delta_y": "min_max",
-                    "action.delta_z": "min_max",
-                    "action.gripper": "min_max",
-                },
-            ),
-        ]
-        return ComposedModalityTransform(transforms=transforms)
-
-
-###########################################################################################
-
 ROBOT_TYPE_CONFIG_MAP = {
     "libero_franka": Libero4in1DataConfig(),
     "oxe_droid": OxeDroidDataConfig(),
@@ -1159,7 +1091,6 @@ ROBOT_TYPE_CONFIG_MAP = {
     "robotwin50": AgilexData50Config(),
     "fourier_gr1_arms_waist": FourierGr1ArmsWaistDataConfig(),
     "vla_arena_franka": VLAArenaFrankaDataConfig(),
-    "metaworld_robot": MetaWorldRobotDataConfig(),
 
     "custom_robot_config": SingleFrankaRobotiqDeltaEefDataConfig(),
 }

--- a/starVLA/dataloader/gr00t_lerobot/data_config.py
+++ b/starVLA/dataloader/gr00t_lerobot/data_config.py
@@ -1079,6 +1079,74 @@ class VLAArenaFrankaDataConfig:
 
 ###########################################################################################
 
+
+class MetaWorldRobotDataConfig:
+    """MetaWorld MT50: 4-DOF delta EEF (Δx, Δy, Δz, gripper), single corner2 camera."""
+
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
+    video_keys = [
+        "video.primary_image",
+    ]
+    state_keys = [
+        "state.joint_pos_x",
+        "state.joint_pos_y",
+        "state.joint_pos_z",
+        "state.gripper",
+    ]
+    action_keys = [
+        "action.delta_x",
+        "action.delta_y",
+        "action.delta_z",
+        "action.gripper",
+    ]
+
+    language_keys = ["annotation.human.action.task_description"]
+
+    observation_indices = [0]
+    action_indices = list(range(8))
+
+    def modality_config(self):
+        video_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.video_keys,
+        )
+        state_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.state_keys,
+        )
+        action_modality = ModalityConfig(
+            delta_indices=self.action_indices,
+            modality_keys=self.action_keys,
+        )
+        language_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.language_keys,
+        )
+        return {
+            "video": video_modality,
+            "state": state_modality,
+            "action": action_modality,
+            "language": language_modality,
+        }
+
+    def transform(self):
+        transforms = [
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={
+                    "action.delta_x": "min_max",
+                    "action.delta_y": "min_max",
+                    "action.delta_z": "min_max",
+                    "action.gripper": "min_max",
+                },
+            ),
+        ]
+        return ComposedModalityTransform(transforms=transforms)
+
+
+###########################################################################################
+
 ROBOT_TYPE_CONFIG_MAP = {
     "libero_franka": Libero4in1DataConfig(),
     "oxe_droid": OxeDroidDataConfig(),
@@ -1091,6 +1159,7 @@ ROBOT_TYPE_CONFIG_MAP = {
     "robotwin50": AgilexData50Config(),
     "fourier_gr1_arms_waist": FourierGr1ArmsWaistDataConfig(),
     "vla_arena_franka": VLAArenaFrankaDataConfig(),
+    "metaworld_robot": MetaWorldRobotDataConfig(),
 
     "custom_robot_config": SingleFrankaRobotiqDeltaEefDataConfig(),
 }

--- a/starVLA/dataloader/gr00t_lerobot/mixtures.py
+++ b/starVLA/dataloader/gr00t_lerobot/mixtures.py
@@ -373,4 +373,8 @@ DATASET_NAMED_MIXTURES = {
     "vla_arena_L0_L": [
         ("VLA_Arena_L0_L_lerobot_openpi", 1.0, "vla_arena_franka"),
     ],
+
+    "metaworld_mt50": [
+        ("metaworld_mt50_lerobot", 1.0, "metaworld_robot"),
+    ],
 }

--- a/starVLA/dataloader/gr00t_lerobot/mixtures.py
+++ b/starVLA/dataloader/gr00t_lerobot/mixtures.py
@@ -373,8 +373,4 @@ DATASET_NAMED_MIXTURES = {
     "vla_arena_L0_L": [
         ("VLA_Arena_L0_L_lerobot_openpi", 1.0, "vla_arena_franka"),
     ],
-
-    "metaworld_mt50": [
-        ("metaworld_mt50_lerobot", 1.0, "metaworld_robot"),
-    ],
 }


### PR DESCRIPTION
Add MetaWorld MT50 benchmark integration following the simBenchmarks convention. Includes eval scripts (tyro CLI), ModelClient adapter, shell wrappers, training config template, and data pipeline registration (MetaWorldRobotDataConfig + metaworld_mt50 mixture).

## Description
<!-- Briefly describe what this PR does -->


## Motivation
<!-- Why is this change needed? Please link the related Issue -->
Closes #

## Changes
<!-- List the key changes -->
-
-

## Testing
<!-- How was this verified? Check at least one -->
<!-- - [ ] `make check` passes  TODO: enable later -->
- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
|           |        |        |

- **Checkpoint**: <!-- Required for framework/benchmark changes: public HF link -->
- **Config**: <!-- Config path under examples/ -->
- **Reproduce**: <!-- Reproduction command -->

## Type of Change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist
<!-- - [ ] `make check` passes (Black + Ruff)  TODO: enable later -->
- [ ] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [ ] No secrets, API keys, or large binaries committed
- [ ] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [ ] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

## Screenshots / Logs (optional)
<!-- Training curves, evaluation result screenshots, relevant logs -->
