### PR TITLE
[feat] (dataloader): configure horizon and normalization

### DIFF
--- a/deployment/model_server/policy_norm_processor.py
+++ b/deployment/model_server/policy_norm_processor.py
@@ -38,6 +38,9 @@ from starVLA.dataloader.gr00t_lerobot.schema import (
     StateActionMetadata,
 )
 from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.config_overrides import (
+    apply_normalization_mode_overrides,
+)
 from starVLA.model.framework.share_tools import read_mode_config
 
 logger = logging.getLogger(__name__)
@@ -282,6 +285,14 @@ class PolicyNormProcessor:
         transform = self._data_config.transform()
         if not isinstance(transform, ComposedModalityTransform):
             transform = ComposedModalityTransform(transforms=[transform])
+        normalization_modes = (
+            cfg.get("datasets", {})
+            .get("vla_data", {})
+            .get("normalization_modes")
+        )
+        transform = apply_normalization_mode_overrides(
+            transform, normalization_modes
+        )
         self._transform = transform
 
         # 3) Pick the requested unnorm_key (finalize; error if still None here).

--- a/docs/starVLA_guideline.md
+++ b/docs/starVLA_guideline.md
@@ -184,10 +184,47 @@ datasets:
     dataset_py: lerobot_datasets
     data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_all          # all 4 suites; use "libero_goal" for single suite
