### PR TITLE
Add MiniCPM-RobotManip LIBERO full-parameter fine-tuning

### DIFF
--- a/examples/modelExtensions/MiniCPM-RobotManip/README.md
+++ b/examples/modelExtensions/MiniCPM-RobotManip/README.md
@@ -35,9 +35,9 @@ are masked out of the loss. `embodiment_id = 0`, `action_horizon = 30`.
 ## Data preparation
 
 This recipe requires the filtered, 20 Hz LeRobot-v3 conversion with absolute
-EE6D targets. The converted dataset will be released soon at
+EE6D targets. The converted dataset is available at
 [`openbmb/MiniCPM-RobotManip-LIBERO`](https://huggingface.co/datasets/openbmb/MiniCPM-RobotManip-LIBERO).
-Once it is published, download it with:
+Download it with:
 
 ```bash
 huggingface-cli download openbmb/MiniCPM-RobotManip-LIBERO \

--- a/examples/modelExtensions/MiniCPM-RobotManip/README.md
+++ b/examples/modelExtensions/MiniCPM-RobotManip/README.md
@@ -1,0 +1,130 @@
+# MiniCPM-RobotManip × LIBERO Fine-tuning
+
+Fine-tune the released **[MiniCPM-RobotManip](https://github.com/OpenBMB/MiniCPM-Robot)**
+generalist VLA on LIBERO inside starVLA.
+
+This integration is contributed by members of the MiniCPM-RobotManip team to
+provide a compact, upstream-friendly training example for the released model.
+
+MiniCPM-RobotManip is a 1.5B generalist manipulation policy: a MiniCPM-V-4.6
+backbone + a flow-matching GR00T action head, trained on a unified **80-D**
+action space. This example loads the released checkpoint
+[`openbmb/MiniCPM-RobotManip`](https://huggingface.co/openbmb/MiniCPM-RobotManip)
+**as-is** (via its shipped `trust_remote_code` model class) and fine-tunes it on
+LIBERO's four task suites.
+
+> **How this differs from `examples/modelExtensions/MiniCPM`.**
+> That example plugs the plain `openbmb/MiniCPM-V-4.6` VLM into starVLA and trains
+> a *fresh* 7-D action head from scratch. **This** example loads the *released
+> MiniCPM-RobotManip* weights (backbone **and** a pretrained 80-D action head) and
+> continues training them — i.e. it showcases the open-sourced model itself.
+
+## Action space
+
+State and action share a unified 80-D layout; LIBERO is single-arm, so the 10-D
+absolute EE6D target (`observation.xvla_abs_ee6d` = xyz(3) + rot6d(6) +
+gripper(1)) occupies the left-arm end-effector slot `[7:17]`. All other channels
+are masked out of the loss. `embodiment_id = 0`, `action_horizon = 30`.
+
+## Requirements
+
+- `transformers` new enough to load `openbmb/MiniCPM-V-4.6` (`AutoModelForImageTextToText`)
+- `trust_remote_code=True` is used to load the released `MiniCPMV_VLA` class
+- LIBERO LeRobot-v3 data with the `observation.xvla_abs_ee6d` column
+
+## Data preparation
+
+This recipe requires the filtered, 20 Hz LeRobot-v3 conversion with absolute
+EE6D targets. The converted dataset will be released soon at
+[`openbmb/MiniCPM-RobotManip-LIBERO`](https://huggingface.co/datasets/openbmb/MiniCPM-RobotManip-LIBERO).
+Once it is published, download it with:
+
+```bash
+huggingface-cli download openbmb/MiniCPM-RobotManip-LIBERO \
+  --repo-type dataset \
+  --local-dir playground/Datasets/LIBERO_EE6D
+```
+
+Do not substitute `lerobot/libero_*_image`: those public datasets contain 7-D
+actions at 10 Hz and do not provide `observation.xvla_abs_ee6d`.
+
+The expected layout is:
+
+```
+playground/Datasets/LIBERO_EE6D/
+  libero_10_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d/
+  libero_goal_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d/
+  libero_object_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d/
+  libero_spatial_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d/
+```
+
+The launcher validates all four suites and installs `meta/modality.json`, which
+maps `observation.xvla_abs_ee6d` into state and action modalities.
+
+## Training (8-GPU node)
+
+```bash
+VLM_PATH=openbmb/MiniCPM-RobotManip \
+LIBERO_EE6D_ROOT=playground/Datasets/LIBERO_EE6D \
+bash examples/modelExtensions/MiniCPM-RobotManip/train_files/run_libero_train.sh
+```
+
+Key settings (`train_files/minicpm_robotmanip_libero.yaml`):
+
+| Parameter | Value |
+|---|---|
+| action_dim / state_dim | 80 |
+| action_horizon | 30 |
+| image resolution | 448 × 448 |
+| base LR / action-head LR | 1e-7 / 3e-6 |
+| total steps / warmup | 1 500 / 100 |
+| batch size per GPU | 12 |
+| repeated diffusion steps | 8 |
+
+The training path follows the LIBERO branch of the released model's mixed
+post-training setup: the same robot/action/FPS prompt, action offsets 1–30,
+unified 80-D mask, repeated diffusion steps 8, length-balanced sampling, and
+removal of incomplete action chunks. Both camera views are resized to the same
+448×448 resolution used by the released model and evaluation interface. The
+clean-action loss is xyz masked-MSE ×500 + rotation6D masked-MSE ×10 + gripper
+masked-L1. The example is intended to provide a correct, runnable
+full-parameter training path; downstream performance depends on the dataset and
+training setup and is not guaranteed by this recipe.
+
+## Exporting a checkpoint
+
+Training checkpoints use starVLA's framework-prefixed state dict. To create a
+local Hugging Face model directory for downstream use, strip that prefix and
+copy the released model's code and tokenizer files:
+
+```bash
+python examples/modelExtensions/MiniCPM-RobotManip/train_files/export_checkpoint.py \
+  --ckpt playground/Checkpoints/minicpm_robotmanip_libero_full_finetune/checkpoints/steps_1500_pytorch_model.pt \
+  --base /path/to/MiniCPM-RobotManip \
+  --out playground/Exported/minicpm_robotmanip_libero_step1500
+```
+
+The exported directory is local output; this recipe does not require publishing
+a separate fine-tuned checkpoint.
+
+## LIBERO results
+
+| Recipe | LIBERO-10 | Goal | Object | Spatial | Overall |
+|---|---:|---:|---:|---:|---:|
+| Simple LIBERO full-parameter fine-tuning, step 1 500 | 93.4 | 98.8 | 99.6 | 94.6 | 96.60 |
+
+This is the result produced by the compact, single-dataset LIBERO recipe in
+this PR. The released generalist model uses a broader multi-embodiment
+post-training setup, which is outside the scope of this example.
+
+## Files
+
+| File | Description |
+|---|---|
+| `starVLA/model/framework/VLM4A/MiniCPMRobotManip.py` | framework: loads released model + adds training loss |
+| `train_files/data_registry/data_config.py` | 80-D EE6D LIBERO data config (auto-discovered) |
+| `train_files/modality.json` | maps `observation.xvla_abs_ee6d` → state/action |
+| `train_files/install_modality.py` | validates each suite and installs the mapping |
+| `train_files/minicpm_robotmanip_libero.yaml` | training config |
+| `train_files/run_libero_train.sh` | 8-GPU launch script |
+| `train_files/export_checkpoint.py` | export a trainer checkpoint to HF format |

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/data_registry/data_config.py
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/data_registry/data_config.py
@@ -1,0 +1,59 @@
+"""MiniCPM-RobotManip LIBERO fine-tune — data config (80-D EE6D recipe).
+
+The LIBERO LeRobot-v3 migration stores X-VLA-aligned single-arm **absolute**
+EE6D targets in ``observation.xvla_abs_ee6d`` (10-D = xyz(3) + rot6d(6) +
+gripper(1)). We read that column for both state (offset 0) and the 30-step
+action chunk (offsets 1..30), keeping the raw metric values (no normalization),
+matching the recipe that produced the released checkpoint. The 10-D vector is
+lifted to the model's 80-D unified layout inside the ``MiniCPMRobotManip``
+framework (left-arm eef slot [7:17]); the remaining channels are masked out.
+"""
+
+from typing import ClassVar
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import StateActionToTensor
+
+ACTION_HORIZON = 30
+
+
+class MiniCPMRobotManipLiberoEE6DConfig:
+    embodiment_tag = EmbodimentTag.FRANKA
+    video_keys: ClassVar = ["video.primary_image", "video.wrist_image"]
+    state_keys: ClassVar = ["state.eef_position", "state.eef_rotation", "state.gripper"]
+    action_keys: ClassVar = ["action.eef_position", "action.eef_rotation", "action.gripper"]
+    language_keys: ClassVar = ["annotation.human.action.task_description"]
+    observation_indices: ClassVar = [0]
+    state_indices: ClassVar = [0]
+    # Absolute EE6D targets for the next ACTION_HORIZON steps (offsets 1..30).
+    action_indices: ClassVar = list(range(1, ACTION_HORIZON + 1))
+
+    def modality_config(self):
+        return {
+            "video": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.video_keys),
+            "state": ModalityConfig(delta_indices=self.state_indices, modality_keys=self.state_keys),
+            "action": ModalityConfig(delta_indices=self.action_indices, modality_keys=self.action_keys),
+            "language": ModalityConfig(delta_indices=self.observation_indices, modality_keys=self.language_keys),
+        }
+
+    def transform(self):
+        # Raw absolute EE6D targets — no normalization (matches released recipe).
+        return ComposedModalityTransform(transforms=[StateActionToTensor(apply_to=self.state_keys + self.action_keys)])
+
+
+ROBOT_TYPE_CONFIG_MAP = {
+    "minicpm_robotmanip_libero_ee6d": MiniCPMRobotManipLiberoEE6DConfig(),
+}
+
+_TASKS = (
+    "libero_10_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d",
+    "libero_goal_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d",
+    "libero_object_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d",
+    "libero_spatial_agentview_rot180_wrist_raw_lerobot_v30_xvla_abs6d",
+)
+
+DATASET_NAMED_MIXTURES = {
+    "minicpm_robotmanip_libero_ee6d": [(t, 1.0, "minicpm_robotmanip_libero_ee6d") for t in _TASKS],
+}

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/deepspeed_zero2_mixed_dtype.yaml
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/deepspeed_zero2_mixed_dtype.yaml
@@ -1,0 +1,9 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  deepspeed_config_file: "./examples/modelExtensions/MiniCPM-RobotManip/train_files/ds_config_mixed_dtype.json"
+  deepspeed_multinode_launcher: standard
+  zero3_init_flag: false
+distributed_type: DEEPSPEED
+num_machines: 1
+num_processes: 8

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/ds_config_mixed_dtype.json
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/ds_config_mixed_dtype.json
@@ -1,0 +1,23 @@
+{
+    "fp16": {
+        "enabled": false
+    },
+    "bf16": {
+        "enabled": false
+    },
+    "train_micro_batch_size_per_gpu": "auto",
+    "train_batch_size": "auto",
+    "gradient_accumulation_steps": 1,
+    "zero_optimization": {
+        "stage": 2,
+        "allgather_partitions": true,
+        "allgather_bucket_size": 500000000,
+        "reduce_scatter": true,
+        "reduce_bucket_size": 500000000,
+        "overlap_comm": true,
+        "contiguous_gradients": true,
+        "cpu_offload": false
+    },
+    "gradient_clipping": 1.0,
+    "steps_per_print": 10
+}

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/export_checkpoint.py
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/export_checkpoint.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Export a starVLA MiniCPMRobotManip fine-tune checkpoint into an HF model dir.
+
+The trainer saves a *framework* state_dict whose keys are prefixed with
+``model.`` (e.g. ``model.vlm.*`` / ``model.action_head.*``). The released
+``MiniCPMV_VLA`` class (loaded via ``AutoModel.from_pretrained(..., trust_remote_code=True)``)
+expects keys without that prefix (``vlm.*`` / ``action_head.*``).
+
+This script strips the prefix and writes a self-contained HF directory
+(released code/config/tokenizer + the fine-tuned ``model.safetensors``) that any
+evaluation harness can load directly:
+
+    python export_checkpoint.py \
+        --ckpt playground/Checkpoints/mrm_libero_ft8/checkpoints/steps_2000_pytorch_model.pt \
+        --base /path/to/MiniCPM-RobotManip \
+        --out  playground/Exported/mrm_libero_ft8_step2000
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+_COPY_FILES = (
+    "config.json",
+    "configuration_minicpm_vla.py",
+    "modeling_minicpm_vla.py",
+    "action_head.py",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "chat_template.jinja",
+)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True, help="framework .pt/.safetensors checkpoint")
+    ap.add_argument("--base", required=True, help="released MiniCPM-RobotManip dir (code + config + tokenizer)")
+    ap.add_argument("--out", required=True, help="output HF model dir")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # 1) copy released code/config/tokenizer
+    base = Path(args.base)
+    for f in _COPY_FILES:
+        src = base / f
+        if src.exists():
+            shutil.copy2(src, out / f)
+
+    # 2) load framework state_dict, strip the leading "model." prefix
+    ckpt = Path(args.ckpt)
+    if ckpt.suffix == ".safetensors":
+        from safetensors.torch import load_file
+
+        sd = load_file(str(ckpt))
+    else:
+        sd = torch.load(str(ckpt), map_location="cpu")
+    sd = sd.get("state_dict", sd)
+
+    new_sd, dropped = {}, 0
+    for k, v in sd.items():
+        nk = k[len("model.") :] if k.startswith("model.") else k
+        if nk.startswith(("vlm.", "action_head.")):
+            new_sd[nk] = v.contiguous()
+        else:
+            dropped += 1
+    print(f"kept {len(new_sd)} tensors, dropped {dropped} non-model keys")
+
+    save_file(new_sd, str(out / "model.safetensors"), metadata={"format": "pt"})
+    print(f"exported HF model dir -> {out}")
+    print("load with: AutoModel.from_pretrained(out, trust_remote_code=True)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/install_modality.py
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/install_modality.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Install MiniCPM-RobotManip's modality mapping into four LIBERO suites."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+SUITES = ("libero_10", "libero_goal", "libero_object", "libero_spatial")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset_root", type=Path)
+    args = parser.parse_args()
+
+    template = Path(__file__).with_name("modality.json")
+    json.loads(template.read_text())
+
+    for suite in SUITES:
+        matches = sorted(path for path in args.dataset_root.glob(f"{suite}_*") if path.is_dir())
+        if len(matches) != 1:
+            raise ValueError(
+                f"Expected exactly one {suite!r} directory under {args.dataset_root}, "
+                f"found {[path.name for path in matches]}"
+            )
+        info_path = matches[0] / "meta" / "info.json"
+        if not info_path.is_file():
+            raise FileNotFoundError(info_path)
+        features = json.loads(info_path.read_text()).get("features", {})
+        required = {
+            "observation.images.image",
+            "observation.images.wrist_image",
+            "observation.xvla_abs_ee6d",
+            "task_index",
+        }
+        missing = sorted(required - features.keys())
+        if missing:
+            raise ValueError(f"{matches[0].name} is missing required features: {missing}")
+
+        destination = matches[0] / "meta" / "modality.json"
+        shutil.copyfile(template, destination)
+        print(f"installed {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/minicpm_robotmanip_libero.yaml
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/minicpm_robotmanip_libero.yaml
@@ -1,0 +1,65 @@
+run_id: minicpm_robotmanip_libero_full_finetune
+run_root_dir: playground/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: starVLA_MiniCPM_RobotManip
+is_debug: false
+
+framework:
+  name: MiniCPMRobotManip
+  # Released 1.5B checkpoint (backbone + pretrained 80-D GR00T head), loaded via
+  # trust_remote_code. Set to a local path to avoid re-downloading from HF.
+  base_vlm: openbmb/MiniCPM-RobotManip
+  attn_implementation: eager
+  repeated_diffusion_steps: 8
+
+datasets:
+  vla_data:
+    dataset_py: lerobot_datasets
+    data_root_dir: playground/Datasets/LIBERO_EE6D
+    data_mix: minicpm_robotmanip_libero_ee6d
+    lerobot_version: v3.0
+    include_state: true
+    # The released model was trained with an FP32 action head and FP32
+    # state/action targets. Avoid the dataloader's legacy FP16 packing, which
+    # quantizes absolute EE positions by as much as 0.49 mm before loss.
+    state_action_dtype: float32
+    # The released model and evaluation interface both use 448×448 inputs.
+    image_size: 448
+    per_device_batch_size: 12
+    num_workers: 2
+    video_backend: torchvision_av
+    # Match the LIBERO branch of the released mixed post-training recipe.
+    balance_dataset_weights: true
+    balance_trajectory_weights: true
+    drop_incomplete_action_chunks: true
+
+trainer:
+  max_train_steps: 1500
+  num_warmup_steps: 100
+  save_interval: 250
+  eval_interval: 1000000   # closed-loop eval is out of scope for this example
+  learning_rate:
+    # Conservative full-parameter training from the released checkpoint.
+    base: 1.0e-07
+    model.action_head: 3.0e-06
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    # Keep the floor proportional because the VLM and action head intentionally
+    # use different peak learning rates.
+    min_lr_rate: 0.1
+  freeze_modules: ''
+  loss_scale:
+    vla: 1.0
+  max_grad_norm: 1.0
+  weight_decay: 1.0e-08
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/modality.json
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/modality.json
@@ -1,0 +1,19 @@
+{
+    "state": {
+        "eef_position": {"start": 0, "end": 3, "original_key": "observation.xvla_abs_ee6d"},
+        "eef_rotation": {"start": 3, "end": 9, "original_key": "observation.xvla_abs_ee6d"},
+        "gripper":      {"start": 9, "end": 10, "original_key": "observation.xvla_abs_ee6d"}
+    },
+    "action": {
+        "eef_position": {"start": 0, "end": 3, "original_key": "observation.xvla_abs_ee6d"},
+        "eef_rotation": {"start": 3, "end": 9, "original_key": "observation.xvla_abs_ee6d"},
+        "gripper":      {"start": 9, "end": 10, "original_key": "observation.xvla_abs_ee6d"}
+    },
+    "video": {
+        "primary_image": {"original_key": "observation.images.image"},
+        "wrist_image":    {"original_key": "observation.images.wrist_image"}
+    },
+    "annotation": {
+        "human.action.task_description": {"original_key": "task_index"}
+    }
+}

--- a/examples/modelExtensions/MiniCPM-RobotManip/train_files/run_libero_train.sh
+++ b/examples/modelExtensions/MiniCPM-RobotManip/train_files/run_libero_train.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Fine-tune the released MiniCPM-RobotManip on LIBERO (80-D EE6D). 8-GPU node.
+set -euo pipefail
+cd "$(dirname "$0")/../../../.."   # -> repo root
+
+export VLM_PATH="${VLM_PATH:-openbmb/MiniCPM-RobotManip}"
+export LIBERO_EE6D_ROOT="${LIBERO_EE6D_ROOT:-playground/Datasets/LIBERO_EE6D}"
+export TOKENIZERS_PARALLELISM=false
+
+# Keep host thread use bounded across eight ranks.
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-1}"
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-1}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+run_id="${RUN_ID:-minicpm_robotmanip_libero_full_finetune}"
+
+# Optional runtime overrides. Learning rates and scheduler settings stay in the
+# YAML so the published recipe has a single source of truth.
+MAX_STEPS="${MAX_STEPS:-1500}"
+WARMUP_STEPS="${WARMUP_STEPS:-100}"
+PER_DEVICE_BS="${PER_DEVICE_BS:-12}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-250}"
+EVAL_INTERVAL="${EVAL_INTERVAL:-1000000}"
+LOG_FREQ="${LOG_FREQ:-10}"
+NUM_WORKERS="${NUM_WORKERS:-2}"
+CONFIG_YAML="${CONFIG_YAML:-examples/modelExtensions/MiniCPM-RobotManip/train_files/minicpm_robotmanip_libero.yaml}"
+
+python examples/modelExtensions/MiniCPM-RobotManip/train_files/install_modality.py \
+  "${LIBERO_EE6D_ROOT}"
+
+NUM_PROCESSES="${NUM_PROCESSES:-$(nvidia-smi -L | wc -l)}"
+
+ACCELERATE_CONFIG_FILE="${ACCELERATE_CONFIG_FILE:-examples/modelExtensions/MiniCPM-RobotManip/train_files/deepspeed_zero2_mixed_dtype.yaml}"
+
+accelerate launch \
+  --config_file "${ACCELERATE_CONFIG_FILE}" \
+  --num_processes "${NUM_PROCESSES}" \
+  starVLA/training/train_starvla.py \
+  --config_yaml "${CONFIG_YAML}" \
+  --framework.base_vlm "${VLM_PATH}" \
+  --datasets.vla_data.data_root_dir "${LIBERO_EE6D_ROOT}" \
+  --datasets.vla_data.per_device_batch_size "${PER_DEVICE_BS}" \
+  --datasets.vla_data.num_workers "${NUM_WORKERS}" \
+  --trainer.max_train_steps "${MAX_STEPS}" \
+  --trainer.num_warmup_steps "${WARMUP_STEPS}" \
+  --trainer.save_interval "${SAVE_INTERVAL}" \
+  --trainer.eval_interval "${EVAL_INTERVAL}" \
+  --trainer.logging_frequency "${LOG_FREQ}" \
+  --run_id "${run_id}" \
+  --run_root_dir playground/Checkpoints

--- a/starVLA/dataloader/gr00t_lerobot/datasets.py
+++ b/starVLA/dataloader/gr00t_lerobot/datasets.py
@@ -1378,17 +1378,37 @@ class LeRobotSingleDataset(Dataset):
 
     def _pack_sample(self, data: dict) -> dict:
         """Pack transformed modality data into training sample format."""
+        state_action_dtype = (
+            self.data_cfg.get("state_action_dtype", "float16")
+            if self.data_cfg is not None
+            else "float16"
+        )
+        try:
+            state_action_dtype = np.dtype(state_action_dtype)
+        except TypeError as exc:
+            raise ValueError(
+                f"state_action_dtype must be a NumPy dtype name, got {state_action_dtype!r}"
+            ) from exc
+
+        image_size = self.data_cfg.get("image_size", 224) if self.data_cfg is not None else 224
+        if isinstance(image_size, int):
+            image_size = (image_size, image_size)
+        else:
+            image_size = tuple(image_size)
+            if len(image_size) != 2:
+                raise ValueError(f"image_size must be an int or a 2-item sequence, got {image_size!r}")
+
         step_images = []
         for video_key in self.modality_keys["video"]:
             image = data[video_key][0]
-            image = Image.fromarray(image).resize((224, 224))
+            image = Image.fromarray(image).resize(image_size)
             step_images.append(image)
 
         language = data[self.modality_keys["language"][0]][0]
         action = []
         for action_key in self.modality_keys["action"]:
             action.append(data[action_key])
-        action = np.concatenate(action, axis=1).astype(np.float16)
+        action = np.concatenate(action, axis=1).astype(state_action_dtype)
 
         sample = {
             "action": action,
@@ -1410,7 +1430,7 @@ class LeRobotSingleDataset(Dataset):
                     stacklevel=2,
                 )
             else:
-                state = np.concatenate(state, axis=1).astype(np.float16)
+                state = np.concatenate(state, axis=1).astype(state_action_dtype)
                 sample["state"] = state
 
         return sample
@@ -2205,11 +2225,50 @@ class LeRobotMixtureDataset(Dataset):
         self.seed = seed
         self.mode = mode
         self.data_cfg = kwargs["data_cfg"] if "data_cfg" in kwargs else None
+        self.drop_incomplete_action_chunks = bool(
+            self.data_cfg.get("drop_incomplete_action_chunks", False)
+            if self.data_cfg is not None
+            else False
+        )
+
+        self._valid_step_bounds: list[tuple[int, int]] = []
+        self._effective_trajectory_lengths: list[np.ndarray] = []
+        if self.drop_incomplete_action_chunks:
+            # Sample only base frames whose action offsets stay in the episode.
+            for dataset in self.datasets:
+                offsets = [
+                    np.asarray(dataset.delta_indices[key], dtype=np.int64)
+                    for key in dataset.modality_keys.get("action", [])
+                ]
+                offsets = np.concatenate(offsets) if offsets else np.array([], dtype=np.int64)
+                min_offset = int(offsets.min()) if offsets.size else 0
+                max_offset = int(offsets.max()) if offsets.size else 0
+                valid_start = max(0, -min_offset)
+                end_trim = max(0, max_offset)
+                effective_lengths = np.maximum(
+                    np.asarray(dataset.trajectory_lengths, dtype=np.int64)
+                    - valid_start
+                    - end_trim,
+                    0,
+                )
+                if not np.any(effective_lengths > 0):
+                    raise ValueError(
+                        f"Dataset {dataset.dataset_name!r} has no complete action chunks "
+                        f"for action offset range [{min_offset}, {max_offset}]"
+                    )
+                self._valid_step_bounds.append((valid_start, end_trim))
+                self._effective_trajectory_lengths.append(effective_lengths)
 
         # Set properties for sampling
 
         # 1. Dataset lengths
-        self._dataset_lengths = np.array([len(dataset) for dataset in self.datasets])
+        if self.drop_incomplete_action_chunks:
+            self._dataset_lengths = np.array(
+                [lengths.sum() for lengths in self._effective_trajectory_lengths]
+            )
+            print(f"Dropped incomplete action chunks; effective dataset lengths: {self._dataset_lengths}")
+        else:
+            self._dataset_lengths = np.array([len(dataset) for dataset in self.datasets])
         print(f"Dataset lengths: {self._dataset_lengths}")
         self._getitem_count = 0
         # 2. Dataset sampling weights
@@ -2238,11 +2297,19 @@ class LeRobotMixtureDataset(Dataset):
         self._trajectory_sampling_weights: list[np.ndarray] = []
         for i, dataset in enumerate(self.datasets):
             trajectory_sampling_weights = np.ones(len(dataset.trajectory_lengths))
+            if self.drop_incomplete_action_chunks:
+                trajectory_sampling_weights[self._effective_trajectory_lengths[i] == 0] = 0
             if self.balance_trajectory_weights:
-                trajectory_sampling_weights *= dataset.trajectory_lengths
+                trajectory_sampling_weights *= (
+                    self._effective_trajectory_lengths[i]
+                    if self.drop_incomplete_action_chunks
+                    else dataset.trajectory_lengths
+                )
             
-            # Check for zero or negative weights before normalization
-            if np.any(trajectory_sampling_weights <= 0):
+            if self.drop_incomplete_action_chunks:
+                if np.any(trajectory_sampling_weights < 0):
+                    raise ValueError(f"Dataset {i} has negative trajectory sampling weights")
+            elif np.any(trajectory_sampling_weights <= 0):
                 print(f"Warning: Dataset {i} has zero or negative trajectory weights")
                 trajectory_sampling_weights = np.maximum(trajectory_sampling_weights, 1e-8)
             
@@ -2335,7 +2402,12 @@ class LeRobotMixtureDataset(Dataset):
         trajectory_id = dataset.trajectory_ids[trajectory_index]
 
         # Sample step
-        base_index = rng.choice(dataset.trajectory_lengths[trajectory_index])
+        if self.drop_incomplete_action_chunks:
+            valid_start, end_trim = self._valid_step_bounds[dataset_index]
+            valid_end_exclusive = int(dataset.trajectory_lengths[trajectory_index]) - end_trim
+            base_index = int(rng.integers(valid_start, valid_end_exclusive))
+        else:
+            base_index = rng.choice(dataset.trajectory_lengths[trajectory_index])
         return dataset, trajectory_id, base_index
 
     

--- a/starVLA/model/framework/VLM4A/MiniCPMRobotManip.py
+++ b/starVLA/model/framework/VLM4A/MiniCPMRobotManip.py
@@ -1,0 +1,256 @@
+# Copyright 2026 starVLA community. All rights reserved.
+# Licensed under the MIT License.
+"""
+MiniCPM-RobotManip Framework
+============================
+
+Fine-tune the released **MiniCPM-RobotManip** generalist VLA
+(https://huggingface.co/openbmb/MiniCPM-RobotManip) inside starVLA.
+
+Unlike the ``MiniCPMGR00T`` example (which trains a *fresh* GR00T head on top of
+the plain ``openbmb/MiniCPM-V-4.6`` backbone), this framework loads the released
+1.5B checkpoint **as-is** through its shipped ``trust_remote_code`` model class
+(``MiniCPMV_VLA`` = MiniCPM-V-4.6 backbone + a pretrained 80-D flow-matching
+GR00T action head) and fine-tunes it.
+
+The released repo ships an inference-only ``predict_action``; the flow-matching
+*training* loss is added here using the LIBERO branch of the mixed post-training
+recipe: clean-action target, xyz masked-MSE x500, rotation6D masked-MSE x10,
+and gripper masked-L1.
+
+Action space: unified 80-D layout. LIBERO is single-arm, so the 10-D absolute
+EE6D target (``observation.xvla_abs_ee6d`` = xyz(3) + rot6d(6) + gripper(1)) is
+placed in the left-arm end-effector slot ``[7:17]``; all other channels are
+masked out of the loss. ``embodiment_id = 0``.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+import torch
+from torch.distributions import Beta
+
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.tools import FRAMEWORK_REGISTRY
+from starVLA.training.trainer_utils import initialize_overwatch
+
+logger = initialize_overwatch(__name__)
+
+# 80-D unified layout: left_arm[0:17] = joint(7) + xyz(3) + rot6d(6) + gripper(1).
+# The 10-D EE6D target maps contiguously onto the left-arm eef slot [7:17].
+EE6D_SLOT_START = 7
+EE6D_SLOT_END = 17
+EE6D_XYZ_END = EE6D_SLOT_START + 3
+EE6D_ROT6D_END = EE6D_XYZ_END + 6
+
+LIBERO_PROMPT_TEMPLATE = (
+    "The robot is LIBERO Franka, a simulated single-arm Franka manipulator. "
+    "Its action control method is absolute single-arm end-effector pose in the unified 80D layout "
+    "with gripper closed command, and its action FPS is 20 Hz. Task: {instruction}"
+)
+
+
+@FRAMEWORK_REGISTRY.register("MiniCPMRobotManip")
+class MiniCPM_RobotManip(baseframework):
+    """Released MiniCPM-RobotManip (MiniCPM-V 4.6 + 80-D GR00T head) fine-tuning."""
+
+    def __init__(self, config: Optional[dict] = None, **kwargs) -> None:
+        super().__init__()
+        from transformers import AutoModel, AutoProcessor
+
+        self.config = config
+        fw = config.framework
+        model_id = fw.get("base_vlm", "openbmb/MiniCPM-RobotManip")
+        # The released MiniCPMV_VLA composite only accepts "eager" / "flash_attention_2"
+        # (it rejects "sdpa"); default to "eager" for portability.
+        attn_impl = fw.get("attn_implementation", "eager")
+        if attn_impl == "flash_attention_2":
+            try:
+                import flash_attn  # noqa: F401
+            except ImportError:
+                logger.warning("flash_attn not installed; falling back to eager")
+                attn_impl = "eager"
+
+        # Released self-contained checkpoint: MiniCPMV_VLA = vlm + action_head.
+        self.model = AutoModel.from_pretrained(
+            model_id,
+            trust_remote_code=True,
+            attn_implementation=attn_impl,
+        )
+        self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        if hasattr(self.processor, "tokenizer") and self.processor.tokenizer is not None:
+            self.processor.tokenizer.padding_side = "left"
+
+        # Optional VLM gradient checkpointing (trades a little compute for a large
+        # activation-memory saving; recommended for full-size fine-tuning batches).
+        grad_ckpt = bool(getattr(getattr(config, "trainer", object()), "gradient_checkpointing", False)) or bool(
+            fw.get("gradient_checkpointing", False)
+        )
+        if grad_ckpt:
+            try:
+                self.model.vlm.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+                if hasattr(self.model.vlm, "enable_input_require_grads"):
+                    self.model.vlm.enable_input_require_grads()
+                logger.info("[MiniCPMRobotManip] VLM gradient_checkpointing ENABLED")
+            except Exception as exc:
+                logger.warning(f"[MiniCPMRobotManip] failed to enable gradient_checkpointing: {exc}")
+
+        head = self.model.action_head
+        self.action_horizon = int(head.action_horizon)
+        self.action_dim = int(head.action_dim)
+        self.state_dim = int(head.state_dim)
+        self.num_timestep_buckets = int(head.num_timestep_buckets)
+        self.action_head_dtype = self.model.action_head_dtype
+
+        # Flow-matching noise schedule (matches the released training recipe).
+        self.repeated_diffusion_steps = int(fw.get("repeated_diffusion_steps", 8))
+        self._beta_dist = Beta(
+            float(fw.get("noise_beta_alpha", 1.5)),
+            float(fw.get("noise_beta_beta", 1.0)),
+        )
+        self._noise_s = float(fw.get("noise_s", 0.999))
+        self.xyz_loss_scale = float(fw.get("xyz_loss_scale", 500.0))
+        self.rot6d_loss_scale = float(fw.get("rot6d_loss_scale", 10.0))
+        self.libero_prompt_template = str(fw.get("libero_prompt_template", LIBERO_PROMPT_TEMPLATE))
+
+    # ------------------------------------------------------------------ utils
+    def _format_instruction(self, instruction: str) -> str:
+        # Evaluation already supplies the full robot prompt. Avoid adding it
+        # twice during direct predict_action() validation.
+        if instruction.startswith("The robot is LIBERO Franka,"):
+            return instruction
+        return self.libero_prompt_template.format(instruction=instruction)
+
+    def _build_vlm_inputs(self, images: List[list], instructions: List[str]):
+        """Tokenize (multi-view images + instruction) with the shipped processor."""
+        messages = []
+        for imgs, instruction in zip(images, instructions, strict=True):
+            content = [{"type": "image", "image": img} for img in imgs]
+            content.append({"type": "text", "text": self._format_instruction(instruction)})
+            messages.append([{"role": "user", "content": content}])
+        batch = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            padding=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        return batch.to(self.model.device)
+
+    def _to_80d(self, arr, device):
+        """(B, T, 10) EE6D -> (B, T, 80) unified layout + valid mask."""
+        t = torch.as_tensor(np.asarray(arr), dtype=torch.float32, device=device)
+        b, horizon, dim = t.shape
+        assert dim == (EE6D_SLOT_END - EE6D_SLOT_START), f"expected 10-D EE6D, got {dim}-D"
+        out = torch.zeros(b, horizon, self.action_dim, dtype=torch.float32, device=device)
+        mask = torch.zeros(b, horizon, self.action_dim, dtype=torch.float32, device=device)
+        out[:, :, EE6D_SLOT_START:EE6D_SLOT_END] = t
+        mask[:, :, EE6D_SLOT_START:EE6D_SLOT_END] = 1.0
+        return out, mask
+
+    def _sample_time(self, batch_size, device, dtype):
+        sample = self._beta_dist.sample([batch_size]).to(device, dtype=dtype).clamp(max=self._noise_s)
+        return (self._noise_s - sample) / self._noise_s
+
+    @staticmethod
+    def _reduce_qwenvla(loss_per_elem, valid_mask):
+        """Apply the released recipe's per-channel masked reduction."""
+        masked = loss_per_elem * valid_mask
+        valid_counts = valid_mask.sum(dim=1)  # (B, D)
+        channel_valid = valid_counts > 0
+        per_channel = masked.sum(dim=1) / valid_counts.clamp_min(1e-8)
+        per_channel = per_channel * channel_valid.to(per_channel.dtype)
+        n_valid_channels = channel_valid.sum(dim=1).clamp_min(1)
+        return (per_channel.sum(dim=1) / n_valid_channels).mean()
+
+    def _group_weighted_action_loss(self, pred, target, valid_mask):
+        """Released-recipe loss: xyz MSE x500 + rot6d MSE x10 + gripper L1."""
+        xyz_slice = slice(EE6D_SLOT_START, EE6D_XYZ_END)
+        rot_slice = slice(EE6D_XYZ_END, EE6D_ROT6D_END)
+        gripper_slice = slice(EE6D_ROT6D_END, EE6D_SLOT_END)
+
+        xyz_loss = self._reduce_qwenvla(
+            (pred[:, :, xyz_slice] - target[:, :, xyz_slice]).square(),
+            valid_mask[:, :, xyz_slice],
+        )
+        rot6d_loss = self._reduce_qwenvla(
+            (pred[:, :, rot_slice] - target[:, :, rot_slice]).square(),
+            valid_mask[:, :, rot_slice],
+        )
+        gripper_loss = self._reduce_qwenvla(
+            (pred[:, :, gripper_slice] - target[:, :, gripper_slice]).abs(),
+            valid_mask[:, :, gripper_slice],
+        )
+        action_loss = self.xyz_loss_scale * xyz_loss + self.rot6d_loss_scale * rot6d_loss + gripper_loss
+        return {
+            "action_loss": action_loss,
+            "xyz_loss": xyz_loss,
+            "rot6d_loss": rot6d_loss,
+            "gripper_loss": gripper_loss,
+        }
+
+    # ---------------------------------------------------------------- forward
+    def forward(self, examples: Optional[List[dict]] = None, **kwargs) -> dict:
+        if examples is None:
+            raise ValueError("examples must be provided")
+        images = [ex["image"] for ex in examples]
+        instructions = [ex["lang"] for ex in examples]
+        actions10 = [ex["action"] for ex in examples]  # each (H, 10)
+        states10 = [ex["state"] for ex in examples]  # each (1, 10)
+
+        vlm_inputs = self._build_vlm_inputs(images, instructions)
+        vl_out = self.model._vlm_forward(vlm_inputs)
+        vl_embs = vl_out.hidden_states[-1].to(self.action_head_dtype)
+
+        device = vl_embs.device
+        action80, valid_mask = self._to_80d(np.stack(actions10), device)
+        state80, _ = self._to_80d(np.stack(states10), device)
+        embodiment_id = torch.zeros(vl_embs.shape[0], dtype=torch.long, device=device)
+
+        # The released checkpoint intentionally keeps the action head in FP32.
+        # Disable the trainer's outer BF16 autocast for this block while leaving
+        # the VLM forward above in BF16.
+        device_type = device.type
+        with torch.autocast(device_type, enabled=False):
+            r = self.repeated_diffusion_steps
+            vl = vl_embs.repeat(r, 1, 1)
+            act = action80.repeat(r, 1, 1)
+            msk = valid_mask.repeat(r, 1, 1)
+            st = state80.repeat(r, 1, 1)
+            eid = embodiment_id.repeat(r)
+
+            head = self.model.action_head
+            noise = torch.randn_like(act)
+            t = self._sample_time(act.shape[0], device, act.dtype)
+            tb = t[:, None, None]
+            # clean-action flow matching: t=0 -> clean, t=1 -> pure noise.
+            noisy = tb * noise + (1.0 - tb) * act
+            t_disc = (t * self.num_timestep_buckets).long()
+            pred = head._predict(noisy, vl, st, t_disc, eid)  # (B, H, 80)
+            losses = self._group_weighted_action_loss(pred, act, msk)
+
+        return losses
+
+    # ---------------------------------------------------------- predict_action
+    @torch.inference_mode()
+    def predict_action(self, examples, **kwargs) -> dict:
+        if not isinstance(examples, list):
+            examples = [examples]
+        images = [ex["image"] for ex in examples]
+        instructions = [ex["lang"] for ex in examples]
+        states10 = [ex["state"] for ex in examples]
+
+        vlm_inputs = self._build_vlm_inputs(images, instructions)
+        device = self.model.device
+        state80, _ = self._to_80d(np.stack(states10), device)
+        embodiment_id = torch.zeros(len(examples), dtype=torch.long, device=device)
+
+        actions80 = self.model.predict_action(
+            state=state80,
+            embodiment_id=embodiment_id,
+            **vlm_inputs,
+        )  # (B, H, 80)
+        # Recover the single-arm 10-D EE6D action from the left-arm eef slot.
+        actions10 = actions80[:, :, EE6D_SLOT_START:EE6D_SLOT_END]
+        return {"normalized_actions": actions10.float().cpu().numpy()}

--- a/tests/test_minicpm_robotmanip.py
+++ b/tests/test_minicpm_robotmanip.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+import torch
+from PIL import Image
+
+from starVLA.dataloader.gr00t_lerobot.datasets import LeRobotSingleDataset
+from starVLA.model.framework.VLM4A.MiniCPMRobotManip import (
+    EE6D_SLOT_END,
+    EE6D_SLOT_START,
+    MiniCPM_RobotManip,
+)
+
+
+class MiniCPMRobotManipActionTest(unittest.TestCase):
+    def setUp(self):
+        self.framework = MiniCPM_RobotManip.__new__(MiniCPM_RobotManip)
+        self.framework.action_dim = 80
+        self.framework.xyz_loss_scale = 500.0
+        self.framework.rot6d_loss_scale = 10.0
+
+    def test_ee6d_is_mapped_to_left_arm_slot(self):
+        ee6d = np.arange(2 * 3 * 10, dtype=np.float32).reshape(2, 3, 10)
+
+        action, valid = self.framework._to_80d(ee6d, torch.device("cpu"))
+
+        self.assertEqual(tuple(action.shape), (2, 3, 80))
+        torch.testing.assert_close(action[:, :, EE6D_SLOT_START:EE6D_SLOT_END], torch.from_numpy(ee6d))
+        self.assertEqual(int(valid.sum().item()), 2 * 3 * 10)
+        self.assertEqual(int(torch.count_nonzero(action[:, :, :EE6D_SLOT_START])), 0)
+        self.assertEqual(int(torch.count_nonzero(action[:, :, EE6D_SLOT_END:])), 0)
+
+    def test_group_loss_ignores_masked_channels(self):
+        target = torch.zeros(1, 2, 80)
+        valid = torch.zeros_like(target)
+        valid[:, :, EE6D_SLOT_START:EE6D_SLOT_END] = 1
+        pred = torch.zeros_like(target)
+        pred[:, :, :EE6D_SLOT_START] = 1000
+
+        losses = self.framework._group_weighted_action_loss(pred, target, valid)
+
+        self.assertEqual(losses["action_loss"].item(), 0.0)
+
+
+class MiniCPMRobotManipDataPackingTest(unittest.TestCase):
+    def test_configurable_dtype_and_image_size(self):
+        dataset = LeRobotSingleDataset.__new__(LeRobotSingleDataset)
+        dataset.data_cfg = {
+            "image_size": 448,
+            "include_state": True,
+            "state_action_dtype": "float32",
+        }
+        dataset._modality_keys = {
+            "video": ["video.primary", "video.wrist"],
+            "language": ["annotation.task"],
+            "action": ["action.eef"],
+            "state": ["state.eef"],
+        }
+        dataset.tag = "franka"
+        data = {
+            "video.primary": [np.zeros((16, 24, 3), dtype=np.uint8)],
+            "video.wrist": [np.zeros((12, 20, 3), dtype=np.uint8)],
+            "annotation.task": ["pick up the object"],
+            "action.eef": np.zeros((30, 10), dtype=np.float64),
+            "state.eef": np.zeros((1, 10), dtype=np.float64),
+        }
+
+        sample = dataset._pack_sample(data)
+
+        self.assertTrue(all(isinstance(image, Image.Image) for image in sample["image"]))
+        self.assertTrue(all(image.size == (448, 448) for image in sample["image"]))
+        self.assertEqual(sample["action"].dtype, np.float32)
+        self.assertEqual(sample["state"].dtype, np.float32)
+
+    def test_incomplete_action_chunks_are_never_sampled(self):
+        from starVLA.dataloader.gr00t_lerobot.datasets import LeRobotMixtureDataset
+
+        class StubDataset:
+            dataset_name = "stub"
+
+            def __init__(self):
+                self.trajectory_lengths = np.array([35])
+                self.trajectory_ids = np.array([7])
+                self.modality_keys = {"action": ["action.eef"]}
+                self.delta_indices = {"action.eef": np.arange(1, 31)}
+
+            def __len__(self):
+                return 35
+
+        with mock.patch.object(LeRobotMixtureDataset, "update_metadata"):
+            mixture = LeRobotMixtureDataset(
+                [(StubDataset(), 1.0)],
+                mode="test",
+                data_cfg={"drop_incomplete_action_chunks": True},
+            )
+
+        sampled = [mixture.sample_step(index)[2] for index in range(100)]
+        self.assertTrue(all(0 <= base_index < 5 for base_index in sampled))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Contributed by members of the MiniCPM-RobotManip team, this PR adds full-parameter LIBERO fine-tuning support for the released `openbmb/MiniCPM-RobotManip` checkpoint.

The example loads the released MiniCPM-RobotManip VLM and pretrained 80-D GR00T action head through its shipped `trust_remote_code` implementation, then trains both components inside starVLA.

## Motivation

MiniCPM-RobotManip is already publicly released, but starVLA does not currently provide a training path for its unified 80-D action representation. This PR adds a compact LIBERO example with the correct EE6D mapping, horizon handling, image resolution, dtype, masking, and loss construction.

## Changes

- Add the `MiniCPMRobotManip` VLM4A framework, including FP32 action-head training loss and released-checkpoint loading.
- Add a LIBERO full-parameter training example, data registry, modality metadata installer, DeepSpeed config, launcher, and local HF checkpoint exporter.
- Add configurable state/action packing dtype and image size to the shared LeRobot loader, plus an opt-in incomplete-action-chunk filter. The defaults preserve existing behavior.
- Add focused tests for EE6D-to-80D mapping, loss masking, FP32/448px data packing, and complete action horizons.

The converted EE6D dataset is publicly available at https://huggingface.co/datasets/openbmb/MiniCPM-RobotManip-LIBERO.

## Testing

- [x] 8-GPU distributed training completed through step 1,500
- [x] Benchmark evaluation results for this fine-tuning recipe

| Benchmark | Metric | Result |
|-----------|--------|--------|
| LIBERO-10 | Success rate | 93.4 |
| LIBERO-Goal | Success rate | 98.8 |
| LIBERO-Object | Success rate | 99.6 |
| LIBERO-Spatial | Success rate | 94.6 |
| LIBERO overall | Mean success rate | 96.60 |


- **Checkpoint**: https://huggingface.co/openbmb/MiniCPM-RobotManip
- **Config**: `examples/modelExtensions/MiniCPM-RobotManip/train_files/minicpm_robotmanip_libero.yaml`
- **Reproduce**: `bash examples/modelExtensions/MiniCPM-RobotManip/train_files/run_libero_train.sh`

Focused validation:

```text
python -m unittest discover -s tests -p "test_minicpm_robotmanip.py" -v
# 4 tests passed

ruff check starVLA/model/framework/VLM4A/MiniCPMRobotManip.py tests/test_minicpm_robotmanip.py examples/modelExtensions/MiniCPM-RobotManip/train_files/data_registry/data_config.py examples/modelExtensions/MiniCPM-RobotManip/train_files/export_checkpoint.py examples/modelExtensions/MiniCPM-RobotManip/train_files/install_modality.py
# All checks passed
```

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules
- [x] Shared dataloader modification is limited to opt-in/configurable behavior required for precise long-horizon samples; existing defaults are preserved and focused tests are included
- [x] Public checkpoint: https://huggingface.co/openbmb/MiniCPM-RobotManip

## Notes

The reported 96.60 result is produced by this compact, single-dataset LIBERO recipe. The released generalist model uses a broader multi-embodiment post-training setup that is outside the scope of this upstream example; no improvement over the released model is claimed.