### PR TITLE
[feat] Add Unitree G1 SONIC StarVLA workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,7 @@ bar
 code
 examples/simBenchmarks/LIBERO/eval_files/auto_eval_scripts/run_all_libero_untested.sh
 starVLA/model/framework/VLM4A/QwenGR00T_v2.py
+examples/realRobots/UnitreeG1_WholeBody/sdk_tools/Jinhui.sh
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/local_self_test.py
+examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar
+examples/realRobots/UnitreeG1_WholeBody/sdk_tools/sonicstar_wbc_deployment_reference

--- a/examples/realRobots/UnitreeG1_WholeBody/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/README.md
@@ -1,0 +1,217 @@
+# Unitree G1 WholeBody with StarVLA
+
+This directory is a workflow scaffold for running StarVLA on Unitree G1-style whole-body embodiments.
+
+The purpose is to help users understand how to connect StarVLA to a real G1 workflow. This directory is intentionally written as a concrete example, not only a link collection.
+
+The main example follows the shape of NVIDIA's `NVlabs/GR00T-WholeBodyControl` workflow:
+
+```text
+GR00T-WholeBodyControl teleop / data collection
+  -> LeRobot v2.1 dataset
+  -> StarVLA training
+  -> StarVLA WebSocket policy server
+  -> GR00T-WholeBodyControl / SONIC / user G1 controller side
+```
+
+StarVLA does not re-implement Unitree SDK, SONIC WBC, PICO teleop, camera servers, or third-party deployment stacks. It documents how to use their outputs and where StarVLA plugs in.
+
+The common path is:
+
+```text
+teleop / data collection
+  -> LeRobot-format dataset
+  -> StarVLA training
+  -> StarVLA policy server
+  -> G1 whole-body controller / user controller
+```
+
+Many implementations are valid. Users may use their own Unitree infra, lab teleop stack, XR/VR toolchain, vendor SDK wrappers, or third-party projects. In this folder, however, the step READMEs are written around the GR00T-WholeBodyControl route so users have a complete worked path.
+
+Useful public paths include:
+
+- LeRobot Unitree G1 docs: https://huggingface.co/docs/lerobot/unitree_g1
+- Unitree XR teleoperation: https://github.com/unitreerobotics/xr_teleoperate
+- Unitree LeRobot tools: https://github.com/unitreerobotics/unitree_lerobot
+- NVIDIA GR00T-WholeBodyControl: https://github.com/NVlabs/GR00T-WholeBodyControl
+
+We use GR00T-WholeBodyControl as the primary reference path because it already demonstrates G1 PICO VR teleop, data collection, LeRobot v2.1 export, and SONIC whole-body control:
+
+- Project: https://github.com/NVlabs/GR00T-WholeBodyControl
+- PICO VR whole-body teleop: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vr_wholebody_teleop.html
+- Data collection: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/data_collection.html
+- VLA workflow: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vla_workflow.html
+- VLA inference: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vla_inference.html
+
+This is the example route for this directory, not a global StarVLA dependency requirement. LeRobot's G1 path or Unitree's XR teleop path are equally reasonable if they match the user's hardware and data needs. StarVLA should sit at the model and data boundary: consume a standardized dataset, train a VLA policy, serve actions, and let the user-owned robot infra execute them safely.
+
+## Collaboration Style
+
+When extending this example, describe the purpose of each layer before writing code:
+
+- What problem does this layer solve?
+- Which parts are owned by StarVLA?
+- Which parts are owned by the user's robot infra or a third-party repo?
+- What artifact does this step produce for the next step?
+- What is the simplest safe way to validate it?
+
+For the first full example, follow the GR00T-WholeBodyControl-style route. Other users can replace that route with LeRobot G1, Unitree XR teleop, Unitree LeRobot conversion tools, or their own teleop/control stacks as long as the same StarVLA boundary is preserved.
+
+## How This Example Maps NVlabs to StarVLA
+
+NVlabs workflow:
+
+```text
+Collect with GR00T-WholeBodyControl
+  -> fine-tune Isaac-GR00T
+  -> run Isaac-GR00T PolicyServer
+  -> launch GR00T-WholeBodyControl inference
+```
+
+StarVLA workflow in this folder:
+
+```text
+Collect with GR00T-WholeBodyControl
+  -> train StarVLA on the exported LeRobot dataset
+  -> run StarVLA WebSocket policy server
+  -> adapt GR00T-WholeBodyControl / SONIC controller side to consume StarVLA actions
+```
+
+The important replacement is the model layer. We reuse the external teleop, camera, data collection, and controller-side ideas; StarVLA owns training and policy serving.
+
+## Viable Upstream Routes
+
+### LeRobot Unitree G1 Route
+
+Use this when the user wants the shortest path through the LeRobot ecosystem. The official LeRobot G1 docs cover Unitree SDK setup, simulation teleoperation, physical robot connection, recording with `lerobot-record`, training, and real-time chunking inference.
+
+StarVLA handoff:
+
+```text
+LeRobot G1 dataset
+  -> StarVLA data_registry + modality
+  -> StarVLA training
+  -> StarVLA policy server
+```
+
+### Unitree XR Teleoperate Route
+
+Use this when the user wants XR-device teleoperation with Unitree's own tooling. The `xr_teleoperate` project supports devices such as Apple Vision Pro, PICO, and Quest, and supports G1 23/29 DoF plus multiple end-effectors.
+
+StarVLA handoff:
+
+```text
+xr_teleoperate recorded data
+  -> Unitree / custom conversion to LeRobot
+  -> StarVLA data_registry + modality
+  -> StarVLA training
+```
+
+### Unitree LeRobot Tools Route
+
+Use this when data is already in Unitree JSON format or collected by Unitree tooling. The Unitree LeRobot repo includes data conversion, dataset visualization/editing, and real-robot evaluation utilities.
+
+StarVLA handoff:
+
+```text
+Unitree JSON or Unitree dataset
+  -> unitree_lerobot / custom conversion
+  -> LeRobot dataset
+  -> StarVLA training and deployment
+```
+
+### GR00T-WholeBodyControl / SONIC Route
+
+Use this when the user wants a full G1 whole-body controller stack with SONIC-style latent actions. This is a strong example for whole-body deployment because the high-frequency balance and motion generation stay in the controller stack.
+
+## Directory Flow
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/
+  README.md
+  DISCUSSION.md
+
+  step0_teleop_data_collection/
+    README.md
+
+  step1_data_conversion/
+    README.md
+
+  step2_training/
+    README.md
+
+  step3_deployment/
+    README.md
+
+  sdk_tools/
+    README.md
+```
+
+## Recommended First Target
+
+Do not start with full G1 whole-body autonomy. Start with a narrow, testable path:
+
+1. Use an external G1 teleop/control stack to collect demonstrations.
+2. Export or convert the demonstrations to LeRobot v2.1.
+3. Define a StarVLA data registry for one G1 embodiment tag.
+4. Train a small StarVLA checkpoint.
+5. Run replay and mock-controller dry-runs before touching the real robot.
+6. Deploy through StarVLA WebSocket policy server into the user's G1 controller adapter.
+
+## Action-Space Choices
+
+There are two practical action-space routes:
+
+### Route A: SONIC-style latent actions
+
+NVIDIA's VLA workflow describes a compact 78D action space: 64D motion token plus 7D left hand joints and 7D right hand joints. In this route, StarVLA predicts the same high-level latent action representation, and SONIC or the user's whole-body controller decodes it into high-frequency robot commands.
+
+This is a good example route if users already rely on GR00T-WholeBodyControl / SONIC for G1, because it keeps balance and high-frequency control in a controller stack designed for that job.
+
+### Route B: Direct grouped control
+
+StarVLA predicts grouped robot commands such as:
+
+```text
+base + torso + left_arm + right_arm + left_hand + right_hand
+```
+
+This route gives more direct control, but it requires the user to own more controller logic, safety checks, latency handling, and train/test consistency validation.
+
+### Route C: User-defined controller actions
+
+Some teams will already have a production G1 controller API. In that case, StarVLA can predict the team's existing action representation. The requirement is that the representation be documented, logged during teleop, converted into LeRobot, and replayable in dry-run before real execution.
+
+## StarVLA Boundary
+
+StarVLA should standardize these pieces:
+
+- LeRobot dataset layout and `meta/modality.json`.
+- `train_files/data_registry/data_config.py`.
+- StarVLA training config.
+- Policy server request / response.
+- Replay and dry-run validation.
+- Thin adapter from StarVLA action chunk to the user's G1 controller API.
+
+StarVLA should not own these pieces:
+
+- PICO / XR / VR device setup.
+- Unitree SDK installation.
+- Low-level balance control.
+- Real-time whole-body control loop.
+- Robot network setup.
+- Emergency stop implementation.
+
+Those pieces should live in the user's G1 infra or in referenced third-party repositories. This example documents how to connect to them, not how to own all of them.
+
+## Start Here
+
+Follow the folders in order:
+
+1. [step0_teleop_data_collection](step0_teleop_data_collection/README.md)
+2. [step1_data_conversion](step1_data_conversion/README.md)
+3. [step2_training](step2_training/README.md)
+4. [step3_deployment](step3_deployment/README.md)
+5. [sdk_tools](sdk_tools/README.md)
+
+Each step should leave behind a small, checkable artifact before moving to the next step.

--- a/examples/realRobots/UnitreeG1_WholeBody/sdk_tools/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/sdk_tools/README.md
@@ -1,0 +1,102 @@
+# SDK Tools
+
+This folder is for helper scripts and notes around the G1 integration. Its purpose is to make collaboration easier: users can keep third-party setup notes, visualization scripts, inspection tools, mock adapters, and one-off debugging tools here without mixing them into StarVLA model code.
+
+Do not put core StarVLA model code here. Keep this folder practical and integration-facing.
+
+## Good Candidates
+
+```text
+sdk_tools/
+  README.md
+  clone_third_party.md
+  visualize_lerobot_episode.py
+  inspect_dataset_schema.py
+  check_camera_stream.py
+  check_action_stats.py
+  mock_g1_state_publisher.py
+  mock_g1_action_consumer.py
+  plot_action_chunks.py
+  compare_train_deploy_obs.py
+```
+
+## Third-Party Repositories
+
+It is acceptable to point users to third-party repositories instead of copying them into StarVLA. For this G1 whole-body example, treat GR00T-WholeBodyControl as the primary external repo.
+
+Primary setup note:
+
+```bash
+mkdir -p ~/playground/Code
+cd ~/playground/Code
+git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git
+```
+
+Optional alternatives to document when needed:
+
+```bash
+cd ~/playground/Code
+git clone https://github.com/unitreerobotics/xr_teleoperate.git
+git clone https://github.com/unitreerobotics/unitree_lerobot.git
+```
+
+Users should follow the GR00T-WholeBodyControl installation docs for the primary example path. Other labs can document their own clone/install commands here if they replace the upstream teleop/control route.
+
+Useful public options:
+
+- LeRobot Unitree G1 docs: https://huggingface.co/docs/lerobot/unitree_g1
+- Unitree XR teleoperate: https://github.com/unitreerobotics/xr_teleoperate
+- Unitree LeRobot tools: https://github.com/unitreerobotics/unitree_lerobot
+- GR00T-WholeBodyControl: https://github.com/NVlabs/GR00T-WholeBodyControl
+
+For the primary GR00T-WholeBodyControl path, the external repo covers:
+
+- PICO teleop setup,
+- camera server,
+- SONIC / WBC deployment,
+- Unitree G1 network setup,
+- real robot safety procedures.
+
+The optional Unitree / LeRobot paths cover XR teleop, LeRobot G1 dataset recording, and Unitree JSON to LeRobot conversion. StarVLA should document how to interoperate with whichever outputs the chosen path produces.
+
+## Visualization Tools
+
+Useful tools to add here:
+
+- LeRobot episode viewer.
+- Multi-camera frame checker.
+- State/action dimension printer.
+- Action histogram and min/max checker.
+- Train-vs-deploy observation diff.
+- Policy server latency logger.
+- Controller command dry-run viewer.
+
+## Checks That Matter
+
+The most important G1 bugs are semantic mismatches, not Python exceptions. Tools in this folder should make these visible:
+
+- camera order changed,
+- RGB/BGR swapped,
+- resize/crop mismatch,
+- state joint order mismatch,
+- action group order mismatch,
+- SONIC latent action dimension mismatch,
+- hand command sign flipped,
+- stale frames,
+- action chunk executed at the wrong frequency.
+
+## Rule
+
+Every helper should print:
+
+```text
+input path / source
+camera keys
+state keys and shape
+action keys and shape
+language key
+episode count
+sample timestamps
+```
+
+This makes the tools useful for both humans and code agents.

--- a/examples/realRobots/UnitreeG1_WholeBody/sdk_tools/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/sdk_tools/README.md
@@ -24,12 +24,32 @@ sdk_tools/
 
 It is acceptable to point users to third-party repositories instead of copying them into StarVLA. For this G1 whole-body example, treat GR00T-WholeBodyControl as the primary external repo.
 
-Primary setup note:
+Primary setup note, if the external repo has not been cloned yet:
 
 ```bash
 mkdir -p ~/playground/Code
 cd ~/playground/Code
 git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git