+    action_horizon: ${framework.action_model.action_horizon}
+    normalization_modes: min_max  # replace the DataConfig's existing modes
     per_device_batch_size: 16
 ```
 
 The `data_mix` field selects which datasets to combine. These mixtures are defined in [`examples/simBenchmarks/LIBERO/train_files/data_registry/data_config.py`](../examples/simBenchmarks/LIBERO/train_files/data_registry/data_config.py):
+
+`action_horizon` is linked to the model value through OmegaConf interpolation.
+The dataloader samples actions with `range(action_horizon)` and raises an error
+at startup if an explicitly configured data horizon differs from the model
+horizon. Therefore a single override changes both sides safely:
+
+```bash
+--framework.action_model.action_horizon 16
+```
+
+`normalization_modes` accepts either one mode, which replaces all normalization
+modes already selected by the DataConfig, or a per-modality/per-key mapping:
+
+```yaml
+# Quick global switch while preserving which keys are normalized:
+normalization_modes: q99
+
+# Fine-grained form:
+normalization_modes:
+  action: q99
+  action.gripper: binary
+  state.joints: mean_std
+```
+
+Supported modes are `min_max`, `q99`, `mean_std`, and `binary`. Setting an
+individual key to `null` disables normalization for that key. The same resolved
+pipeline is reconstructed by the policy server for action un-normalization.
+For example, both settings can be switched in one training invocation:
+
+```bash
+python -m starVLA.training.train_starvla \
+  --config_yaml examples/simBenchmarks/LIBERO/train_files/starvla_cotrain_libero.yaml \
+  --framework.action_model.action_horizon 16 \
+  --datasets.vla_data.normalization_modes q99
+```
 
 ```python
 DATASET_NAMED_MIXTURES = {

--- a/examples/modelExtensions/CoTrainVLM/train_files/starvla_cotrain_libero.yaml
+++ b/examples/modelExtensions/CoTrainVLM/train_files/starvla_cotrain_libero.yaml
@@ -59,6 +59,8 @@ datasets:
     include_state: false
     data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_goal # libero_goal
+    action_horizon: ${framework.action_model.action_horizon}
+    normalization_modes: min_max
     action_type: delta_qpos
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
     per_device_batch_size: 16

--- a/examples/simBenchmarks/LIBERO/train_files/starvla_cotrain_libero.yaml
+++ b/examples/simBenchmarks/LIBERO/train_files/starvla_cotrain_libero.yaml
@@ -35,6 +35,10 @@ datasets:
     dataset_py: lerobot_datasets
     data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_all # libero_goal
+    # Keep data sampling and model prediction chunks tied to one CLI-overridable value.
+    action_horizon: ${framework.action_model.action_horizon}
+    # A scalar replaces the DataConfig's existing per-key normalization modes.
+    normalization_modes: min_max
     action_type: delta_qpos
     sequential_step_sampling: False
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."

--- a/starVLA/config/training/starvla_cotrain_libero.yaml
+++ b/starVLA/config/training/starvla_cotrain_libero.yaml
@@ -62,6 +62,8 @@ datasets:
     include_state: false
     data_root_dir: playground/Datasets/LEROBOT_LIBERO_DATA
     data_mix: libero_goal # libero_goal
+    action_horizon: ${framework.action_model.action_horizon}
+    normalization_modes: min_max
     action_type: delta_qpos
     CoT_prompt: "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
     per_device_batch_size: 16

--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -10,6 +10,16 @@ from starVLA.dataloader.vlm_datasets import make_vlm_dataloader
 
 logger = get_logger(__name__)
 
+
+def _get_model_action_horizon(cfg):
+    """Read action_horizon from both current and OpenPI-style schemas."""
+    from omegaconf import OmegaConf
+
+    nested = OmegaConf.select(cfg, "framework.action_model.action_horizon", default=None)
+    if nested is not None:
+        return nested
+    return OmegaConf.select(cfg, "framework.action_horizon", default=None)
+
 def save_dataset_statistics(dataset_statistics, run_dir):
     """Saves a `dataset_statistics.json` file."""
     out_path = run_dir / "dataset_statistics.json"
@@ -41,6 +51,7 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
 
         vla_dataset = get_vla_dataset(
             data_cfg=vla_dataset_cfg,
+            model_action_horizon=_get_model_action_horizon(cfg),
             balance_dataset_weights=vla_dataset_cfg.get("balance_dataset_weights", False),
             balance_trajectory_weights=vla_dataset_cfg.get("balance_trajectory_weights", False),
         )

--- a/starVLA/dataloader/gr00t_lerobot/config_overrides.py
+++ b/starVLA/dataloader/gr00t_lerobot/config_overrides.py
@@ -1,0 +1,266 @@
+"""Runtime overrides shared by training and deployment data pipelines.
+
+DataConfig classes remain the source of modality keys and default transforms,
+while the training YAML may override the action chunk length and normalization
+mode without mutating the globally registered DataConfig instances.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import (
+    Normalizer,
+    StateActionTransform,
+)
+
+
+def _to_plain_value(value: Any) -> Any:
+    if OmegaConf.is_config(value):
+        return OmegaConf.to_container(value, resolve=True)
+    return value
+
+
+def _positive_horizon(value: Any, *, source: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{source} must be a positive integer, got {value!r}")
+    try:
+        horizon = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{source} must be a positive integer, got {value!r}") from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError(f"{source} must be a positive integer, got {value!r}")
+    if isinstance(value, str) and value.strip() != str(horizon):
+        raise ValueError(f"{source} must be a positive integer, got {value!r}")
+    if horizon <= 0:
+        raise ValueError(f"{source} must be a positive integer, got {horizon}")
+    return horizon
+
+
+def resolve_action_horizon(
+    *,
+    model_action_horizon: Any = None,
+    data_action_horizon: Any = None,
+) -> int | None:
+    """Resolve and validate the model/data action horizon.
+
+    The model value is the canonical source used to construct
+    ``range(action_horizon)``.  ``datasets.vla_data.action_horizon`` is an
+    explicit consistency assertion when present.  A missing side falls back
+    to the value supplied by the other side for backward compatibility.
+    """
+
+    model_horizon = _positive_horizon(
+        model_action_horizon, source="model action_horizon"
+    )
+    data_horizon = _positive_horizon(
+        data_action_horizon, source="datasets.vla_data.action_horizon"
+    )
+
+    if (
+        model_horizon is not None
+        and data_horizon is not None
+        and model_horizon != data_horizon
+    ):
+        raise ValueError(
+            "Action horizon mismatch: "
+            f"model action_horizon={model_horizon}, but "
+            f"datasets.vla_data.action_horizon={data_horizon}. "
+            "Set datasets.vla_data.action_horizon to an interpolation of the "
+            "model action_horizon (or the matching literal)."
+        )
+
+    return model_horizon if model_horizon is not None else data_horizon
+
+
+def override_action_horizon(
+    modality_configs: dict[str, ModalityConfig],
+    action_horizon: int | None,
+) -> dict[str, ModalityConfig]:
+    """Return modality configs whose action indices are ``range(horizon)``."""
+
+    if action_horizon is None:
+        return modality_configs
+    if "action" not in modality_configs:
+        raise ValueError(
+            "Cannot apply action_horizon because the DataConfig has no action modality"
+        )
+
+    action_cfg = modality_configs["action"]
+    updated = dict(modality_configs)
+    updated["action"] = ModalityConfig(
+        delta_indices=list(range(action_horizon)),
+        modality_keys=list(action_cfg.modality_keys),
+    )
+    return updated
+
+
+def _validate_normalization_mode(mode: Any, *, key: str) -> str | None:
+    if mode is None:
+        return None
+    if not isinstance(mode, str) or mode not in Normalizer.valid_modes:
+        raise ValueError(
+            f"Invalid normalization mode for {key!r}: {mode!r}. "
+            f"Expected one of {Normalizer.valid_modes} or null."
+        )
+    return mode
+
+
+def _state_action_transforms(
+    transform: ComposedModalityTransform,
+) -> list[StateActionTransform]:
+    return [
+        item
+        for item in transform.transforms
+        if isinstance(item, StateActionTransform)
+    ]
+
+
+def _set_exact_normalization_mode(
+    transforms: list[StateActionTransform],
+    full_key: str,
+    mode: Any,
+) -> None:
+    normalized_mode = _validate_normalization_mode(mode, key=full_key)
+    matches = [transform for transform in transforms if full_key in transform.apply_to]
+    if not matches:
+        available = sorted(
+            {key for transform in transforms for key in transform.apply_to}
+        )
+        raise ValueError(
+            f"Cannot override normalization for {full_key!r}; it is not handled by "
+            f"a StateActionTransform. Available keys: {available}"
+        )
+    for transform in matches:
+        if normalized_mode is None:
+            transform.normalization_modes.pop(full_key, None)
+        else:
+            transform.normalization_modes[full_key] = normalized_mode
+
+
+def _replace_existing_modes(
+    transforms: list[StateActionTransform],
+    mode: Any,
+    *,
+    modality: str | None = None,
+) -> int:
+    label = modality if modality is not None else "normalization_modes"
+    normalized_mode = _validate_normalization_mode(mode, key=label)
+    changed = 0
+    prefix = f"{modality}." if modality is not None else None
+    for transform in transforms:
+        keys = list(transform.normalization_modes)
+        for key in keys:
+            if prefix is not None and not key.startswith(prefix):
+                continue
+            changed += 1
+            if normalized_mode is None:
+                transform.normalization_modes.pop(key, None)
+            else:
+                transform.normalization_modes[key] = normalized_mode
+    return changed
+
+
+def apply_normalization_mode_overrides(
+    transform: ComposedModalityTransform,
+    normalization_modes: Any,
+) -> ComposedModalityTransform:
+    """Apply YAML normalization overrides to a transform pipeline.
+
+    Supported forms under ``datasets.vla_data.normalization_modes``::
+
+        normalization_modes: q99
+
+    replaces every normalization mode already selected by the DataConfig.
+    A mapping can target a modality or individual keys::
+
+        normalization_modes:
+          action: q99
+          state.joints: mean_std
+          action.gripper: binary
+
+    ``null`` disables normalization for the selected existing modality/key.
+    Per-key entries may also be nested below ``action`` or ``state``.
+    """
+
+    normalization_modes = _to_plain_value(normalization_modes)
+    if normalization_modes is None:
+        return transform
+
+    transforms = _state_action_transforms(transform)
+    if not transforms:
+        raise ValueError(
+            "normalization_modes was configured, but the DataConfig transform "
+            "pipeline contains no StateActionTransform"
+        )
+
+    if isinstance(normalization_modes, str):
+        if _replace_existing_modes(transforms, normalization_modes) == 0:
+            raise ValueError(
+                "normalization_modes was configured, but the DataConfig has no "
+                "existing normalization entries to override"
+            )
+        return transform
+
+    if not isinstance(normalization_modes, Mapping):
+        raise ValueError(
+            "datasets.vla_data.normalization_modes must be a mode string, a "
+            "mapping, or null"
+        )
+
+    for key, value in normalization_modes.items():
+        key = str(key)
+        value = _to_plain_value(value)
+        if key in {"action", "state"}:
+            if isinstance(value, Mapping):
+                for subkey, submode in value.items():
+                    subkey = str(subkey)
+                    if subkey in {"*", "__all__"}:
+                        if _replace_existing_modes(
+                            transforms, submode, modality=key
+                        ) == 0:
+                            raise ValueError(
+                                f"No existing {key} normalization entries to override"
+                            )
+                    else:
+                        full_key = subkey if "." in subkey else f"{key}.{subkey}"
+                        _set_exact_normalization_mode(transforms, full_key, submode)
+            else:
+                if _replace_existing_modes(transforms, value, modality=key) == 0:
+                    raise ValueError(
+                        f"No existing {key} normalization entries to override"
+                    )
+        elif "." in key:
+            _set_exact_normalization_mode(transforms, key, value)
+        else:
+            raise ValueError(
+                f"Invalid normalization override key {key!r}; use 'action', "
+                "'state', or a full key such as 'action.gripper'."
+            )
+
+    return transform
+
+
+def build_overridden_data_pipeline(
+    data_config: Any,
+    *,
+    action_horizon: int | None = None,
+    normalization_modes: Any = None,
+) -> tuple[dict[str, ModalityConfig], ComposedModalityTransform]:
+    """Build a DataConfig pipeline with non-mutating runtime overrides."""
+
+    modality_configs = override_action_horizon(
+        data_config.modality_config(), action_horizon
+    )
+    transform = data_config.transform()
+    if not isinstance(transform, ComposedModalityTransform):
+        transform = ComposedModalityTransform(transforms=[transform])
+    transform = apply_normalization_mode_overrides(transform, normalization_modes)
+    return modality_configs, transform

--- a/starVLA/dataloader/lerobot_datasets.py
+++ b/starVLA/dataloader/lerobot_datasets.py
@@ -15,6 +15,10 @@ from starVLA.dataloader.gr00t_lerobot.registry import (
     DATASET_NAMED_MIXTURES,
     EmbodimentTag,
 )
+from starVLA.dataloader.gr00t_lerobot.config_overrides import (
+    build_overridden_data_pipeline,
+    resolve_action_horizon,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,7 @@ def make_LeRobotSingleDataset(
     robot_type: str,
     delete_pause_frame: bool = False,
     data_cfg: dict | None = None,
+    action_horizon: int | None = None,
 ) -> LeRobotSingleDataset:
     """
     Make a LeRobotSingleDataset object.
@@ -39,8 +44,12 @@ def make_LeRobotSingleDataset(
     """
     
     data_config = ROBOT_TYPE_CONFIG_MAP[robot_type]
-    modality_config = data_config.modality_config()
-    transforms = data_config.transform()
+    normalization_modes = data_cfg.get("normalization_modes") if data_cfg else None
+    modality_config, transforms = build_overridden_data_pipeline(
+        data_config,
+        action_horizon=action_horizon,
+        normalization_modes=normalization_modes,
+    )
     dataset_path = data_root_dir / data_name
     embodiment_tag = getattr(data_config, "embodiment_tag", None)
     if embodiment_tag is None:
@@ -80,6 +89,7 @@ def get_vla_dataset(
     balance_dataset_weights: bool = False,
     balance_trajectory_weights: bool = False,
     seed: int = 42,
+    model_action_horizon: int | None = None,
     **kwargs: dict,
 ) -> LeRobotMixtureDataset:
     """
@@ -88,6 +98,10 @@ def get_vla_dataset(
     data_root_dir = data_cfg.data_root_dir
     data_mix = data_cfg.data_mix
     delete_pause_frame = data_cfg.get("delete_pause_frame", False)
+    action_horizon = resolve_action_horizon(
+        model_action_horizon=model_action_horizon,
+        data_action_horizon=data_cfg.get("action_horizon"),
+    )
     mixture_spec = DATASET_NAMED_MIXTURES[data_mix]
     logger.info(f"[dataloader] Using mixture '{data_mix}': {[(d, w, r) for d, w, r in mixture_spec]}")
     included_datasets, filtered_mixture_spec = set(), []
@@ -102,7 +116,19 @@ def get_vla_dataset(
 
     dataset_mixture = []
     for d_name, d_weight, robot_type in filtered_mixture_spec:
-        dataset_mixture.append((make_LeRobotSingleDataset(Path(data_root_dir), d_name, robot_type, delete_pause_frame=delete_pause_frame, data_cfg=data_cfg), d_weight))
+        dataset_mixture.append(
+            (
+                make_LeRobotSingleDataset(
+                    Path(data_root_dir),
+                    d_name,
+                    robot_type,
+                    delete_pause_frame=delete_pause_frame,
+                    data_cfg=data_cfg,
+                    action_horizon=action_horizon,
+                ),
+                d_weight,
+            )
+        )
 
     return LeRobotMixtureDataset(
         dataset_mixture,

--- a/tests/test_data_config_overrides.py
+++ b/tests/test_data_config_overrides.py
@@ -1,0 +1,120 @@
+import unittest
+
+from omegaconf import OmegaConf
+
+from starVLA.dataloader.gr00t_lerobot.config_overrides import (
+    apply_normalization_mode_overrides,
+    build_overridden_data_pipeline,
+    resolve_action_horizon,
+)
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionTransform
+from starVLA.dataloader.lerobot_datasets import get_vla_dataset
+
+
+class _FakeDataConfig:
+    action_keys = ["action.x", "action.gripper"]
+
+    def modality_config(self):
+        return {
+            "action": ModalityConfig(
+                delta_indices=list(range(8)),
+                modality_keys=self.action_keys,
+            )
+        }
+
+    def transform(self):
+        return ComposedModalityTransform(
+            transforms=[
+                StateActionTransform(
+                    apply_to=self.action_keys,
+                    normalization_modes={"action.x": "min_max"},
+                )
+            ]
+        )
+
+
+class ActionHorizonOverrideTest(unittest.TestCase):
+    def test_matching_model_and_data_horizons_are_accepted(self):
+        self.assertEqual(
+            resolve_action_horizon(
+                model_action_horizon=12,
+                data_action_horizon=12,
+            ),
+            12,
+        )
+
+    def test_model_horizon_is_used_when_data_value_is_omitted(self):
+        self.assertEqual(
+            resolve_action_horizon(model_action_horizon=16),
+            16,
+        )
+
+    def test_mismatched_horizons_fail_before_dataset_construction(self):
+        with self.assertRaisesRegex(ValueError, "Action horizon mismatch"):
+            resolve_action_horizon(
+                model_action_horizon=16,
+                data_action_horizon=8,
+            )
+
+    def test_dataset_entrypoint_validates_before_touching_dataset_files(self):
+        data_cfg = OmegaConf.create(
+            {
+                "data_root_dir": "/path/that/does/not/exist",
+                "data_mix": "libero_all",
+                "action_horizon": 8,
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "Action horizon mismatch"):
+            get_vla_dataset(data_cfg, model_action_horizon=16)
+
+    def test_pipeline_uses_range_of_resolved_horizon_without_mutating_default(self):
+        data_config = _FakeDataConfig()
+        original = data_config.modality_config()
+
+        overridden, _ = build_overridden_data_pipeline(
+            data_config,
+            action_horizon=12,
+        )
+
+        self.assertEqual(overridden["action"].delta_indices, list(range(12)))
+        self.assertEqual(original["action"].delta_indices, list(range(8)))
+
+
+class NormalizationModeOverrideTest(unittest.TestCase):
+    def _transform(self):
+        return _FakeDataConfig().transform()
+
+    def test_scalar_replaces_existing_modes_but_preserves_unnormalized_keys(self):
+        transform = apply_normalization_mode_overrides(self._transform(), "q99")
+        state_action = transform.transforms[0]
+
+        self.assertEqual(state_action.normalization_modes, {"action.x": "q99"})
+        self.assertNotIn("action.gripper", state_action.normalization_modes)
+
+    def test_per_key_mapping_can_enable_a_previously_unnormalized_key(self):
+        override = OmegaConf.create(
+            {"action": {"x": "mean_std", "gripper": "binary"}}
+        )
+        transform = apply_normalization_mode_overrides(self._transform(), override)
+        state_action = transform.transforms[0]
+
+        self.assertEqual(
+            state_action.normalization_modes,
+            {"action.x": "mean_std", "action.gripper": "binary"},
+        )
+
+    def test_null_per_key_mapping_disables_normalization(self):
+        transform = apply_normalization_mode_overrides(
+            self._transform(), {"action.x": None}
+        )
+        self.assertEqual(transform.transforms[0].normalization_modes, {})
+
+    def test_invalid_mode_is_rejected_early(self):
+        with self.assertRaisesRegex(ValueError, "Invalid normalization mode"):
+            apply_normalization_mode_overrides(self._transform(), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The model action horizon is configurable, but the LeRobot dataloader previously obtained its action indices independently from Python DataConfig classes. This could silently desynchronize model prediction chunks and dataset labels.

Related to #353 

## Changes

  - Generate dataset action indices with `range(action_horizon)`.
  - Validate model and dataset horizons before dataset construction.
  - Support `datasets.vla_data.normalization_modes` as a global, per-modality, or per-key override.
  - Preserve existing DataConfig defaults when overrides are absent.
  - Reconstruct the same normalization pipeline during deployment.
  - Add LIBERO example configuration, documentation, and unit tests.

## Testing

  - [x] Black passes on Python files touched by this PR.
  - [x] Ruff passes on Python files touched by this PR.
  - [x] `python -m unittest tests.test_data_config_overrides -v`
  - [x] `python -m unittest tests.test_config_overrides -v`
  - [x] `python -m unittest discover -s tests -v`
  - [x] OmegaConf interpolation smoke test.

## Breaking Changes

None. Existing DataConfig defaults remain active when the new dataset fields are omitted.