### PR TITLE
[fix] (VLA-Arena) Align evaluator image modalities with training config in VLA-Arena

### DIFF
--- a/examples/simBenchmarks/VLA-Arena/eval_files/eval_vla_arena.py
+++ b/examples/simBenchmarks/VLA-Arena/eval_files/eval_vla_arena.py
@@ -278,6 +278,7 @@ def _run_episode(
 
             # Rotate 180° to match training pre-processing
             img = np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
+            wrist_img = np.ascontiguousarray(obs["robot0_eye_in_hand_image"][::-1, ::-1])
             replay_images.append(img)
 
             state = np.concatenate((
@@ -287,7 +288,7 @@ def _run_episode(
             ))
 
             example_dict = {
-                "image": [img],
+                "image": [img, wrist_img],
                 "lang": effective_description,
             }
 


### PR DESCRIPTION
## Description

Fix the VLA-Arena evaluator to provide both the primary agent-view image and the wrist-camera image to the policy server.

The VLA-Arena training data configuration declares two visual modalities in [`examples/VLA-Arena/train_files/data_registry/data_config.py`](https://github.com/starVLA/starVLA/blob/starVLA/examples/VLA-Arena/train_files/data_registry/data_config.py):

```python
video_keys = [
    "video.primary_image",  # agentview camera
    "video.wrist_image",    # wrist camera
]
```

However, the evaluator only provided the primary agent-view image during inference. This train-test modality mismatch can lead to catastrophic policy failure. This PR aligns the evaluation input with the training contract by sending the images in the same `[primary, wrist]` order.

## Motivation

Models trained with the provided VLA-Arena data configuration receive two image blocks per sample. Supplying only the primary image during evaluation creates a train-evaluation modality mismatch:

```text
Training:   [primary image, wrist image]
Evaluation: [primary image]
```

This fix is isolated to the VLA-Arena evaluator and does not change the model implementation, policy server, training pipeline, or other benchmark integrations.

Related issue: N/A — the mismatch was identified while reproducing VLA-Arena evaluation results.

## Changes

- Read `robot0_eye_in_hand_image` from the VLA-Arena environment observation.
- Apply the same contiguous 180-degree image transformation used for the primary view.
- Send `[primary_image, wrist_image]` to the policy server, matching the order declared by `video_keys` during training.
- Keep replay-video rendering based on the primary agent-view image.

The core change is:

```python
img = np.ascontiguousarray(
    obs["agentview_image"][::-1, ::-1]
)

wrist_img = np.ascontiguousarray(
    obs["robot0_eye_in_hand_image"][::-1, ::-1]
)

example_dict = {
    "image": [img, wrist_img],
    "lang": effective_description,
}
```

## Testing

- [x] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| LangForce | Evaluation input | L0 SR | L1 SR | L2 SR |
|-----------|------------------|------:|------:|------:|
| Before fix | Primary view only | 0.0% | 0.0% | 0.0% |
| After fix | Primary + wrist views | 84.2% | 38.8% | 24.1% |

- **Checkpoint**: [LiamLian0727/LangForce_VLA_Arena](https://huggingface.co/LiamLian0727/LangForce_VLA_Arena)
- **Config**: `examples/VLA-Arena/train_files/starvla_cotrain_vla_arena.yaml`

##  Reproduce

Start the policy server from the starVLA root:

```bash
export PYTHONPATH=$(pwd):${PYTHONPATH}
CUDA_VISIBLE_DEVICES=0 python deployment/model_server/server_policy.py --ckpt_path /path/to/steps_50000_pytorch_model.pt --port 10093 --use_bf16
```

Run the VLA-Arena evaluator in the VLA-Arena environment:

```bash
python examples/VLA-Arena/eval_files/eval_vla_arena.py --args.pretrained-path /path/to/steps_50000_pytorch_model.pt --args.host 127.0.0.1 --args.port 10093 --args.task-suite-name safety_static_obstacles --args.task-level 0 --args.num-trials-per-task 20 --args.init-state-offset-random --args.save-video-mode none
```

## Type of Change

- [x] Bug fix (non-breaking)

## Checklist

- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/` 
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [x] If adding framework/benchmark: checkpoint uploaded to personal HF (public) 