+```
+
+Expose the external repo through this folder with a symlink:
+
+```bash
+cd <STARVLA_ROOT>
+ln -s /path/to/GR00T-WholeBodyControl \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
+```
+
+After that, use this path as the stable entry point from the StarVLA repo root:
+
+```bash
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
+```
+
+If the terminal starts from the parent directory that contains `starVLA`, this equivalent form is also fine:
+
+```bash
+cd starVLA/examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
 ```
 
 Optional alternatives to document when needed:
@@ -48,6 +68,117 @@ Useful public options:
 - Unitree XR teleoperate: https://github.com/unitreerobotics/xr_teleoperate
 - Unitree LeRobot tools: https://github.com/unitreerobotics/unitree_lerobot
 - GR00T-WholeBodyControl: https://github.com/NVlabs/GR00T-WholeBodyControl
+- SonicStar SONIC/G1 reference: https://github.com/BlackOtters/SonicStar
+
+## SonicStar WBC Deployment Reference
+
+This example can use SonicStar as a reference for the SONIC / WBC side of the
+Unitree G1 stack. We keep that code as a local SDK reference instead of
+tracking it in this repository, because the full tree can contain large runtime
+assets, generated files, model weights, meshes, and machine-specific setup.
+
+Local paths used by this workspace:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar/
+examples/realRobots/UnitreeG1_WholeBody/sdk_tools/sonicstar_wbc_deployment_reference/
+```
+
+Both paths are intentionally git-ignored. The first can hold a fuller local
+SonicStar mirror. The second holds a curated deployment-facing subset for quick
+inspection.
+
+To recreate the local reference from a fresh checkout:
+
+```bash
+cd <STARVLA_ROOT>
+mkdir -p bar
+git clone https://github.com/BlackOtters/SonicStar.git bar/SonicStar
+
+mkdir -p examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar
+rsync -a bar/SonicStar/wbc/ \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar/wbc/
+```
+
+Create the curated deployment subset:
+
+```bash
+cd <STARVLA_ROOT>
+mkdir -p examples/realRobots/UnitreeG1_WholeBody/sdk_tools/sonicstar_wbc_deployment_reference
+
+rsync -a \
+  --exclude 'thirdparty/' \
+  --exclude 'policy/release/*.onnx' \
+  --exclude 'g1/meshes/' \
+  --exclude 'g1/images/' \
+  --exclude '*.so' \
+  --exclude '*.a' \
+  --exclude '*.onnx' \
+  --exclude '*.pt' \
+  --exclude '*.pth' \
+  --exclude '*.pkl' \
+  --exclude '*.mp4' \
+  --exclude '*.gif' \
+  --exclude '*.usd' \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar/wbc/gear_sonic_deploy/ \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/sonicstar_wbc_deployment_reference/gear_sonic_deploy/
+
+rsync -a \
+  --exclude 'data/assets/' \
+  --exclude 'data/robots/' \
+  --exclude 'data/robot_model/model_data/' \
+  --exclude 'data/human/*.pkl' \
+  --exclude '*.onnx' \
+  --exclude '*.pt' \
+  --exclude '*.pth' \
+  --exclude '*.pkl' \
+  --exclude '*.mp4' \
+  --exclude '*.gif' \
+  --exclude '*.usd' \
+  --exclude '*.STL' \
+  --exclude '*.stl' \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/SonicStar/wbc/gear_sonic/ \
+  examples/realRobots/UnitreeG1_WholeBody/sdk_tools/sonicstar_wbc_deployment_reference/gear_sonic/
+```
+
+The useful entry points in the curated copy are:
+
+```text
+sonicstar_wbc_deployment_reference/gear_sonic_deploy/deploy.sh
+sonicstar_wbc_deployment_reference/gear_sonic_deploy/src/
+sonicstar_wbc_deployment_reference/gear_sonic_deploy/g1/*.xml
+sonicstar_wbc_deployment_reference/gear_sonic/scripts/run_sim_loop.py
+sonicstar_wbc_deployment_reference/gear_sonic/scripts/run_camera_viewer.py
+sonicstar_wbc_deployment_reference/gear_sonic/scripts/run_data_exporter.py
+sonicstar_wbc_deployment_reference/gear_sonic/scripts/run_vla_inference.py
+sonicstar_wbc_deployment_reference/gear_sonic/scripts/send_keyboard_cmd.py
+```
+
+The tracked StarVLA-side deployment entry points remain:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_policy_server.sh
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_starvla_eval.sh
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/model2unitree_g1_interface.py
+```
+
+The active training entry point is:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh
+```
+
+Important difference from SonicStar: the SonicStar training reference uses a
+QwenGR00T/DiT route with longer action horizon. This example currently uses a
+QwenOFT/MLP route and a 78D SONIC action contract:
+
+```text
+64D motion token + 7D left hand + 7D right hand
+```
+
+Do not mix checkpoints, normalization stats, and deployment adapters across
+these routes without updating the dataset registry and action contract
+together.
 
 For the primary GR00T-WholeBodyControl path, the external repo covers:
 

