### PR TITLE
fix(libero): support legacy forward for released Qwen3-PI eval

### DIFF
--- a/deployment/model_server/policy_wrapper.py
+++ b/deployment/model_server/policy_wrapper.py
@@ -22,12 +22,12 @@ Exposed API:
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
 import torch
 
-from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.framework.base_framework import baseframework, merge_config_overrides
 from starVLA.model.framework.share_tools import read_mode_config
 
 from deployment.model_server.policy_norm_processor import PolicyNormProcessor
@@ -59,23 +59,25 @@ class PolicyServerWrapper:
         device: str = "cuda",
         use_bf16: bool = False,
         unnorm_key: Optional[str] = None,
+        config_overrides: Sequence[str] | None = None,
     ) -> None:
         self._ckpt_path = str(ckpt_path)
 
         logging.info("PolicyServerWrapper: loading framework from %s", self._ckpt_path)
-        framework = baseframework.from_pretrained(self._ckpt_path)
+        framework = baseframework.from_pretrained(self._ckpt_path, config_overrides=config_overrides)
         if use_bf16:
             framework = framework.to(torch.bfloat16)
         framework = framework.to(device).eval()
         self._framework = framework
 
         # Co-located metadata.
-        model_cfg, _ = read_mode_config(self._ckpt_path)
+        model_cfg, norm_stats = read_mode_config(self._ckpt_path)
+        model_cfg = merge_config_overrides(model_cfg, config_overrides)
         self._model_cfg = model_cfg
 
         # action_chunk_size = future_action_window_size + 1 (matches old client).
         action_model_cfg = model_cfg["framework"]["action_model"]
-        
+
         if "action_horizon" in action_model_cfg:
             self._action_chunk_size = int(action_model_cfg["action_horizon"])
         elif "future_action_window_size" in action_model_cfg:
@@ -91,8 +93,7 @@ class PolicyServerWrapper:
         self._norm_processors: Dict[str, PolicyNormProcessor] = {}
 
         # Peek at available keys without building a full processor.
-        _, _ns = read_mode_config(self._ckpt_path)
-        self._available_unnorm_keys: List[str] = list(_ns.keys())
+        self._available_unnorm_keys: List[str] = list(norm_stats.keys())
 
         # Eagerly build when unambiguous; defer for multi-key / no explicit key.
         if unnorm_key is not None or len(self._available_unnorm_keys) == 1:

