### PR TITLE
fix: resolve image tag mismatch bug in dataloader

### DIFF
--- a/starVLA/dataloader/vlm_datasets.py
+++ b/starVLA/dataloader/vlm_datasets.py
@@ -141,14 +141,23 @@ def update_processor_pixels(processor, data_args):
 
 def _build_messages(item: Dict[str, Any], base_path: Path) -> List[Dict[str, Any]]:
     # Extract and normalize images and videos
-    images = item.get("image") or []
+    # Support both image/images and video/videos for inconsistent dataset metadata, convert to list uniformly.
+    images = item.get("images") or item.get("image") or []
     if isinstance(images, str):
         images = [images]
-
-    videos = item.get("video") or []
+        
+    videos = item.get("videos") or item.get("video") or []
     if isinstance(videos, str):
         videos = [videos]
 
+    # Check if at least one media exists
+    if not images and not videos:
+        raise ValueError(
+            "No valid image/video identifiers found. "
+            "This code only supports data tagged with 'image', 'images', 'video', 'videos'.\n"
+            "Example: 'please describe the picture <image>' or 'please describe the picture <images>'."
+        )
+    
     # Build media pools with absolute paths
     image_pool = [
         {"type": "image", "image": load_image(_make_abs_paths(base_path, img))} for img in images


### PR DESCRIPTION
During debugging with LLaVA-OneVision-COCO format data, tag inconsistency between dataloader (image) and dataset (images) caused accelerate data preloading error. Fixed field compatibility and added error prompt for invalid media tags.

## Motivation
I noticed that this can be quite confusing and frustrating for beginners or users who want to get the VLM training code running as quickly as possible, since it is an extremely hidden minor bug.
The official COCO dataset, after extraction, uses “images” as the semantic token embedded in the text, but the code was hard-coded to “image”, causing a mismatch. This led to frequent errors during dataset preloading in the upper-level Accelerate framework, which is very unfriendly for debugging and initial execution.
Therefore, I have revised the relevant logic so that specific error messages will be thrown when similar issues occur, making it easier for users and developers to troubleshoot.

## Changes
fixed the function：vlm_datasets._build_messages
Before:
"""line 144
    images = item.get("image") or []
    if isinstance(images, str):
        images = [images]

    videos = item.get("video") or []
    if isinstance(videos, str):
        videos = [videos]
"""line 150
Now:
"""line 144
# Support both image/images and video/videos for inconsistent dataset metadata, convert to list uniformly.
    images = item.get("images") or item.get("image") or []
    if isinstance(images, str):
        images = [images]
        
    videos = item.get("videos") or item.get("video") or []
    if isinstance(videos, str):
        videos = [videos]

    # Check if at least one media exists
    if not images and not videos:
        raise ValueError(
            "No valid image/video identifiers found. "
            "This code only supports data tagged with 'image', 'images', 'video', 'videos'.\n"
            "Example: 'please describe the picture <image>' or 'please describe the picture <images>'."
        )
""" line 160