--- a/examples/realRobots/UnitreeG1_WholeBody/step0_teleop_data_collection/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step0_teleop_data_collection/README.md
@@ -1,0 +1,247 @@
+# Step 0: Teleop Data Collection
+
+This step is about collecting usable G1 demonstrations. In this example, use `NVlabs/GR00T-WholeBodyControl` as the concrete data-collection path, then hand the exported dataset to StarVLA.
+
+StarVLA does not own the teleop stack. Here the teleop, camera server, data exporter, and G1 controller side come from GR00T-WholeBodyControl.
+
+Other routes are valid, but they are alternatives to this example:
+
+- LeRobot's official Unitree G1 workflow,
+- the user's existing Unitree G1 infra,
+- Unitree SDK-based collection,
+- Unitree `xr_teleoperate`,
+- Unitree `unitree_lerobot`,
+- lab-specific VR / XR / motion-capture teleop,
+- XRoboToolkit-style teleop,
+- custom keyboard / gamepad / SpaceMouse collection,
+- NVIDIA GR00T-WholeBodyControl.
+
+## Primary Example: GR00T-WholeBodyControl
+
+Use these upstream docs as the reference for environment setup and hardware safety:
+
+- PICO VR whole-body teleop: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vr_wholebody_teleop.html
+- Data collection for VLA: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/data_collection.html
+- VLA workflow: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vla_workflow.html
+- Repository: https://github.com/NVlabs/GR00T-WholeBodyControl
+
+The upstream teleop workflow has three pieces:
+
+```text
+MuJoCo sim or real G1
+  + C++ deploy / SONIC controller
+  + PICO teleop streamer
+  + optional data exporter
+```
+
+For StarVLA, this step's job is to produce the same kind of dataset that the NVlabs VLA workflow would fine-tune on.
+
+## Step A: Bring Up Teleop in Simulation
+
+Start in simulation before touching the real robot.
+
+Terminal 1, from the GR00T-WholeBodyControl repo root:
+
+```bash
+source .venv_teleop/bin/activate
+python gear_sonic/scripts/run_sim_loop.py
+```
+
+Terminal 2, from `gear_sonic_deploy/`:
+
+```bash
+cd gear_sonic_deploy
+source scripts/setup_env.sh
+./deploy.sh --input-type zmq_manager sim
+```
+
+Terminal 3, from the repo root:
+
+```bash
+source .venv_teleop/bin/activate
+python gear_sonic/scripts/pico_manager_thread_server.py --manager \
+  --vis_vr3pt --vis_smpl
+```
+
+Validation before continuing:
+
+- the visualizer opens,
+- the simulated G1 can be controlled,
+- mode switching is understood,
+- emergency stop behavior is tested,
+- calibration pose is repeatable.
+
+## Step B: Collect VLA Demonstrations
+
+Use GR00T-WholeBodyControl's data collection launcher as the first concrete collection path:
+
+```bash
+python gear_sonic/scripts/launch_data_collection.py \
+  --camera-host 192.168.123.164 \
+  --task-prompt "pick up the soda can and place it in the bin"
+```
+
+Expected upstream output is a LeRobot v2.1-style dataset directory, for example:
+
+```text
+outputs/2026-04-03-14-30-00-G1-robot01/
+  data/
+    train-00000.parquet
+  videos/
+    observation.images.ego_view/
+      episode_000000.mp4
+  meta/
+    info.json
+    modality.json
+    episodes.jsonl
+    tasks.jsonl
+```
+
+Move or symlink the collected dataset into the StarVLA workspace convention:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
+```
+
+## Step C: Optional Real-Robot Collection
+
+Only move to the physical G1 after simulation teleop is stable.
+
+The upstream real-robot path uses two main terminals:
+
+Terminal 1, C++ deployment from `gear_sonic_deploy/`:
+
+```bash
+cd gear_sonic_deploy
+source scripts/setup_env.sh
+./deploy.sh --input-type zmq_manager real
+```
+
+Terminal 2, PICO teleop streamer from the repo root:
+
+```bash
+source .venv_teleop/bin/activate
+python gear_sonic/scripts/pico_manager_thread_server.py --manager
+```
+
+If the teleop streamer runs offboard, set the ZMQ host consistently with the upstream instructions. Keep a safety operator ready and verify emergency stop before recording.
+
+## Alternative Public Paths
+
+### LeRobot Unitree G1
+
+Docs: https://huggingface.co/docs/lerobot/unitree_g1
+
+This path is useful when the user wants LeRobot-native collection and training conventions. The docs cover:
+
+- Unitree SDK setup,
+- LeRobot installation with the G1 extra,
+- simulation teleoperation,
+- physical robot connection,
+- robot server and camera setup,
+- loco-manipulation recording with `lerobot-record`,
+- training and RTC inference examples.
+
+For StarVLA, the most important output is a LeRobot dataset with clear camera/state/action keys.
+
+### Unitree XR Teleoperate
+
+Repo: https://github.com/unitreerobotics/xr_teleoperate
+
+This path is useful when the user wants XR-device teleoperation. The repo supports G1 29 DoF and 23 DoF variants, supports devices such as Apple Vision Pro, PICO, and Quest, and has recording mode via launch flags such as `--record`.
+
+For StarVLA, this route usually needs a conversion step after collection.
+
+### Unitree LeRobot Tools
+
+Repo: https://github.com/unitreerobotics/unitree_lerobot
+
+This path is useful when working with Unitree-recorded JSON datasets or Unitree public examples. The repo includes data conversion, dataset visualization/editing, and G1/Dex real-world evaluation utilities.
+
+For StarVLA, this can be used as a bridge from Unitree raw data into LeRobot.
+
+## Purpose of This Layer
+
+This layer answers:
+
+- How do we safely control or teleoperate G1?
+- How do we record demonstrations?
+- How do we know which episodes are successful?
+- What camera/state/action streams will StarVLA see later?
+
+This layer should not answer:
+
+- How does StarVLA train?
+- How does the VLA model normalize actions?
+- How does the policy server run?
+
+## What This Step Should Produce
+
+At the end of this step, you should have raw or already-exported demonstrations:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/
+  raw/
+    <task_name>/
+      episodes/
+      metadata/
+```
+
+or, if the external stack already exports LeRobot v2.1:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/
+  lerobot/
+    <task_name>/
+      data/
+      videos/
+      meta/
+```
+
+## Minimum Data Contract
+
+Every collected episode should include:
+
+- episode id
+- task prompt
+- success / failure / discarded flag
+- synchronized camera frames
+- synchronized robot state
+- synchronized action or teleop command
+- timestamps for every stream
+- control frequency
+- camera names and order
+- state/action schema version
+
+## Practical G1 Notes
+
+For first StarVLA integration, prefer a constrained setup:
+
+- Start in simulation or replay first.
+- Use a fixed task prompt.
+- Use one or two camera views before adding all cameras.
+- Freeze locomotion or lower-body control unless your controller stack already handles it safely.
+- Prefer a controller-level latent or grouped action interface over direct motor command prediction.
+
+If using GR00T-WholeBodyControl / SONIC, keep their teleop and WBC process outside StarVLA. If using another stack, keep that stack outside StarVLA too. StarVLA only needs the exported dataset and the action semantics.
+
+## Safety Gate
+
+Before collecting on the real robot:
+
+- Teleop works smoothly in simulation.
+- Emergency stop is tested.
+- A safety operator is present.
+- Calibration pose and mode switching are understood.
+- No StarVLA model is in the loop yet.
+
+## Handoff to Step 1
+
+Move to [step1_data_conversion](../step1_data_conversion/README.md) when you can answer:
+
+- Where is the dataset?
+- Is it already LeRobot v2.1?
+- What are the exact camera keys?
+- What are the exact state keys and dimensions?
+- What are the exact action keys and dimensions?
+- What is the embodiment/action route: SONIC latent or direct grouped control?

--- a/examples/realRobots/UnitreeG1_WholeBody/step0_teleop_data_collection/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step0_teleop_data_collection/README.md
@@ -40,24 +40,26 @@ For StarVLA, this step's job is to produce the same kind of dataset that the NVl
 
 Start in simulation before touching the real robot.
 
-Terminal 1, from the GR00T-WholeBodyControl repo root:
+Terminal 1, MuJoCo simulation loop from the StarVLA repo root:
 
 ```bash
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
 source .venv_teleop/bin/activate
 python gear_sonic/scripts/run_sim_loop.py
 ```
 
-Terminal 2, from `gear_sonic_deploy/`:
+Terminal 2, SONIC deploy from the StarVLA repo root:
 
 ```bash
-cd gear_sonic_deploy
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl/gear_sonic_deploy
 source scripts/setup_env.sh
 ./deploy.sh --input-type zmq_manager sim
 ```
 
-Terminal 3, from the repo root:
+Terminal 3, PICO teleop streamer from the StarVLA repo root:
 
 ```bash
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
 source .venv_teleop/bin/activate
 python gear_sonic/scripts/pico_manager_thread_server.py --manager \
   --vis_vr3pt --vis_smpl
@@ -76,6 +78,7 @@ Validation before continuing:
 Use GR00T-WholeBodyControl's data collection launcher as the first concrete collection path:
 
 ```bash
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
 python gear_sonic/scripts/launch_data_collection.py \
   --camera-host 192.168.123.164 \
   --task-prompt "pick up the soda can and place it in the bin"
@@ -109,17 +112,18 @@ Only move to the physical G1 after simulation teleop is stable.
 
 The upstream real-robot path uses two main terminals:
 
-Terminal 1, C++ deployment from `gear_sonic_deploy/`:
+Terminal 1, C++ deployment from the StarVLA repo root:
 
 ```bash
-cd gear_sonic_deploy
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl/gear_sonic_deploy
 source scripts/setup_env.sh
 ./deploy.sh --input-type zmq_manager real
 ```
 
-Terminal 2, PICO teleop streamer from the repo root:
+Terminal 2, PICO teleop streamer from the StarVLA repo root:
 
 ```bash
+cd examples/realRobots/UnitreeG1_WholeBody/sdk_tools/GR00T-WholeBodyControl
 source .venv_teleop/bin/activate
 python gear_sonic/scripts/pico_manager_thread_server.py --manager
 ```

--- a/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
@@ -1,178 +1,293 @@
 # Step 1: Data Conversion
 
-This step prepares the GR00T-WholeBodyControl demonstrations for StarVLA training. In the primary example route, GR00T-WholeBodyControl already exports a LeRobot v2.1-style dataset, so this step is mostly validation, cleanup, and StarVLA schema registration.
+This step prepares G1 WholeBody demonstrations for StarVLA training on the
+local PC.
 
-StarVLA's preferred boundary is LeRobot v2.1 plus a clear modality schema. If the upstream collector already produces LeRobot v2.1, do not reconvert it unnecessarily. Instead, validate it and add the StarVLA registry files.
+For this setup, the collected data is already stored in LeRobot v2.1 layout.
+Do not reconvert it. Register it under StarVLA, validate the metadata, then
+pass the schema into `step2_training`.
 
-This means LeRobot G1, Unitree `xr_teleoperate`, Unitree `unitree_lerobot`, GR00T-WholeBodyControl, a custom Unitree logger, a rosbag pipeline, or another teleop stack can all be valid inputs. The requirement is not the source tool. The requirement is a consistent LeRobot dataset with documented semantics.
+## Local Working Layout
 
-## Primary Input from GR00T-WholeBodyControl
-
-GR00T-WholeBodyControl's VLA collection flow writes a dataset shaped like:
-
-```text
-outputs/<timestamp>-G1-<robot_id>/
-  data/
-    train-00000.parquet
-  videos/
-    observation.images.<camera_name>/
-      episode_000000.mp4
-  meta/
-    info.json
-    modality.json
-    episodes.jsonl
-    tasks.jsonl
-```
-
-Copy or symlink it into:
+Use the local paths on this machine:
 
 ```text
-playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
+/home/hoi-4090-01/yjh/starVLA
+/home/hoi-4090-01/yjh/GR00T-WholeBodyControl
 ```
 
-## Post-Process the NVlabs Dataset
+The current dataset used for this example is:
 
-Before StarVLA training, run the upstream cleanup step if needed:
+```text
+/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+```
+
+If Git ever needs a local safe-directory entry for a copied workspace, use:
 
 ```bash
-source .venv_data_collection/bin/activate
-python gear_sonic/scripts/process_dataset.py \
-  --dataset-path outputs/<timestamp>-G1-<robot_id> \
-  --output-path outputs/<task_name>_cleaned
+git config --global --add safe.directory \
+  /home/hoi-4090-01/yjh/starVLA
 ```
 
-Use the cleaned dataset for StarVLA. This removes discarded demonstrations and stale motion frames according to the upstream workflow.
+## Register Data Under StarVLA
 
-## Generic Input
+The local example dataset is already present in StarVLA, so no extra import
+step is required on this PC.
 
-One of:
+If you later export another copy of `test_sonic`, replace the source path in
+the commands below with the archive location you saved on disk.
 
-```text
-playground/Datasets/UnitreeG1_WholeBody/raw/<task_name>/
-```
-
-or:
+The expected target structure is:
 
 ```text
-playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
-```
-
-## Output
-
-```text
-playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
-  data/
-  videos/
+playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic/
+  data/chunk-000/episode_000000.parquet
+  videos/chunk-000/observation.images.ego_view/episode_000000.mp4
   meta/
     info.json
     modality.json
     episodes.jsonl
     tasks.jsonl