--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -18,10 +18,15 @@ def main(args) -> None:
     eval clients (LIBERO / SimplerEnv / etc.) just need to forward `examples`
     and consume already-unnormalized actions from the response.
     """
+    config_overrides = getattr(args, "config_override", [])
+    if config_overrides:
+        override_keys = [item.split("=", 1)[0] for item in config_overrides]
+        logging.info("Applying config override keys: %s", override_keys)
     wrapper = PolicyServerWrapper(
         ckpt_path=args.ckpt_path,
         device="cuda",
         use_bf16=args.use_bf16,
+        config_overrides=config_overrides,
     )
 
     hostname = socket.gethostname()
@@ -69,6 +74,13 @@ def build_argparser():
     parser.add_argument("--port", type=int, default=10093)
     parser.add_argument("--use_bf16", action="store_true")
     parser.add_argument("--idle_timeout", type=int, default=1800, help="Idle timeout in seconds, -1 means never close")
+    parser.add_argument(
+        "--config_override",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Repeatable OmegaConf dotlist override applied before model construction.",
+    )
     return parser
 
 

--- a/examples/simBenchmarks/LIBERO/README.md
+++ b/examples/simBenchmarks/LIBERO/README.md
@@ -74,6 +74,23 @@ bash examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh
 
 ⚠️ **Note:** Please ensure that you specify the correct checkpoint path in `examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh`  
 
+### Released Qwen3-PI LIBERO checkpoint compatibility
+
+PR #373 introduced the canonical LayerwiseFM path used by current and newly
+trained models. The released `StarVLA/Qwen3-VL-PI-LIBERO-4in1` checkpoint was
+trained with historical LayerwiseFM semantics, so evaluate that checkpoint with
+the compatibility override below:
+
+```bash
+CKPT=/path/to/StarVLA/Qwen3-VL-PI-LIBERO-4in1/checkpoints/steps_100000_pytorch_model.pt \
+USE_CANONICAL_FORWARD=false \
+bash examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh
+```
+
+When `USE_CANONICAL_FORWARD` is unset, the server keeps the canonical default.
+Do not edit the checkpoint `config.yaml`; use the launcher override instead.
+The released checkpoint config uses 4 inference steps.
+
 
 ---
 

--- a/examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh
+++ b/examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh
@@ -21,4 +21,14 @@ if [[ "${USE_BF16}" == "1" ]]; then
   CMD+=(--use_bf16)
 fi
 
+if [[ -n "${USE_CANONICAL_FORWARD:-}" ]]; then
+  if [[ "${USE_CANONICAL_FORWARD}" != "true" && "${USE_CANONICAL_FORWARD}" != "false" ]]; then
+    echo "USE_CANONICAL_FORWARD must be 'true' or 'false' when set; got '${USE_CANONICAL_FORWARD}'." >&2
+    exit 2
+  fi
+  OVERRIDE="framework.action_model.diffusion_model_cfg.use_canonical_forward=${USE_CANONICAL_FORWARD}"
+  echo "Applying config override: ${OVERRIDE}"
+  CMD+=(--config_override "${OVERRIDE}")
+fi
+
 CUDA_VISIBLE_DEVICES="${GPU_ID}" "${CMD[@]}"

--- a/starVLA/model/framework/base_framework.py
+++ b/starVLA/model/framework/base_framework.py
@@ -9,7 +9,8 @@ Note: No device placement or optimizer concerns handled here (delegated to train
 import importlib
 import pkgutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
+from omegaconf import OmegaConf
 
 import numpy as np
 import torch
@@ -21,6 +22,39 @@ from starVLA.training.trainer_utils import initialize_overwatch
 
 logger = initialize_overwatch(__name__)
 _FRAMEWORKS_IMPORTED = False
+
+
+def merge_config_overrides(model_config: dict, config_overrides: Sequence[str] | None = None) -> dict:
+    """Merge optional OmegaConf dotlist overrides into a checkpoint config.
+
+    The checkpoint config has lower precedence than the dotlist. Values are not
+    resolved, so unrelated interpolations remain untouched.
+    """
+    if isinstance(config_overrides, str):
+        raise TypeError("config_overrides must be a sequence of KEY=VALUE strings, not a bare string.")
+    if not config_overrides:
+        return model_config
+
+    overrides = list(config_overrides)
+    non_string_overrides = [item for item in overrides if not isinstance(item, str)]
+    if non_string_overrides:
+        raise TypeError(
+            "config_overrides must be a sequence of KEY=VALUE strings; "
+            f"got non-string entries: {non_string_overrides}"
+        )
+
+    bad_overrides = [item for item in overrides if "=" not in item]
+    if bad_overrides:
+        raise ValueError("Invalid config_overrides entries. Expected KEY=VALUE dotlist items, " f"got: {bad_overrides}")
+
+    try:
+        override_cfg = OmegaConf.from_dotlist(overrides)
+        return OmegaConf.to_container(
+            OmegaConf.merge(OmegaConf.create(model_config), override_cfg),
+            resolve=False,
+        )
+    except Exception as exc:
+        raise ValueError(f"Failed to parse config_overrides={overrides!r}: {exc}") from exc
 
 
 def _auto_import_framework_modules() -> None:
@@ -85,11 +119,13 @@ class baseframework(PreTrainedModel):
       - Use provided helpers for action normalization handling
     """
 
-    def __init__(self, hf_config=PretrainedConfig()) -> None:
+    def __init__(self, hf_config: PretrainedConfig | None = None) -> None:
         """
         Initialize base nn.Module. Subclasses add components.
         """
 
+        if hf_config is None:
+            hf_config = PretrainedConfig()
         super().__init__(hf_config)
 
     # ------------------------------------------------------------------
@@ -142,7 +178,7 @@ class baseframework(PreTrainedModel):
             return hasattr(self, "qwen_vl_interface") or type(self).forward_vlm is not baseframework.forward_vlm
         return False
 
-    def compute_loss(self, tag: str, batch, loss_scale: dict = None) -> Dict[str, torch.Tensor] | None:
+    def compute_loss(self, tag: str, batch, loss_scale: dict | None = None) -> Dict[str, torch.Tensor] | None:
         """Unified forward entry-point: route to the right forward by *tag*.
 
         The trainer calls ``model.compute_loss(tag, batch)`` for every
@@ -206,6 +242,7 @@ class baseframework(PreTrainedModel):
     def from_pretrained(
         cls,
         pretrained_checkpoint: str,
+        config_overrides: Sequence[str] | None = None,
         **kwargs,
     ) -> None:
         """
@@ -220,6 +257,8 @@ class baseframework(PreTrainedModel):
 
         Args:
             pretrained_checkpoint: Path to .pt file inside run/checkpoints directory.
+            config_overrides: Optional OmegaConf dotlist overrides applied after the
+                checkpoint config and before model construction.
             **kwargs: Extra constructor overrides passed to subclass.
 
         Returns:
@@ -231,11 +270,12 @@ class baseframework(PreTrainedModel):
         """
         pretrained_checkpoint = Path(pretrained_checkpoint)
         model_config, norm_stats = read_mode_config(pretrained_checkpoint)  # read config and norm_stats
+        model_config = merge_config_overrides(model_config, config_overrides)
 
         config = dict_to_namespace(model_config)
         model_config = config
         model_config.trainer.pretrained_checkpoint = None
-        
+
         FrameworkModel = build_framework(cfg=model_config)
         # set for action un-norm
         FrameworkModel.norm_stats = norm_stats
@@ -266,4 +306,3 @@ class baseframework(PreTrainedModel):
         # **ensure model is on GPU**
         FrameworkModel = FrameworkModel
         return FrameworkModel
-

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -1,0 +1,418 @@
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import torch
+from omegaconf import OmegaConf
+
+from deployment.model_server import policy_wrapper, server_policy
+from starVLA.model.framework import base_framework
+
+
+def _checkpoint_config(use_canonical_forward=True):
+    return {
+        "framework": {
+            "name": "DummyFramework",
+            "action_model": {
+                "action_horizon": 8,
+                "diffusion_model_cfg": {
+                    "use_canonical_forward": use_canonical_forward,
+                    "num_inference_timesteps": 4,
+                },
+            },
+        },
+        "trainer": {"pretrained_checkpoint": "original.pt"},
+        "datasets": {"vla_data": {"data_mix": "dummy_mix"}},
+    }
+
+
+class _FakeFramework:
+    def state_dict(self):
+        return {}
+
+    def load_state_dict(self, state_dict, strict=True):
+        self.loaded_state_dict = state_dict
+        self.loaded_strict = strict
+
+
+class _FakeServerModel:
+    def to(self, *args, **kwargs):
+        return self
+
+    def eval(self):
+        return self
+
+
+class ConfigOverrideLoadTest(unittest.TestCase):
+    def _load_with_config(self, config, overrides=None):
+        captured = {}
+
+        def fake_build_framework(cfg):
+            captured["cfg"] = cfg
+            return _FakeFramework()
+
+        with (
+            mock.patch.object(base_framework, "read_mode_config", return_value=(config, {"stats": {}})),
+            mock.patch.object(base_framework, "build_framework", side_effect=fake_build_framework),
+            mock.patch.object(torch, "load", return_value={}),
+        ):
+            model = base_framework.baseframework.from_pretrained(
+                "/tmp/run/checkpoints/steps_1_pytorch_model.pt",
+                config_overrides=overrides,
+            )
+        return model, captured["cfg"]
+
+    def test_from_pretrained_without_overrides_preserves_checkpoint_config(self):
+        _, cfg = self._load_with_config(_checkpoint_config(use_canonical_forward=True))
+
+        self.assertIs(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward"),
+            True,
+        )
+
+    def test_false_override_resolves_to_bool_false_before_build_framework(self):
+        _, cfg = self._load_with_config(
+            _checkpoint_config(use_canonical_forward=True),
+            ["framework.action_model.diffusion_model_cfg.use_canonical_forward=false"],
+        )
+
+        resolved = OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward")
+        self.assertIs(resolved, False)
+
+    def test_override_has_precedence_over_checkpoint_yaml(self):
+        _, cfg = self._load_with_config(
+            _checkpoint_config(use_canonical_forward=True),
+            ["framework.action_model.diffusion_model_cfg.num_inference_timesteps=6"],
+        )
+
+        self.assertEqual(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.num_inference_timesteps"),
+            6,
+        )
+
+    def test_repeatable_overrides_are_accepted(self):
+        _, cfg = self._load_with_config(
+            _checkpoint_config(use_canonical_forward=True),
+            (
+                "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+                "framework.action_model.diffusion_model_cfg.num_inference_timesteps=6",
+            ),
+        )
+
+        self.assertIs(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward"),
+            False,
+        )
+        self.assertEqual(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.num_inference_timesteps"),
+            6,
+        )
+
+    def test_duplicate_override_later_value_wins(self):
+        _, cfg = self._load_with_config(
+            _checkpoint_config(use_canonical_forward=True),
+            [
+                "framework.action_model.diffusion_model_cfg.use_canonical_forward=true",
+                "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+            ],
+        )
+
+        self.assertIs(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward"),
+            False,
+        )
+
+    def test_invalid_override_syntax_has_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "Expected KEY=VALUE"):
+            self._load_with_config(_checkpoint_config(), ["framework.action_model.bad_override"])
+
+    def test_bare_string_config_overrides_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "sequence of KEY=VALUE strings"):
+            self._load_with_config(
+                _checkpoint_config(),
+                "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+            )
+
+    def test_empty_string_config_overrides_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "sequence of KEY=VALUE strings"):
+            self._load_with_config(_checkpoint_config(), "")
+
+    def test_empty_list_config_overrides_is_valid_noop(self):
+        _, cfg = self._load_with_config(_checkpoint_config(use_canonical_forward=True), [])
+
+        self.assertIs(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward"),
+            True,
+        )
+
+    def test_empty_tuple_config_overrides_is_valid_noop(self):
+        _, cfg = self._load_with_config(_checkpoint_config(use_canonical_forward=True), ())
+
+        self.assertIs(
+            OmegaConf.select(cfg, "framework.action_model.diffusion_model_cfg.use_canonical_forward"),
+            True,
+        )
+
+    def test_unrelated_interpolation_is_not_resolved_when_override_applies(self):
+        config = _checkpoint_config()
+        config["run_root_dir"] = "/tmp/root"
+        config["run_id"] = "run_a"
+        config["output_dir"] = "${run_root_dir}/${run_id}"
+
+        merged = base_framework.merge_config_overrides(
+            config,
+            ["framework.action_model.diffusion_model_cfg.use_canonical_forward=false"],
+        )
+
+        self.assertEqual(merged["output_dir"], "${run_root_dir}/${run_id}")
+
+    def test_checkpoint_config_file_is_not_modified(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            ckpt_dir = run_dir / "checkpoints"
+            ckpt_dir.mkdir(parents=True)
+            ckpt_path = ckpt_dir / "steps_1_pytorch_model.pt"
+            ckpt_path.write_bytes(b"placeholder")
+            config_path = run_dir / "config.yaml"
+            config_text = textwrap.dedent("""
+                framework:
+                  name: DummyFramework
+                  action_model:
+                    action_horizon: 8
+                    diffusion_model_cfg:
+                      use_canonical_forward: true
+                trainer:
+                  pretrained_checkpoint: original.pt
+                datasets:
+                  vla_data:
+                    data_mix: dummy_mix
+                """).lstrip()
+            config_path.write_text(config_text)
+            (run_dir / "dataset_statistics.json").write_text("{}")
+
+            with (
+                mock.patch.object(base_framework, "build_framework", return_value=_FakeFramework()),
+                mock.patch.object(torch, "load", return_value={}),
+            ):
+                base_framework.baseframework.from_pretrained(
+                    str(ckpt_path),
+                    config_overrides=["framework.action_model.diffusion_model_cfg.use_canonical_forward=false"],
+                )
+
+            self.assertEqual(config_path.read_text(), config_text)
+
+
+class PolicyServerOverrideTest(unittest.TestCase):
+    def test_policy_server_wrapper_passes_config_overrides_to_from_pretrained(self):
+        overrides = ["framework.action_model.diffusion_model_cfg.use_canonical_forward=false"]
+        model_cfg = _checkpoint_config()
+        norm_stats = {"key_a": {}, "key_b": {}}
+
+        with (
+            mock.patch.object(policy_wrapper.baseframework, "from_pretrained", return_value=_FakeServerModel()) as load,
+            mock.patch.object(policy_wrapper, "read_mode_config", return_value=(model_cfg, norm_stats)),
+        ):
+            policy_wrapper.PolicyServerWrapper(
+                ckpt_path="/tmp/model.pt",
+                device="cpu",
+                config_overrides=overrides,
+            )
+
+        load.assert_called_once_with("/tmp/model.pt", config_overrides=overrides)
+
+    def test_policy_server_wrapper_metadata_uses_resolved_config(self):
+        overrides = [
+            "framework.action_model.action_horizon=12",
+            "datasets.vla_data.data_mix=override_mix",
+            "datasets.vla_data.obs_image_size=[128,128]",
+        ]
+        model_cfg = _checkpoint_config()
+        norm_stats = {"key_a": {}, "key_b": {}}
+
+        with (
+            mock.patch.object(policy_wrapper.baseframework, "from_pretrained", return_value=_FakeServerModel()),
+            mock.patch.object(policy_wrapper, "read_mode_config", return_value=(model_cfg, norm_stats)),
+        ):
+            wrapper = policy_wrapper.PolicyServerWrapper(
+                ckpt_path="/tmp/model.pt",
+                device="cpu",
+                config_overrides=overrides,
+            )
+
+        self.assertEqual(wrapper.metadata["action_chunk_size"], 12)
+        self.assertEqual(wrapper.metadata["training_data_mix"], "override_mix")
+        self.assertEqual(wrapper.metadata["training_obs_image_size"], [128, 128])
+        self.assertEqual(wrapper._model_cfg["framework"]["action_model"]["action_horizon"], 12)
+
+    def test_policy_server_wrapper_rejects_bare_string_config_overrides(self):
+        model_cfg = _checkpoint_config()
+        norm_stats = {"key_a": {}, "key_b": {}}
+
+        with (
+            mock.patch.object(policy_wrapper.baseframework, "from_pretrained", return_value=_FakeServerModel()),
+            mock.patch.object(policy_wrapper, "read_mode_config", return_value=(model_cfg, norm_stats)),
+            self.assertRaisesRegex(TypeError, "sequence of KEY=VALUE strings"),
+        ):
+            policy_wrapper.PolicyServerWrapper(
+                ckpt_path="/tmp/model.pt",
+                device="cpu",
+                config_overrides="framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+            )
+
+    def test_server_cli_parses_repeated_config_override_values(self):
+        parser = server_policy.build_argparser()
+        args = parser.parse_args(
+            [
+                "--ckpt_path",
+                "/tmp/model.pt",
+                "--config_override",
+                "a.b=false",
+                "--config_override",
+                "x.y=7",
+            ]
+        )
+
+        self.assertEqual(args.config_override, ["a.b=false", "x.y=7"])
+
+    def test_server_main_logs_override_keys_not_values(self):
+        overrides = [
+            "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+            "secret.token=do-not-log",
+        ]
+        args = mock.Mock(
+            ckpt_path="/tmp/model.pt",
+            use_bf16=False,
+            port=12345,
+            idle_timeout=-1,
+            config_override=overrides,
+        )
+        fake_wrapper = mock.Mock()
+        fake_wrapper.metadata = {"env": "test"}
+        fake_server = mock.Mock()
+
+        with (
+            mock.patch.object(server_policy, "PolicyServerWrapper", return_value=fake_wrapper) as wrapper_cls,
+            mock.patch.object(server_policy, "WebsocketPolicyServer", return_value=fake_server),
+            mock.patch.object(server_policy.logging, "info") as log_info,
+            mock.patch.object(server_policy.logging, "warning"),
+        ):
+            server_policy.main(args)
+
+        wrapper_cls.assert_called_once_with(
+            ckpt_path="/tmp/model.pt",
+            device="cuda",
+            use_bf16=False,
+            config_overrides=overrides,
+        )
+        fake_server.serve_forever.assert_called_once_with()
+
+        info_messages = [call.args for call in log_info.call_args_list]
+        override_log = next(args for args in info_messages if args[0] == "Applying config override keys: %s")
+        self.assertEqual(
+            override_log[1],
+            [
+                "framework.action_model.diffusion_model_cfg.use_canonical_forward",
+                "secret.token",
+            ],
+        )
+        rendered_logs = "\n".join(str(args) for args in info_messages)
+        self.assertNotIn("false", rendered_logs)
+        self.assertNotIn("do-not-log", rendered_logs)
+
+
+class LiberoLauncherOverrideTest(unittest.TestCase):
+    def _run_launcher(self, use_canonical_forward=None):
+        script = Path("examples/simBenchmarks/LIBERO/eval_files/run_policy_server.sh").resolve()
+        with tempfile.TemporaryDirectory() as tmp:
+            recorder = Path(tmp) / "record_args.py"
+            output = Path(tmp) / "args.txt"
+            recorder.write_text(textwrap.dedent(f"""\
+                    #!/usr/bin/env python3
+                    import pathlib
+                    import sys
+                    pathlib.Path({str(output)!r}).write_text("\\n".join(sys.argv[1:]))
+                    """))
+            recorder.chmod(recorder.stat().st_mode | stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "STARVLA_DIR": str(Path.cwd()),
+                    "STARVLA_PYTHON": str(recorder),
+                    "CKPT": "/tmp/model.pt",
+                    "GPU_ID": "0",
+                    "PORT": "6694",
+                    "USE_BF16": "",
+                }
+            )
+            if use_canonical_forward is None:
+                env.pop("USE_CANONICAL_FORWARD", None)
+            else:
+                env["USE_CANONICAL_FORWARD"] = use_canonical_forward
+
+            result = subprocess.run(
+                ["bash", str(script)],
+                cwd=Path.cwd(),
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            recorded_args = output.read_text().splitlines() if output.exists() else None
+            return result, recorded_args
+
+    def test_use_canonical_forward_false_passes_exact_override(self):
+        result, args = self._run_launcher(use_canonical_forward="false")
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "Applying config override: " "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+            result.stdout,
+        )
+        self.assertIn("--config_override", args)
+        idx = args.index("--config_override")
+        self.assertEqual(
+            args[idx + 1],
+            "framework.action_model.diffusion_model_cfg.use_canonical_forward=false",
+        )
+
+    def test_use_canonical_forward_true_passes_exact_override(self):
+        result, args = self._run_launcher(use_canonical_forward="true")
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "Applying config override: " "framework.action_model.diffusion_model_cfg.use_canonical_forward=true",
+            result.stdout,
+        )
+        self.assertIn("--config_override", args)
+        idx = args.index("--config_override")
+        self.assertEqual(
+            args[idx + 1],
+            "framework.action_model.diffusion_model_cfg.use_canonical_forward=true",
+        )
+
+    def test_empty_or_unset_use_canonical_forward_preserves_old_command(self):
+        unset_result, unset_args = self._run_launcher(use_canonical_forward=None)
+        empty_result, empty_args = self._run_launcher(use_canonical_forward="")
+
+        self.assertEqual(unset_result.returncode, 0, msg=unset_result.stdout + unset_result.stderr)
+        self.assertEqual(empty_result.returncode, 0, msg=empty_result.stdout + empty_result.stderr)
+        self.assertNotIn("--config_override", unset_args)
+        self.assertNotIn("--config_override", empty_args)
+        self.assertEqual(unset_args, empty_args)
+
+    def test_invalid_use_canonical_forward_fails_before_server_command(self):
+        result, args = self._run_launcher(use_canonical_forward="flase")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(args)
+        self.assertIn("USE_CANONICAL_FORWARD must be 'true' or 'false'", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds an explicit evaluation-time compatibility override for the released Qwen3-PI LIBERO checkpoint:

```text
framework.action_model.diffusion_model_cfg.use_canonical_forward=false
```

The released `StarVLA/Qwen3-VL-PI-LIBERO-4in1` checkpoint was trained with the historical LayerwiseFM forward semantics. Current upstream code defaults to the canonical DiT forward path, so this checkpoint needs an explicit opt-in compatibility setting when evaluated with current code.

The canonical forward path remains the default. The compatibility path is opt-in, no checkpoint file is modified, and this PR does not change the model computation implementation.

Closes #402

## Motivation

The released Qwen3-PI LIBERO checkpoint underperforms when evaluated through the current canonical path. The intended fix is to make the existing compatibility flag usable and reproducible from normal server/evaluation launch paths, while preserving canonical behavior for current and newly trained models.

## Changes

- Added a shared `merge_config_overrides` helper for repeatable OmegaConf dotlist overrides.
- Added repeatable `--config_override KEY=VALUE` support to the policy server CLI.
- Ensured model construction and server metadata use the same resolved config.
- Added strict `true`/`false` validation for `USE_CANONICAL_FORWARD` in the LIBERO policy-server launcher.
- Avoided eager resolution of unrelated OmegaConf interpolation while merging overrides.
- Added Python API validation for config override behavior.
- Documented released-checkpoint LIBERO evaluation with the opt-in compatibility override.
- Added focused unit tests for legacy/canonical override plumbing and CLI logging behavior.

## Explicit Non-Changes

This PR does not modify:

- LayerwiseFM forward implementation.
- `cross_attention_dit.py`.
- QwenPI training.
- Default canonical behavior.
- Checkpoint weights or checkpoint config.
- Camera ordering or camera selection.
- CALVIN, SimplerEnv, GR00T, OFT or FAST behavior.

## Testing

- [x] Benchmark evaluation results.
- [x] No unrelated changes mixed in.
- [x] No secrets, API keys, or large binaries committed.

## Runtime Proof

Using the released checkpoint through the same policy-server loader path with the compatibility override:

- Model config value is bool `False`.
- Runtime DiT value is bool `False`.
- Strict checkpoint load succeeded; no missing/unexpected key failure occurred.
- Checkpoint config remained byte-for-byte unchanged.
- `action_chunk_size` is `8`.
- `framework.action_model.num_inference_timesteps` remains `4`.
- Clean-fork imports were used.

## Smoke Evaluation

One-trial smoke with `use_canonical_forward=false`:

| Suite | Result |
| --- | ---: |
| Spatial | 9/10 |
| Object | 10/10 |
| Goal | 10/10 |
| Long | 10/10 |
| **Overall** | **39/40** |

## Formal Evaluation

Protocol:

- Released jointly trained four-suite checkpoint.
- 10 tasks per suite.
- 50 trials per task.
- 4 inference timesteps.
- `use_canonical_forward=false`.

| Suite | Successes | Trials | Success rate |
| --- | ---: | ---: | ---: |
| LIBERO-Spatial | 459 | 500 | 91.8% |
| LIBERO-Object | 494 | 500 | 98.8% |
| LIBERO-Goal | 488 | 500 | 97.6% |
| LIBERO-Long | 475 | 500 | 95.0% |
| **Overall** | **1916** | **2000** | **95.8%** |

### Spatial task-specific failure concentration

The lower aggregate LIBERO-Spatial score is dominated by a single task:

- **Task:** `pick up the black bowl on the ramekin and place it on the plate`
- **Result:** **15/50 (30.0%)**
- **Failures contributed:** **35 of the 41 Spatial failures (85.4%)**
- **Remaining nine Spatial tasks:** **444/450 (98.7%)**

Therefore, the Spatial result does not reflect a suite-wide degradation. Performance remained near 99% across the other nine tasks, while failures were strongly concentrated in this one task-specific case.

The policy server remained healthy throughout evaluation: it was initialized once, the compatibility override remained active, no checkpoint-loading or runtime errors occurred, and performance returned to near-100% on subsequent
tasks.

## Checkpoint

- Checkpoint: `StarVLA/Qwen3-VL-PI-LIBERO-4in1`
- File path relative to checkpoint repository: `StarVLA-Qwen3-VL-PI-LIBERO-4in1/checkpoints/steps_100000_pytorch_model.pt`
- SHA256: `32dc240010524e7bb636bb3ec5d10474dfe55cf5494d5c30166f2e90805cf001`

## Reproduce

Server command shape:

```bash
cd <STARVLA_FORK>
PYTHONPATH="<STARVLA_FORK>:${PYTHONPATH:-}" \
CUDA_VISIBLE_DEVICES=<GPU_ID> \
<SERVER_PYTHON> deployment/model_server/server_policy.py \
  --ckpt_path "<CHECKPOINT_PATH>" \
  --port "<PORT>" \
  --use_bf16 \
  --config_override "framework.action_model.diffusion_model_cfg.use_canonical_forward=false" \
  --config_override "framework.qwenvl.base_vlm=<BASE_VLM_PATH>" \
  --config_override "framework.qwenvl.attn_implementation=sdpa"
```

Evaluator command shape:

```bash
cd <STARVLA_FORK>
PYTHONPATH="<LIBERO_ROOT>:<STARVLA_FORK>:${PYTHONPATH:-}" \
CUDA_VISIBLE_DEVICES=<GPU_ID> \
MUJOCO_GL=osmesa \
PYOPENGL_PLATFORM=osmesa \
TOKENIZERS_PARALLELISM=false \
LIBERO_HOME="<LIBERO_ROOT>" \
LIBERO_CONFIG_PATH="<LIBERO_ROOT>/.libero_config" \
<EVAL_PYTHON> ./examples/simBenchmarks/LIBERO/eval_files/eval_libero.py \
  --args.pretrained-path "<CHECKPOINT_PATH>" \
  --args.host 127.0.0.1 \
  --args.port "<PORT>" \
  --args.task-suite-name "<SUITE>" \
  --args.max-tasks 10 \
  --args.num-trials-per-task 50 \
  --args.video-out-path "<VIDEO_OUT_DIR>"
```

Formal suite mapping:

| Suite | GPU | Port |
| --- | ---: | ---: |
| `libero_spatial` | 0 | 18100 |
| `libero_object` | 1 | 18101 |
| `libero_goal` | 2 | 18102 |
| `libero_10` | 3 | 18103 |

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Breaking Changes

None. Without an explicit override, the default canonical forward path is unchanged.

This PR does not claim to change or improve newly trained checkpoints.