+```
+
+## Source Dataset Schema
+
+The checked `test_sonic` dataset reports:
+
+```text
+codebase_version: v2.1
+fps: 50
+total_episodes: 49
+total_frames: 56919
+video key: observation.images.ego_view
+task: pick the toy on the table, and put it into the box.
+```
+
+The important tensor dimensions from a sampled parquet episode are:
+
+```text
+observation.state: 43
+observation.eef_state: 14
+action.wbc: 43
+action.motion_token: 64
+teleop.left_hand_joints: 7
+teleop.right_hand_joints: 7
+teleop.smpl_pose: 63
+teleop.vr_3pt_position: 9
+teleop.vr_3pt_orientation: 18
+```
+
+The `meta/modality.json` maps these fields into groups:
+
+```text
+state:
+  observation.state:
+    left_leg 0:6
+    right_leg 6:12
+    waist 12:15
+    left_arm 15:22
+    left_hand 22:29
+    right_arm 29:36
+    right_hand 36:43
+  observation.eef_state:
+    left_wrist_pos 0:3
+    left_wrist_abs_quat 3:7
+    right_wrist_pos 7:10
+    right_wrist_abs_quat 10:14
+
+action:
+  action.motion_token: 64
+  teleop.left_hand_joints: 7
+  teleop.right_hand_joints: 7
+  teleop.delta_heading: 1
+  teleop.smpl_pose: 63
+  teleop.vr_3pt_position: 9
+  teleop.vr_3pt_orientation: 18
+
+video:
+  observation.images.ego_view
+
+annotation:
+  annotation.human.task_description from task_index/tasks.jsonl
+```
+
+For the first StarVLA training pass, use the explicit robot type:
+
+```text
+unitree_g1_sonic_dex3
+```
+
+Recommended first action registry:
+
+```text
+action.motion_token: 64
+teleop.left_hand_joints: 7
+teleop.right_hand_joints: 7
+```
+
+This is a 78D controller target. Keep `action.wbc` available for analysis, but
+do not train both `action.wbc` and `action.motion_token` in the same first
+adapter unless the downstream policy head is designed for that.
+
+## Validate the Registered Dataset
+
+Metadata check with local system Python:
+
+```bash
+export DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+dataset = Path(os.environ["DATASET"])
+info = json.loads((dataset / "meta/info.json").read_text())
+modality = json.loads((dataset / "meta/modality.json").read_text())
+tasks = [json.loads(line) for line in (dataset / "meta/tasks.jsonl").read_text().splitlines() if line.strip()]
+features = info.get("features", {})
+video_keys = [
+    key for key, value in features.items()
+    if value.get("dtype") in ("video", "image")
+]
+
+print("dataset:", dataset)
+print("codebase_version:", info.get("codebase_version"))
+print("fps:", info.get("fps"))
+print("episodes:", info.get("total_episodes"))
+print("frames:", info.get("total_frames"))
+print("video_keys:", video_keys)
+print("feature_keys:", sorted(features.keys()))
+print("state_groups:", sorted(modality.get("state", {}).keys()))
+print("action_groups:", sorted(modality.get("action", {}).keys()))
+print("task:", tasks[0]["task"] if tasks else None)
+PY
+```
+
+Parquet shape check using the local GR00T environment:
+
+```bash
+GROOT=/home/hoi-4090-01/yjh/GR00T-WholeBodyControl
+export DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+
+"${GROOT}/.venv_data_collection/bin/python" - <<'PY'
+import os
+from pathlib import Path
+import pandas as pd
+
+dataset = Path(os.environ["DATASET"])
+parquet = next((dataset / "data/chunk-000").glob("episode_*.parquet"))
+df = pd.read_parquet(parquet)
+
+keys = [
+    "observation.state",
+    "observation.eef_state",
+    "action.wbc",
+    "action.motion_token",
+    "teleop.left_hand_joints",
+    "teleop.right_hand_joints",
+    "teleop.smpl_pose",
+    "teleop.vr_3pt_position",
+    "teleop.vr_3pt_orientation",
+]
+
+print("parquet:", parquet)
+print("rows:", len(df))
+for key in keys:
+    value = df[key].iloc[0]
+    print(key, len(value))
+PY
+```
+
+Video presence check:
+
+```bash
+DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+
+find "${DATASET}/videos" -type f -name '*.mp4' | head
+```
+
+## Optional GR00T Cleanup
+
+The local GR00T repository provides the cleaner here:
+
+```text
+/home/hoi-4090-01/yjh/GR00T-WholeBodyControl/gear_sonic/scripts/process_dataset.py
+```
+
+For this PC, the `.venv_data_collection` environment already has the needed
+packages (`av`, `pandas`, `numpy`, `tyro`, `pyarrow`).
+
+To clean a dataset in place:
+
+```bash
+cd /home/hoi-4090-01/yjh/GR00T-WholeBodyControl
+source .venv_data_collection/bin/activate
+
+python gear_sonic/scripts/process_dataset.py \
+  --dataset-path /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic \
+  --output-path /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic_cleaned \
+  --remove-discarded
+```
+
+After cleanup, point the StarVLA path at the cleaned directory:
+
+```bash
+cd /home/hoi-4090-01/yjh/starVLA
+
+rm -rf playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+mv playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic_cleaned \
+  playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 ```
 
 ## Conversion Strategy
 
-Use the least invasive converter possible:
+Use the least invasive route:
 
-1. If GR00T-WholeBodyControl already exported LeRobot v2.1, keep it and validate it.
-2. If LeRobot G1 already produced a LeRobot dataset, keep it.
-3. If Unitree `unitree_lerobot` can convert the collected JSON data, use it.
-4. If data is HDF5 / JSON / PKL / rosbag / vendor logs, convert to LeRobot.
-5. If another converter already works, such as an `any4lerobot` style pipeline, use it and document the command here.
-6. Only write a custom converter when the source format or action semantics require it.
-
-## Source-Specific Notes
-
-### From LeRobot G1
-
-Usually no structural conversion is needed. Validate the dataset and write StarVLA's `data_config.py` against the existing keys.
-
-### From Unitree XR Teleoperate
-
-The recorded data may need conversion into LeRobot. Preserve the XR action semantics, arm/end-effector type, camera source, and episode success metadata.
-
-### From Unitree LeRobot
-
-Use their converter when possible, then inspect the output. Their tooling is useful for Unitree JSON data, dataset visualization, episode editing, and conversion into LeRobot-compatible datasets.
-
-### From GR00T-WholeBodyControl
-
-Keep the LeRobot export and action contract. If using SONIC latent actions, document the latent/action groups explicitly in StarVLA's registry.
-
-For the primary example, treat the action as:
-
-```text
-action.sonic_latent: 64
-action.left_hand: 7
-action.right_hand: 7
-```
-
-These are the dimensions described by the NVlabs VLA workflow. Verify them against the actual dataset before training.
-
-## StarVLA Files to Add Later
-
-This folder is only the data conversion stage, but it should prepare the information needed for:
-
-```text
-../step2_training/train_files/
-  data_registry/data_config.py
-  modality.json
-  starvla_cotrain_g1_wholebody.yaml
-```
-
-Recommended robot type names for the primary example:
-
-```text
-unitree_g1_sonic
-```
-
-Use `unitree_g1_sonic` for the GR00T-WholeBodyControl / SONIC path. Use a different robot type if your data comes from another action representation.
-
-## Required Schema Notes
-
-Write these down before training:
-
-```text
-camera_order:
-  - video.<camera_0>
-  - video.<camera_1>
-
-state_keys:
-  - state.<group_name>: dim, unit, coordinate frame, order
-
-action_keys:
-  - action.<group_name>: dim, unit, control mode, frequency
-
-language_keys:
-  - annotation.human.action.task_description
-
-normalization:
-  state: q99
-  action: q99 / binary / passthrough
-```
-
-Use `q99` as the StarVLA-side default for continuous state and action groups. This means the dataset statistics must include `q01` and `q99` for each continuous key. Use `binary` only for true binary commands, and use `passthrough` only when a controller-specific field should not be normalized.
-
-## Validation Checklist
-
-Run these checks before training:
-
-- Episode count matches collection logs.
-- Discarded / failed episodes are removed or tagged intentionally.
-- All frames have valid timestamps.
-- Camera videos decode correctly.
-- Camera order matches the intended training order.
-- State vector shape is constant.
-- Action vector shape is constant.
-- Continuous state/action statistics include `q01` and `q99`.
-- `modality.json` key names match the actual LeRobot fields.
-- A sampled episode can be replayed without loading a real robot.
+1. If the dataset is already LeRobot v2.1, keep it and validate it.
+2. If the dataset only needs filtering, use `process_dataset.py`.
+3. If a future dataset is HDF5, JSON, PKL, rosbag, or vendor logs, convert it
+   to the same LeRobot v2.1 boundary first.
+4. Only write a custom converter when the source format or action semantics
+   cannot be represented by the existing LeRobot fields.
 
 ## Handoff to Step 2
 
-Move to [step2_training](../step2_training/README.md) when:
+Move to [step2_training](../step2_training/README.md) when these values are final:
 
-- the LeRobot dataset exists,
-- `meta/modality.json` is present,
-- the action/state dimensions are final for this first experiment,
-- you know the `data_root_dir`, `data_mix`, and `robot_type` strings.
+```text
+data_root_dir:
+  /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot
+
+data_mix:
+  test_sonic
+
+robot_type:
+  unitree_g1_sonic_dex3
+
+video_keys:
+  observation.images.ego_view
+
+state_keys:
+  observation.state
+  observation.eef_state
+
+action_keys:
+  action.motion_token
+  teleop.left_hand_joints
+  teleop.right_hand_joints
+
+language_keys:
+  annotation.human.task_description
+
+normalization:
+  continuous state/action keys: q99
+```
+
+Before full training:
+
+- Episode count matches `meta/info.json`.
+- `meta/modality.json` and parquet tensor shapes agree.
+- Camera videos decode and match the episode count.
+- The selected action keys match the deployment-side SONIC controller contract.
+- Keep 6D-hand datasets and 7D-hand datasets in separate robot-type configs.

--- a/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
@@ -1,0 +1,178 @@
+# Step 1: Data Conversion
+
+This step prepares the GR00T-WholeBodyControl demonstrations for StarVLA training. In the primary example route, GR00T-WholeBodyControl already exports a LeRobot v2.1-style dataset, so this step is mostly validation, cleanup, and StarVLA schema registration.
+
+StarVLA's preferred boundary is LeRobot v2.1 plus a clear modality schema. If the upstream collector already produces LeRobot v2.1, do not reconvert it unnecessarily. Instead, validate it and add the StarVLA registry files.
+
+This means LeRobot G1, Unitree `xr_teleoperate`, Unitree `unitree_lerobot`, GR00T-WholeBodyControl, a custom Unitree logger, a rosbag pipeline, or another teleop stack can all be valid inputs. The requirement is not the source tool. The requirement is a consistent LeRobot dataset with documented semantics.
+
+## Primary Input from GR00T-WholeBodyControl
+
+GR00T-WholeBodyControl's VLA collection flow writes a dataset shaped like:
+
+```text
+outputs/<timestamp>-G1-<robot_id>/
+  data/
+    train-00000.parquet
+  videos/
+    observation.images.<camera_name>/
+      episode_000000.mp4
+  meta/
+    info.json
+    modality.json
+    episodes.jsonl
+    tasks.jsonl
+```
+
+Copy or symlink it into:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
+```
+
+## Post-Process the NVlabs Dataset
+
+Before StarVLA training, run the upstream cleanup step if needed:
+
+```bash
+source .venv_data_collection/bin/activate
+python gear_sonic/scripts/process_dataset.py \
+  --dataset-path outputs/<timestamp>-G1-<robot_id> \
+  --output-path outputs/<task_name>_cleaned
+```
+
+Use the cleaned dataset for StarVLA. This removes discarded demonstrations and stale motion frames according to the upstream workflow.
+
+## Generic Input
+
+One of:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/raw/<task_name>/
+```
+
+or:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
+```
+
+## Output
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/lerobot/<task_name>/
+  data/
+  videos/
+  meta/
+    info.json
+    modality.json
+    episodes.jsonl
+    tasks.jsonl
+```
+
+## Conversion Strategy
+
+Use the least invasive converter possible:
+
+1. If GR00T-WholeBodyControl already exported LeRobot v2.1, keep it and validate it.
+2. If LeRobot G1 already produced a LeRobot dataset, keep it.
+3. If Unitree `unitree_lerobot` can convert the collected JSON data, use it.
+4. If data is HDF5 / JSON / PKL / rosbag / vendor logs, convert to LeRobot.
+5. If another converter already works, such as an `any4lerobot` style pipeline, use it and document the command here.
+6. Only write a custom converter when the source format or action semantics require it.
+
+## Source-Specific Notes
+
+### From LeRobot G1
+
+Usually no structural conversion is needed. Validate the dataset and write StarVLA's `data_config.py` against the existing keys.
+
+### From Unitree XR Teleoperate
+
+The recorded data may need conversion into LeRobot. Preserve the XR action semantics, arm/end-effector type, camera source, and episode success metadata.
+
+### From Unitree LeRobot
+
+Use their converter when possible, then inspect the output. Their tooling is useful for Unitree JSON data, dataset visualization, episode editing, and conversion into LeRobot-compatible datasets.
+
+### From GR00T-WholeBodyControl
+
+Keep the LeRobot export and action contract. If using SONIC latent actions, document the latent/action groups explicitly in StarVLA's registry.
+
+For the primary example, treat the action as:
+
+```text
+action.sonic_latent: 64
+action.left_hand: 7
+action.right_hand: 7
+```
+
+These are the dimensions described by the NVlabs VLA workflow. Verify them against the actual dataset before training.
+
+## StarVLA Files to Add Later
+
+This folder is only the data conversion stage, but it should prepare the information needed for:
+
+```text
+../step2_training/train_files/
+  data_registry/data_config.py
+  modality.json
+  starvla_cotrain_g1_wholebody.yaml
+```
+
+Recommended robot type names for the primary example:
+
+```text
+unitree_g1_sonic
+```
+
+Use `unitree_g1_sonic` for the GR00T-WholeBodyControl / SONIC path. Use a different robot type if your data comes from another action representation.
+
+## Required Schema Notes
+
+Write these down before training:
+
+```text
+camera_order:
+  - video.<camera_0>
+  - video.<camera_1>
+
+state_keys:
+  - state.<group_name>: dim, unit, coordinate frame, order
+
+action_keys:
+  - action.<group_name>: dim, unit, control mode, frequency
+
+language_keys:
+  - annotation.human.action.task_description
+
+normalization:
+  state: q99
+  action: q99 / binary / passthrough
+```
+
+Use `q99` as the StarVLA-side default for continuous state and action groups. This means the dataset statistics must include `q01` and `q99` for each continuous key. Use `binary` only for true binary commands, and use `passthrough` only when a controller-specific field should not be normalized.
+
+## Validation Checklist
+
+Run these checks before training:
+
+- Episode count matches collection logs.
+- Discarded / failed episodes are removed or tagged intentionally.
+- All frames have valid timestamps.
+- Camera videos decode correctly.
+- Camera order matches the intended training order.
+- State vector shape is constant.
+- Action vector shape is constant.
+- Continuous state/action statistics include `q01` and `q99`.
+- `modality.json` key names match the actual LeRobot fields.
+- A sampled episode can be replayed without loading a real robot.
+
+## Handoff to Step 2
+
+Move to [step2_training](../step2_training/README.md) when:
+
+- the LeRobot dataset exists,
+- `meta/modality.json` is present,
+- the action/state dimensions are final for this first experiment,
+- you know the `data_root_dir`, `data_mix`, and `robot_type` strings.

--- a/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step1_data_conversion/README.md
@@ -9,24 +9,29 @@ pass the schema into `step2_training`.
 
 ## Local Working Layout
 
-Use the local paths on this machine:
+Run StarVLA commands from the repository root:
 
-```text
-/home/hoi-4090-01/yjh/starVLA
-/home/hoi-4090-01/yjh/GR00T-WholeBodyControl
+```bash
+cd starVLA
 ```
 
-The current dataset used for this example is:
+If you also use GR00T-WholeBodyControl locally, keep it next to `starVLA` or
+set `GROOT` to its location:
+
+```bash
+GROOT=../GR00T-WholeBodyControl
+```
+
+The current dataset used for this example is under the StarVLA repository:
 
 ```text
-/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 ```
 
 If Git ever needs a local safe-directory entry for a copied workspace, use:
 
 ```bash
-git config --global --add safe.directory \
-  /home/hoi-4090-01/yjh/starVLA
+git config --global --add safe.directory "$(pwd)"
 ```
 
 ## Register Data Under StarVLA
@@ -134,7 +139,8 @@ adapter unless the downstream policy head is designed for that.
 Metadata check with local system Python:
 
 ```bash
-export DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+cd starVLA
+export DATASET=playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 
 python3 - <<'PY'
 import json
@@ -167,8 +173,9 @@ PY
 Parquet shape check using the local GR00T environment:
 
 ```bash
-GROOT=/home/hoi-4090-01/yjh/GR00T-WholeBodyControl
-export DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+cd starVLA
+GROOT=../GR00T-WholeBodyControl
+export DATASET=playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 
 "${GROOT}/.venv_data_collection/bin/python" - <<'PY'
 import os
@@ -202,7 +209,8 @@ PY
 Video presence check:
 
 ```bash
-DATASET=/home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
+cd starVLA
+DATASET=playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 
 find "${DATASET}/videos" -type f -name '*.mp4' | head
 ```
@@ -212,7 +220,7 @@ find "${DATASET}/videos" -type f -name '*.mp4' | head
 The local GR00T repository provides the cleaner here:
 
 ```text
-/home/hoi-4090-01/yjh/GR00T-WholeBodyControl/gear_sonic/scripts/process_dataset.py
+<GROOT_ROOT>/gear_sonic/scripts/process_dataset.py
 ```
 
 For this PC, the `.venv_data_collection` environment already has the needed
@@ -221,19 +229,19 @@ packages (`av`, `pandas`, `numpy`, `tyro`, `pyarrow`).
 To clean a dataset in place:
 
 ```bash
-cd /home/hoi-4090-01/yjh/GR00T-WholeBodyControl
+cd ../GR00T-WholeBodyControl
 source .venv_data_collection/bin/activate
 
 python gear_sonic/scripts/process_dataset.py \
-  --dataset-path /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic \
-  --output-path /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic_cleaned \
+  --dataset-path ../starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic \
+  --output-path ../starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic_cleaned \
   --remove-discarded
 ```
 
 After cleanup, point the StarVLA path at the cleaned directory:
 
 ```bash
-cd /home/hoi-4090-01/yjh/starVLA
+cd starVLA
 
 rm -rf playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic
 mv playground/Datasets/UnitreeG1_WholeBody/lerobot/test_sonic_cleaned \
@@ -257,7 +265,7 @@ Move to [step2_training](../step2_training/README.md) when these values are fina
 
 ```text
 data_root_dir:
-  /home/hoi-4090-01/yjh/starVLA/playground/Datasets/UnitreeG1_WholeBody/lerobot
+  playground/Datasets/UnitreeG1_WholeBody/lerobot
 
 data_mix:
   test_sonic

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
@@ -151,7 +151,7 @@ Only start full training after both pass.
 This workspace has been verified with a 1-step smoke training run:
 
 ```bash
-cd /home/hoi-4090-01/yjh/starVLA
+cd starVLA
 WANDB_MODE=disabled BATCH=1 MAX_STEPS=1 SAVE_EVERY=1 EVAL_EVERY=1 LOG_EVERY=1 \
   bash examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh
 ```

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
@@ -1,8 +1,16 @@
 # Step 2: Training
 
-This step trains StarVLA on the G1 dataset collected with GR00T-WholeBodyControl. In the upstream NVlabs VLA workflow, this stage fine-tunes Isaac-GR00T. In this StarVLA example, this stage trains StarVLA instead.
+This step trains StarVLA on the local G1 dataset collected with
+GR00T-WholeBodyControl. In the upstream NVlabs VLA workflow, this stage fine-tunes
+Isaac-GR00T. In this StarVLA example, this stage trains StarVLA instead.
 
 Training should not depend on Unitree SDK or the teleop runtime. At this point the only required input is the LeRobot-format dataset plus StarVLA data registry files.
+
+For this workspace, the local LeRobot root is:
+
+```text
+playground/Datasets/UnitreeG1_WholeBody/lerobot
+```
 
 ## Expected Files
 
@@ -19,7 +27,18 @@ examples/realRobots/UnitreeG1_WholeBody/step2_training/
     run_g1_train.sh
 ```
 
-These files are not implemented yet in this scaffold. When implementing them, follow the patterns in:
+These files are now implemented in this scaffold. The single-GPU walk-through
+uses:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/
+  data_registry/data_config.py
+  modality.json
+  starvla_qwenoft_g1_sonic.yaml
+  run_starvla_qwenoft_g1_sonic_train.sh
+```
+
+Follow the patterns in:
 
 - `examples/realRobots/Franka/train_files/`
 - `examples/realRobots/RoboChallenge_table30v2/train_files/`
@@ -32,22 +51,46 @@ For the GR00T-WholeBodyControl / SONIC example version, prefer explicit naming:
 ```python
 class UnitreeG1SonicConfig:
     embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
-    video_keys = ["video.<camera_0>", "video.<camera_1>"]
-    state_keys = ["state.<robot_state_group>"]
-    action_keys = ["action.sonic_latent", "action.left_hand", "action.right_hand"]
+    video_keys = ["video.ego_view"]
+    state_keys = [
+        "state.left_leg", "state.right_leg", "state.waist",
+        "state.left_arm", "state.left_hand", "state.right_arm",
+        "state.right_hand", "state.left_wrist_pos", "state.left_wrist_abs_quat",
+        "state.right_wrist_pos", "state.right_wrist_abs_quat",
+        "state.root_orientation", "state.projected_gravity",
+        "state.cpp_rotation_offset", "state.init_base_quat",
+    ]
+    action_keys = ["action.motion_token", "action.left_hand_joints", "action.right_hand_joints"]
     language_keys = ["annotation.human.action.task_description"]
 
     # Example only. Use real dimensions from the dataset.
     action_key_dims = {
-        "action.sonic_latent": 64,
-        "action.left_hand": 7,
-        "action.right_hand": 7,
+        "action.motion_token": 64,
+        "action.left_hand_joints": 7,
+        "action.right_hand_joints": 7,
+    }
+    state_key_dims = {
+        "state.left_leg": 6,
+        "state.right_leg": 6,
+        "state.waist": 3,
+        "state.left_arm": 7,
+        "state.left_hand": 7,
+        "state.right_arm": 7,
+        "state.right_hand": 7,
+        "state.left_wrist_pos": 3,
+        "state.left_wrist_abs_quat": 4,
+        "state.right_wrist_pos": 3,
+        "state.right_wrist_abs_quat": 4,
+        "state.root_orientation": 4,
+        "state.projected_gravity": 3,
+        "state.cpp_rotation_offset": 4,
+        "state.init_base_quat": 4,
     }
 ```
 
 Do not copy these dimensions blindly. Use the dataset and controller action contract as the source of truth. If the user chooses a different controller route, define different `action_keys` and `action_key_dims`.
 
-For the primary NVlabs-style route, the expected action family is:
+For the primary local walk-through route, the expected action family is:
 
 ```text
 64D SONIC motion latent + 7D left hand + 7D right hand = 78D
@@ -95,13 +138,35 @@ Run the same style of checks used by other StarVLA examples:
 
 ```bash
 python starVLA/dataloader/lerobot_datasets.py \
-  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_cotrain_g1_wholebody.yaml
+  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_qwenoft_g1_sonic.yaml
 
 python starVLA/model/framework/VLM4A/QwenOFT.py \
-  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_cotrain_g1_wholebody.yaml
+  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_qwenoft_g1_sonic.yaml
 ```
 
 Only start full training after both pass.
+
+## Verified Local Run
+
+This workspace has been verified with a 1-step smoke training run:
+
+```bash
+cd /home/hoi-4090-01/yjh/starVLA
+WANDB_MODE=disabled BATCH=1 MAX_STEPS=1 SAVE_EVERY=1 EVAL_EVERY=1 LOG_EVERY=1 \
+  bash examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh
+```
+
+Observed result:
+
+```text
+results/Checkpoints/starvla_qwenoft_g1_sonic_smoke/
+  checkpoints/steps_1/
+  config.full.yaml
+  config.yaml
+  dataset_statistics.json
+```
+
+The run completed successfully on a single RTX 4090 and reached the first checkpoint.
 
 ## Training Output
 

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/README.md
@@ -1,0 +1,128 @@
+# Step 2: Training
+
+This step trains StarVLA on the G1 dataset collected with GR00T-WholeBodyControl. In the upstream NVlabs VLA workflow, this stage fine-tunes Isaac-GR00T. In this StarVLA example, this stage trains StarVLA instead.
+
+Training should not depend on Unitree SDK or the teleop runtime. At this point the only required input is the LeRobot-format dataset plus StarVLA data registry files.
+
+## Expected Files
+
+Recommended local structure:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step2_training/
+  README.md
+  train_files/
+    data_registry/
+      data_config.py
+    modality.json
+    starvla_cotrain_g1_wholebody.yaml
+    run_g1_train.sh
+```
+
+These files are not implemented yet in this scaffold. When implementing them, follow the patterns in:
+
+- `examples/realRobots/Franka/train_files/`
+- `examples/realRobots/RoboChallenge_table30v2/train_files/`
+- `docs/agent_skills/integrate-starvla-dataset/assets/templates/`
+
+## Data Registry Shape
+
+For the GR00T-WholeBodyControl / SONIC example version, prefer explicit naming:
+
+```python
+class UnitreeG1SonicConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
+    video_keys = ["video.<camera_0>", "video.<camera_1>"]
+    state_keys = ["state.<robot_state_group>"]
+    action_keys = ["action.sonic_latent", "action.left_hand", "action.right_hand"]
+    language_keys = ["annotation.human.action.task_description"]
+
+    # Example only. Use real dimensions from the dataset.
+    action_key_dims = {
+        "action.sonic_latent": 64,
+        "action.left_hand": 7,
+        "action.right_hand": 7,
+    }
+```
+
+Do not copy these dimensions blindly. Use the dataset and controller action contract as the source of truth. If the user chooses a different controller route, define different `action_keys` and `action_key_dims`.
+
+For the primary NVlabs-style route, the expected action family is:
+
+```text
+64D SONIC motion latent + 7D left hand + 7D right hand = 78D
+```
+
+That action representation is what the downstream SONIC/controller side should know how to consume.
+
+## Training Config Responsibilities
+
+The YAML should make these values easy to audit:
+
+- dataset path
+- mixture name
+- action dimension
+- state dimension
+- normalization modes, with `q99` as the default for continuous state/action keys
+- action horizon
+- image size
+- backbone / action head
+- output directory
+- batch size and training steps
+
+For the primary G1/SONIC route, the data registry should use `q99` for continuous keys:
+
+```python
+StateActionTransform(
+    apply_to=self.state_keys,
+    normalization_modes={k: "q99" for k in self.state_keys},
+)
+StateActionTransform(
+    apply_to=self.action_keys,
+    normalization_modes={
+        "action.sonic_latent": "q99",
+        "action.left_hand": "q99",
+        "action.right_hand": "q99",
+    },
+)
+```
+
+Use `binary` only for actual binary gripper/open-close commands. Do not use `min_max` as the default for this example unless you are intentionally matching an existing checkpoint or external controller contract.
+
+## Smoke Tests Before Full Training
+
+Run the same style of checks used by other StarVLA examples:
+
+```bash
+python starVLA/dataloader/lerobot_datasets.py \
+  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_cotrain_g1_wholebody.yaml
+
+python starVLA/model/framework/VLM4A/QwenOFT.py \
+  --config_yaml examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_cotrain_g1_wholebody.yaml
+```
+
+Only start full training after both pass.
+
+## Training Output
+
+Expected output:
+
+```text
+playground/Checkpoints/<g1_run_name>/
+  dataset_statistics.json
+  checkpoints/
+    steps_<N>_pytorch_model.pt
+  config.yaml
+```
+
+Keep `dataset_statistics.json` with the checkpoint. Deployment needs it for action unnormalization.
+
+## Handoff to Step 3
+
+Move to [step3_deployment](../step3_deployment/README.md) when:
+
+- dataloader smoke test passes,
+- model forward smoke test passes,
+- a checkpoint exists,
+- `dataset_statistics.json` exists beside the checkpoint,
+- action/state keys match the intended deployment adapter.

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/data_registry/data_config.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/data_registry/data_config.py
@@ -1,0 +1,92 @@
+"""Unitree G1 WholeBody - SONIC / Dex3 data registry for QwenOFT."""
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionToTensor, StateActionTransform
+
+
+class UnitreeG1SonicDex3QwenOFTDataConfig:
+    embodiment_tag = EmbodimentTag.NEW_EMBODIMENT
+    video_keys = ["video.ego_view"]
+    state_keys = [
+        "state.left_leg",
+        "state.right_leg",
+        "state.waist",
+        "state.left_arm",
+        "state.left_hand",
+        "state.right_arm",
+        "state.right_hand",
+        "state.left_wrist_pos",
+        "state.left_wrist_abs_quat",
+        "state.right_wrist_pos",
+        "state.right_wrist_abs_quat",
+        "state.root_orientation",
+        "state.projected_gravity",
+        "state.cpp_rotation_offset",
+        "state.init_base_quat",
+    ]
+    action_keys = [
+        "action.motion_token",
+        "action.left_hand_joints",
+        "action.right_hand_joints",
+    ]
+    language_keys = ["annotation.human.task_description"]
+    observation_indices = [0]
+    action_indices = list(range(8))
+
+    state_key_dims = {
+        "state.left_leg": 6,
+        "state.right_leg": 6,
+        "state.waist": 3,
+        "state.left_arm": 7,
+        "state.left_hand": 7,
+        "state.right_arm": 7,
+        "state.right_hand": 7,
+        "state.left_wrist_pos": 3,
+        "state.left_wrist_abs_quat": 4,
+        "state.right_wrist_pos": 3,
+        "state.right_wrist_abs_quat": 4,
+        "state.root_orientation": 4,
+        "state.projected_gravity": 3,
+        "state.cpp_rotation_offset": 4,
+        "state.init_base_quat": 4,
+    }
+    action_key_dims = {
+        "action.motion_token": 64,
+        "action.left_hand_joints": 7,
+        "action.right_hand_joints": 7,
+    }
+
+    def modality_config(self):
+        return {
+            "video": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
+            "state": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.state_keys),
+            "action": ModalityConfig(delta_indices=self.action_indices, modality_keys=self.action_keys),
+            "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
+        }
+
+    def transform(self):
+        return ComposedModalityTransform(
+            transforms=[
+                StateActionToTensor(apply_to=self.state_keys),
+                StateActionTransform(
+                    apply_to=self.state_keys,
+                    normalization_modes={key: "q99" for key in self.state_keys},
+                ),
+                StateActionToTensor(apply_to=self.action_keys),
+                StateActionTransform(
+                    apply_to=self.action_keys,
+                    normalization_modes={key: "q99" for key in self.action_keys},
+                ),
+            ]
+        )
+
+
+ROBOT_TYPE_CONFIG_MAP = {
+    "unitree_g1_sonic_dex3": UnitreeG1SonicDex3QwenOFTDataConfig(),
+}
+
+DATASET_NAMED_MIXTURES = {
+    "unitree_g1_test_sonic": [("test_sonic", 1.0, "unitree_g1_sonic_dex3")],
+}

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/modality.json
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/modality.json
@@ -1,0 +1,111 @@
+{
+  "state": {
+    "left_leg": {
+      "start": 0,
+      "end": 6,
+      "original_key": "observation.state"
+    },
+    "right_leg": {
+      "start": 6,
+      "end": 12,
+      "original_key": "observation.state"
+    },
+    "waist": {
+      "start": 12,
+      "end": 15,
+      "original_key": "observation.state"
+    },
+    "left_arm": {
+      "start": 15,
+      "end": 22,
+      "original_key": "observation.state"
+    },
+    "left_hand": {
+      "start": 22,
+      "end": 29,
+      "original_key": "observation.state"
+    },
+    "right_arm": {
+      "start": 29,
+      "end": 36,
+      "original_key": "observation.state"
+    },
+    "right_hand": {
+      "start": 36,
+      "end": 43,
+      "original_key": "observation.state"
+    },
+    "left_wrist_pos": {
+      "start": 0,
+      "end": 3,
+      "original_key": "observation.eef_state"
+    },
+    "left_wrist_abs_quat": {
+      "start": 3,
+      "end": 7,
+      "original_key": "observation.eef_state",
+      "rotation_type": "quaternion"
+    },
+    "right_wrist_pos": {
+      "start": 7,
+      "end": 10,
+      "original_key": "observation.eef_state"
+    },
+    "right_wrist_abs_quat": {
+      "start": 10,
+      "end": 14,
+      "original_key": "observation.eef_state",
+      "rotation_type": "quaternion"
+    },
+    "root_orientation": {
+      "start": 0,
+      "end": 4,
+      "original_key": "observation.root_orientation",
+      "rotation_type": "quaternion"
+    },
+    "projected_gravity": {
+      "start": 0,
+      "end": 3,
+      "original_key": "observation.projected_gravity"
+    },
+    "cpp_rotation_offset": {
+      "start": 0,
+      "end": 4,
+      "original_key": "observation.cpp_rotation_offset",
+      "rotation_type": "quaternion"
+    },
+    "init_base_quat": {
+      "start": 0,
+      "end": 4,
+      "original_key": "observation.init_base_quat",
+      "rotation_type": "quaternion"
+    }
+  },
+  "action": {
+    "motion_token": {
+      "start": 0,
+      "end": 64,
+      "original_key": "action.motion_token"
+    },
+    "left_hand_joints": {
+      "start": 0,
+      "end": 7,
+      "original_key": "teleop.left_hand_joints"
+    },
+    "right_hand_joints": {
+      "start": 0,
+      "end": 7,
+      "original_key": "teleop.right_hand_joints"
+    }
+  },
+  "video": {
+    "ego_view": {
+      "original_key": "observation.images.ego_view"
+    }
+  },
+  "annotation": {
+    "human.task_description": {
+      "original_key": "task_index"
+    }
+  }
+}

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Single-GPU walk-through for G1 SONIC/Dex3 QwenOFT training.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../../../../" && pwd)"
+
+cd "${ROOT_DIR}"
+
+Framework_name=QwenOFT
+freeze_module_list=''
+config_yaml=./examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_qwenoft_g1_sonic.yaml
+data_root_dir=playground/Datasets/UnitreeG1_WholeBody
+data_mix=unitree_g1_test_sonic
+run_root_dir=./results/Checkpoints
+run_id=starvla_qwenoft_g1_sonic_smoke
+num_processes=1
+BATCH=${BATCH:-1}
+MAX_STEPS=${MAX_STEPS:-1000}
+SAVE_EVERY=${SAVE_EVERY:-200}
+EVAL_EVERY=${EVAL_EVERY:-500}
+LOG_EVERY=${LOG_EVERY:-10}
+
+mkdir -p "${run_root_dir}/${run_id}"
+cp "${SCRIPT_DIR}/run_starvla_qwenoft_g1_sonic_train.sh" "${run_root_dir}/${run_id}/run_starvla_qwenoft_g1_sonic_train.sh"
+cp "${config_yaml#./}" "${run_root_dir}/${run_id}/$(basename "${config_yaml}")"
+
+export WANDB_MODE=${WANDB_MODE:-disabled}
+export PYTHONPATH="${ROOT_DIR}/starVLA:${PYTHONPATH:-}"
+
+accelerate launch \
+  --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml \
+  --num_processes "${num_processes}" \
+  starVLA/training/train_starvla.py \
+    --config_yaml "${config_yaml}" \
+    --datasets.vla_data.per_device_batch_size "${BATCH}" \
+    --trainer.max_train_steps "${MAX_STEPS}" \
+    --trainer.save_interval "${SAVE_EVERY}" \
+    --trainer.logging_frequency "${LOG_EVERY}" \
+    --trainer.eval_interval "${EVAL_EVERY}" \
+    --run_root_dir "${run_root_dir}" \
+    --run_id "${run_id}" \
+    --wandb_project starVLA_unitree_g1_wholebody

--- a/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_qwenoft_g1_sonic.yaml
+++ b/examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/starvla_qwenoft_g1_sonic.yaml
@@ -1,0 +1,64 @@
+run_id: starvla_qwenoft_g1_sonic_smoke
+run_root_dir: results/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_unitree_g1_wholebody
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: QwenOFT
+  qwenvl:
+    base_vlm: ./playground/Pretrained_models/Qwen3.5-0.8B
+    attn_implementation: sdpa
+  action_model:
+    action_model_type: MLP
+    action_dim: 78
+    state_dim: 72
+    action_horizon: 8
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    include_state: true
+    data_root_dir: playground/Datasets/UnitreeG1_WholeBody/lerobot
+    data_mix: unitree_g1_test_sonic
+    action_type: abs_qpos
+    action_mode: abs
+    sequential_step_sampling: false
+    per_device_batch_size: 1
+    load_all_data_for_training: true
+    obs_image_size: [224, 224]
+    delete_pause_frame: false
+    video_backend: torchvision_av
+
+trainer:
+  max_train_steps: 1000
+  num_warmup_steps: 50
+  save_interval: 200
+  eval_interval: 500
+  learning_rate:
+    base: 2.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 1.0e-06
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+    vlm: 0.1
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 4
+  gradient_checkpointing: true
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+
+  save_format: pt

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
@@ -102,7 +102,8 @@ action.right_hand_joints -> [T, 7]
 To let the existing GR00T `run_vla_inference.py` import this wrapper without editing its source, prepend both the StarVLA repo root and this deployment directory to `PYTHONPATH` before launching the GR00T sim stack:
 
 ```bash
-export PYTHONPATH=/home/hoi-4090-01/yjh/starVLA:/home/hoi-4090-01/yjh/starVLA/examples/realRobots/UnitreeG1_WholeBody/step3_deployment:${PYTHONPATH}
+cd starVLA
+export PYTHONPATH=$PWD:$PWD/examples/realRobots/UnitreeG1_WholeBody/step3_deployment:${PYTHONPATH}
 ```
 
 The compatibility shim at `step3_deployment/gr00t/policy/server_client.py` then shadows the GR00T `PolicyClient` import and forwards calls to StarVLA.
@@ -112,7 +113,7 @@ The deployment scripts now discover the normalization key from the policy server
 For a direct local smoke test:
 
 ```bash
-cd /home/hoi-4090-01/yjh/starVLA
+cd starVLA
 PYTHONPATH=$PWD:$PWD/examples/realRobots/UnitreeG1_WholeBody/step3_deployment \
   python examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/local_self_test.py \
     --ckpt-path results/Checkpoints/starvla_qwenoft_g1_sonic_smoke/checkpoints/steps_1_pytorch_model.pt \

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
@@ -1,0 +1,141 @@
+# Step 3: Deployment
+
+This step connects a trained StarVLA checkpoint to the GR00T-WholeBodyControl / SONIC-style G1 controller stack. The purpose is to replace the model-serving part of the NVlabs VLA workflow with StarVLA while leaving real-time robot execution to the controller infra.
+
+The recommended shape is:
+
+```text
+StarVLA checkpoint
+  -> StarVLA WebSocket policy server
+  -> G1 policy client / adapter
+  -> user-owned controller stack
+  -> Unitree G1
+```
+
+For the primary example, keep GR00T-WholeBodyControl / SONIC as the controller side. StarVLA should replace or provide only the VLA policy server/client boundary, not the whole-body controller.
+
+## NVlabs Deployment Shape
+
+The upstream inference path has:
+
+```text
+Isaac-GR00T PolicyServer
+  -> VLA inference client
+  -> camera server
+  -> C++ deploy / SONIC WBC
+  -> Unitree G1
+```
+
+The StarVLA version should be:
+
+```text
+StarVLA WebSocket policy server
+  -> G1 StarVLA adapter
+  -> camera server / robot state source
+  -> C++ deploy / SONIC WBC or equivalent controller
+  -> Unitree G1
+```
+
+Useful upstream references:
+
+- VLA inference: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vla_inference.html
+- VLA workflow: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vla_workflow.html
+- GR00T-WholeBodyControl repo: https://github.com/NVlabs/GR00T-WholeBodyControl
+
+## StarVLA Policy Server
+
+Start StarVLA's policy server on the GPU machine:
+
+```bash
+export PYTHONPATH=$(pwd):${PYTHONPATH}
+
+CUDA_VISIBLE_DEVICES=0 python deployment/model_server/server_policy.py \
+  --ckpt_path /path/to/g1/checkpoints/steps_<N>_pytorch_model.pt \
+  --port 5694 \
+  --use_bf16
+```
+
+The server returns unnormalized action chunks through `deployment/model_server/policy_wrapper.py`. For this G1 example, continuous state/action groups should be trained and unnormalized with `q99` statistics (`q01`/`q99`), not `min_max`, unless an existing checkpoint explicitly used a different normalization contract.
+
+This replaces the upstream `run_gr00t_server.py` role. The controller side should still see the same high-level action semantics expected by the selected G1 route.
+
+## G1 Adapter Responsibilities
+
+The G1-side adapter should do only bridge work:
+
+1. Read camera images and robot state from the user's G1 infra.
+2. Build the StarVLA request:
+
+   ```python
+   {
+       "examples": [{
+           "image": [cam0, cam1],
+           "state": state,
+           "lang": prompt,
+       }],
+       "unnorm_key": "unitree_g1_sonic",
+   }
+   ```
+
+3. Receive `actions` with shape `[B, T, action_dim]`.
+4. Split each flat action into controller groups.
+5. Apply safety limits.
+6. Publish to the SONIC decoder / C++ deploy side / user G1 controller bridge.
+
+For the primary NVlabs-style route, the adapter should preserve the 78D action meaning:
+
+```text
+action[0:64]   -> SONIC motion latent
+action[64:71]  -> left hand command
+action[71:78]  -> right hand command
+```
+
+Verify this against the actual training dataset and controller contract before real execution.
+
+The adapter should not reimplement normalization math. It should consume the unnormalized action chunk returned by the StarVLA policy server and only handle grouping, clipping, stale-action checks, and controller publishing.
+
+## Suggested Deployment Files
+
+When implementation starts, add:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/
+  run_policy_server.sh
+  model2unitree_g1_interface.py
+  local_self_test.py
+  replay_lerobot_episode.py
+  mock_g1_controller.py
+  g1_controller_adapter.py
+  g1_safety_limits.example.yaml
+```
+
+## Dry-Run Order
+
+Do not run directly on the real robot. Use this order:
+
+1. `local_self_test.py` with synthetic observation.
+2. `replay_lerobot_episode.py` with a real recorded episode.
+3. `mock_g1_controller.py` to inspect action groups.
+4. Simulation or third-party controller dry-run.
+5. Real robot with policy paused.
+6. Real robot with low-speed, limited action groups.
+7. Gradually enable more action groups.
+
+## Safety Requirements
+
+Deployment must have:
+
+- emergency stop independent from StarVLA,
+- action clipping per group,
+- velocity / acceleration limits,
+- stale action timeout,
+- camera/state freshness check,
+- policy pause command,
+- controller health check,
+- clear operator procedure.
+
+If any of these are missing, stay in dry-run or simulation.
+
+## Handoff to sdk_tools
+
+Use [sdk_tools](../sdk_tools/README.md) for visualization, data inspection, mock controller scripts, third-party clone instructions, and conversion sanity checks.

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/README.md
@@ -59,6 +59,70 @@ The server returns unnormalized action chunks through `deployment/model_server/p
 
 This replaces the upstream `run_gr00t_server.py` role. The controller side should still see the same high-level action semantics expected by the selected G1 route.
 
+## StarVLA Inference Wrapper
+
+The sim / eval data flow is:
+
+```text
+camera + robot state
+  -> GR00T inference loop
+  -> PolicyClient shim
+  -> StarVLA websocket policy server
+  -> unnormalized 78D action chunk
+  -> SONIC / C++ deploy
+```
+
+The client wrapper lives here:
+
+```text
+examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/model2unitree_g1_interface.py
+```
+
+It converts the GR00T-style observation dict into the StarVLA request format:
+
+```python
+{
+    "examples": [{
+        "image": [ego_view_image],
+        "lang": task_prompt,
+        "state": flat_proprioception,
+    }],
+    "unnorm_key": "new_embodiment",
+}
+```
+
+and splits the returned action chunk into:
+
+```text
+action.motion_token      -> [T, 64]
+action.left_hand_joints  -> [T, 7]
+action.right_hand_joints -> [T, 7]
+```
+
+To let the existing GR00T `run_vla_inference.py` import this wrapper without editing its source, prepend both the StarVLA repo root and this deployment directory to `PYTHONPATH` before launching the GR00T sim stack:
+
+```bash
+export PYTHONPATH=/home/hoi-4090-01/yjh/starVLA:/home/hoi-4090-01/yjh/starVLA/examples/realRobots/UnitreeG1_WholeBody/step3_deployment:${PYTHONPATH}
+```
+
+The compatibility shim at `step3_deployment/gr00t/policy/server_client.py` then shadows the GR00T `PolicyClient` import and forwards calls to StarVLA.
+
+The deployment scripts now discover the normalization key from the policy server metadata when possible. For the current smoke-tested checkpoint, that key is `new_embodiment`.
+
+For a direct local smoke test:
+
+```bash
+cd /home/hoi-4090-01/yjh/starVLA
+PYTHONPATH=$PWD:$PWD/examples/realRobots/UnitreeG1_WholeBody/step3_deployment \
+  python examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/local_self_test.py \
+    --ckpt-path results/Checkpoints/starvla_qwenoft_g1_sonic_smoke/checkpoints/steps_1_pytorch_model.pt \
+    --server-host 127.0.0.1 \
+    --server-port 5694
+```
+
+The helper script `step3_deployment/run_starvla_eval.sh` wraps the same path setup for repeated checks.
+The matching server launcher is `step3_deployment/run_policy_server.sh`.
+
 ## G1 Adapter Responsibilities
 
 The G1-side adapter should do only bridge work:

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/__init__.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/__init__.py
@@ -1,0 +1,2 @@
+"""Deployment eval helpers for the Unitree G1 StarVLA example."""
+

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/model2unitree_g1_interface.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/eval_files/model2unitree_g1_interface.py
@@ -1,0 +1,190 @@
+"""StarVLA -> Unitree G1 inference adapter.
+
+This client mirrors the GR00T PolicyClient contract used by
+`gear_sonic/scripts/run_vla_inference.py`, but it talks to the StarVLA
+websocket policy server instead of Isaac-GR00T.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy
+
+
+_STATE_ORDER = [
+    "left_leg",
+    "right_leg",
+    "waist",
+    "left_arm",
+    "left_hand",
+    "right_arm",
+    "right_hand",
+    "left_wrist_pos",
+    "left_wrist_abs_quat",
+    "right_wrist_pos",
+    "right_wrist_abs_quat",
+    "root_orientation",
+    "projected_gravity",
+    "cpp_rotation_offset",
+    "init_base_quat",
+]
+
+
+def _as_array(x: Any) -> np.ndarray:
+    arr = np.asarray(x)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    return arr
+
+
+def _extract_prompt(observation: dict, fallback: str) -> str:
+    lang = observation.get("language")
+    if isinstance(lang, dict):
+        for value in lang.values():
+            if value is None:
+                continue
+            if isinstance(value, list) and value and isinstance(value[0], list):
+                return str(value[0][0])
+            if isinstance(value, list) and value:
+                return str(value[0])
+            return str(value)
+    if "lang" in observation and observation["lang"] is not None:
+        return str(observation["lang"])
+    return fallback
+
+
+def _extract_image(observation: dict) -> np.ndarray:
+    if "image" in observation:
+        return np.asarray(observation["image"])
+    video = observation.get("video", {})
+    if isinstance(video, dict):
+        if "ego_view" in video:
+            return np.asarray(video["ego_view"])[0, 0]
+    raise KeyError("observation does not contain an image or video.ego_view")
+
+
+def _extract_state(observation: dict) -> Optional[np.ndarray]:
+    if "state" not in observation:
+        return None
+
+    state = observation["state"]
+    if isinstance(state, np.ndarray):
+        return state.reshape(-1).astype(np.float32)
+
+    if isinstance(state, dict):
+        pieces = []
+        for key in _STATE_ORDER:
+            if key not in state:
+                continue
+            pieces.append(_as_array(state[key]).reshape(-1))
+        if pieces:
+            return np.concatenate(pieces, axis=0).astype(np.float32)
+
+    if "q" in observation:
+        return np.asarray(observation["q"]).reshape(-1).astype(np.float32)
+
+    return None
+
+
+@dataclass
+class PolicyOutput:
+    motion_token: np.ndarray
+    left_hand_joints: np.ndarray
+    right_hand_joints: np.ndarray
+
+    def as_action_dict(self) -> dict[str, np.ndarray]:
+        return {
+            "action.motion_token": self.motion_token,
+            "action.left_hand_joints": self.left_hand_joints,
+            "action.right_hand_joints": self.right_hand_joints,
+        }
+
+
+class ModelClient:
+    """Drop-in replacement for the GR00T PolicyClient used in inference."""
+
+    def __init__(
+        self,
+        policy_ckpt_path: str,
+        unnorm_key: Optional[str] = None,
+        policy_setup: str = "unitree_g1_sonic",
+        image_size: list[int] | None = None,
+        host: str = "127.0.0.1",
+        port: int = 10093,
+    ) -> None:
+        self.policy_ckpt_path = policy_ckpt_path
+        self.policy_setup = policy_setup
+        self.image_size = image_size or [224, 224]
+        self.client = WebsocketClientPolicy(host=host, port=port)
+        self.server_meta = self.client.get_server_metadata()
+        self.unnorm_key = (
+            unnorm_key
+            or self.server_meta.get("default_unnorm_key")
+            or "new_embodiment"
+        )
+
+    def ping(self) -> bool:
+        return self.server_meta is not None
+
+    def get_server_metadata(self) -> Dict[str, Any]:
+        return self.server_meta
+
+    def close(self) -> None:
+        self.client.close()
+
+    def _build_starvla_example(self, observation: dict, fallback_prompt: str = "demo") -> dict:
+        image = _extract_image(observation)
+        prompt = _extract_prompt(observation, fallback_prompt)
+        state = _extract_state(observation)
+
+        example = {
+            "image": [image],
+            "lang": prompt,
+        }
+        if state is not None:
+            example["state"] = state[np.newaxis, :]
+        return example
+
+    def _split_action(self, actions: np.ndarray) -> PolicyOutput:
+        chunk = np.asarray(actions)
+        if chunk.ndim == 3:
+            chunk = chunk[0]
+        if chunk.ndim != 2:
+            raise ValueError(f"Expected actions with shape [T, D] or [1, T, D], got {chunk.shape}")
+
+        if chunk.shape[-1] < 78:
+            raise ValueError(f"Expected at least 78 action dims, got {chunk.shape[-1]}")
+
+        return PolicyOutput(
+            motion_token=chunk[:, :64].astype(np.float32),
+            left_hand_joints=chunk[:, 64:71].astype(np.float32),
+            right_hand_joints=chunk[:, 71:78].astype(np.float32),
+        )
+
+    def get_action(self, observation: dict):
+        """Mirror the Isaac-GR00T PolicyClient API.
+
+        Returns:
+            (action_dict, info_dict)
+        """
+        example = self._build_starvla_example(observation)
+        response = self.client.predict_action(
+            {
+                "examples": [example],
+                "unnorm_key": self.unnorm_key,
+            }
+        )
+        if response.get("status") != "ok":
+            raise RuntimeError(f"StarVLA policy server error: {response}")
+
+        actions = np.asarray(response["data"]["actions"])
+        split = self._split_action(actions)
+        return split.as_action_dict(), {"actions": actions, "server_meta": self.server_meta}
+
+
+# Backward-compatible alias for GR00T import sites.
+PolicyClient = ModelClient

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/__init__.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/__init__.py
@@ -1,0 +1,2 @@
+"""Local GR00T compatibility shim for Unitree G1 StarVLA deployment."""
+

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/policy/__init__.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/policy/__init__.py
@@ -1,0 +1,2 @@
+"""GR00T policy compatibility shim for StarVLA deployment."""
+

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/policy/server_client.py
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/gr00t/policy/server_client.py
@@ -1,0 +1,3 @@
+"""Compatibility shim that forwards GR00T PolicyClient imports to StarVLA."""
+
+from eval_files.model2unitree_g1_interface import ModelClient, PolicyClient

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_policy_server.sh
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_policy_server.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <ckpt_path> [port]" >&2
+  exit 1
+fi
+
+CKPT_PATH="$1"
+PORT="${2:-5694}"
+
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR:${PYTHONPATH:-}"
+
+python deployment/model_server/server_policy.py \
+  --ckpt_path "$CKPT_PATH" \
+  --port "$PORT" \
+  --use_bf16
+

--- a/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_starvla_eval.sh
+++ b/examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_starvla_eval.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+DEPLOY_DIR="$ROOT_DIR/examples/realRobots/UnitreeG1_WholeBody/step3_deployment"
+
+export PYTHONPATH="$ROOT_DIR:$DEPLOY_DIR:${PYTHONPATH:-}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <ckpt_path> [server_port]" >&2
+  exit 1
+fi
+
+CKPT_PATH="$1"
+SERVER_PORT="${2:-5694}"
+
+python "$DEPLOY_DIR/eval_files/local_self_test.py" \
+  --ckpt-path "$CKPT_PATH" \
+  --server-host 127.0.0.1 \
+  --server-port "$SERVER_PORT"
+

--- a/starVLA/dataloader/gr00t_lerobot/registry.py
+++ b/starVLA/dataloader/gr00t_lerobot/registry.py
@@ -98,7 +98,7 @@ def _find_registry_dirs() -> list[Path]:
     return sorted(
         p
         for p in examples_dir.glob("**/train_files/data_registry")
-        if p.is_dir()
+        if p.is_dir() and "sdk_tools" not in p.relative_to(examples_dir).parts
     )
 
 

--- a/starVLA/dataloader/gr00t_lerobot/registry.py
+++ b/starVLA/dataloader/gr00t_lerobot/registry.py
@@ -87,7 +87,7 @@ _DISCOVERED = False
 
 
 def _find_registry_dirs() -> list[Path]:
-    """Return all ``examples/*/train_files/data_registry/`` directories."""
+    """Return all ``examples/**/train_files/data_registry/`` directories."""
     # Walk up from this file to the repo root
     # registry.py is at starVLA/dataloader/gr00t_lerobot/registry.py
     #   parents: [0]=gr00t_lerobot, [1]=dataloader, [2]=starVLA(pkg), [3]=repo root
@@ -95,12 +95,11 @@ def _find_registry_dirs() -> list[Path]:
     examples_dir = repo_root / "examples"
     if not examples_dir.is_dir():
         return []
-    dirs: list[Path] = []
-    for bench_dir in sorted(examples_dir.iterdir()):
-        registry_dir = bench_dir / "train_files" / _REGISTRY_DIR_NAME
-        if registry_dir.is_dir():
-            dirs.append(registry_dir)
-    return dirs
+    return sorted(
+        p
+        for p in examples_dir.glob("**/train_files/data_registry")
+        if p.is_dir()
+    )
 
 
 def _load_module_from_path(module_name: str, file_path: Path):
@@ -122,7 +121,7 @@ def discover_and_merge() -> None:
     _DISCOVERED = True
 
     for registry_dir in _find_registry_dirs():
-        bench_name = registry_dir.parents[1].name  # examples/<BenchName>/train_files/data_registry
+        bench_name = registry_dir.parents[1].name  # examples/**/<BenchName>/train_files/data_registry
         prefix = f"_data_registry_{bench_name}"
 
         # --- data_config.py (may contain all three registries) ---


### PR DESCRIPTION
## Summary
- Add Unitree G1 real-robot workflow updates and SONIC/QwenOFT training files.
- Add StarVLA websocket deployment adapter and helper launch scripts for G1 SONIC actions.
- Document SonicStar/SONIC WBC setup guidance while keeping local SDK mirrors ignored.
- Skip sdk_tools registries during gr00t_lerobot example registry discovery.

## Checks
- python -m compileall -q starVLA/dataloader/gr00t_lerobot/registry.py examples/simBenchmarks/LIBERO/train_files/data_registry/data_config.py examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/data_registry/data_config.py
- bash -n examples/realRobots/UnitreeG1_WholeBody/step2_training/train_files/run_starvla_qwenoft_g1_sonic_train.sh examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_policy_server.sh examples/realRobots/UnitreeG1_WholeBody/step3_deployment/run_starvla_eval.sh
- Registry discovery smoke check confirmed LIBERO and Unitree G1 configs are registered, while ignored SonicStar sdk_tools references are skipped.