### PR TITLE
[fix] default QwenPI_v3 to legacy all-cross attention

### DIFF
--- a/starVLA/model/framework/VLM4A/QwenPI_v3.py
+++ b/starVLA/model/framework/VLM4A/QwenPI_v3.py
@@ -55,10 +55,7 @@ from starVLA.model.framework.share_tools import merge_framework_config, populate
 from starVLA.model.modules.action_model.LayerwiseFM_ActionHeader import LayerwiseFlowmatchingActionHead, get_action_model
 from starVLA.model.modules.vlm import get_vlm_model
 from starVLA.model.tools import FRAMEWORK_REGISTRY
-from starVLA.training.trainer_utils import initialize_overwatch
 from starVLA.training.trainer_utils.trainer_tools import resize_images
-
-logger = initialize_overwatch(__name__)
 
 # HuggingFace Default / LLaMa-2 IGNORE_INDEX (for labels)
 IGNORE_INDEX = -100
@@ -126,7 +123,14 @@ class QwenPI_v3DefaultConfig:
                 "action_dit_hidden_dim": 1024,
                 "dropout": 0.2,
                 "final_dropout": True,
-                "interleave_self_attention": True,
+                # A single mode switch: false is legacy all-cross, true is
+                # canonical interleaved self/cross attention.
+                # A checkpoint config containing this field overrides the
+                # default; for old HF releases, use the matching code snapshot.
+                "interleave_self_attention": False,
+                # QwenPI_v3 intentionally keeps the historical layer-wise
+                # all-cross-attention semantics by default, without changing
+                # defaults for other frameworks.
                 "norm_type": "ada_norm",
                 "positional_embeddings": None,
                 "attention_head_dim": 64,
@@ -148,6 +152,12 @@ class Qwen_PI_v3(baseframework):
       ``action_dit_hidden_dim`` before feeding the Action DiT.
     - Layer-wise cross-DiT flow-matching action head that attends to every
       selected VLM layer in parallel.
+
+    QwenPI_v3 defaults to the historical legacy all-cross-attention DiT
+    forward. Set ``interleave_self_attention=true`` only for a checkpoint
+    explicitly trained with the canonical interleaved forward. The historical
+    ``use_canonical_forward`` boolean remains accepted as a compatibility alias
+    for existing launchers and is mapped to the same single mode switch.
 
     Focus: predict a future action chunk conditioned on multi-view images
     and a natural-language instruction (with optional discretised state prefix).

--- a/starVLA/model/framework/base_framework.py
+++ b/starVLA/model/framework/base_framework.py
@@ -102,6 +102,19 @@ def build_framework(cfg): # The single entry point for building different model 
             f"Framework `{framework_id}` is not implemented. Available frameworks: {available}"
         )
 
+    # This applies to every evaluation model, not to one framework or one
+    # known compatibility issue: the repository is continuously updated, so a
+    # released HF checkpoint may correspond to an older code/config/eval
+    # snapshot. Reproduce it with the repository revision from its release or
+    # training time and the checkpoint's own configuration.
+    logger.warning(
+        "[StarVLA] Reproducibility notice: this repository is under active development. "
+        "The latest code may not exactly reproduce every previously released HF "
+        "checkpoint because code, configs, preprocessing, and evaluation behavior "
+        "can change over time. For exact reproduction, checkout the repository "
+        "revision from the checkpoint's release/training time and use its own config."
+    )
+
     model_class = FRAMEWORK_REGISTRY[framework_id]
     return model_class(cfg)
 

--- a/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit.py
+++ b/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Optional
 
 import torch
@@ -209,18 +208,21 @@ class DiT(ModelMixin, ConfigMixin):
         compute_dtype=torch.float32,
         final_dropout: bool = True,
         positional_embeddings: Optional[str] = "sinusoidal",
+        # This is the single forward-mode switch:
+        #   False -> legacy all-cross attention; True -> canonical interleaving.
+        # Released checkpoints may come from an older repository snapshot;
+        # use the checkpoint-time code/config when exact reproduction matters.
         interleave_self_attention=False,
-        use_canonical_forward: bool = True,  # False restores the legacy all-cross-attention forward (old checkpoints)
+        # Deprecated compatibility alias. The effective mode is represented by
+        # interleave_self_attention after this value is applied.
+        use_canonical_forward: Optional[bool] = None,
         cross_attention_dim: Optional[int] = None,
         **kwargs,
     ):
         super().__init__()
-        if not use_canonical_forward:
-            logging.getLogger(__name__).warning(
-                "use_canonical_forward=False: running the legacy all-cross-attention DiT forward. "
-                "Old checkpoints may have degraded performance due to state-conditioning issues. "
-                "Please retrain with the updated forward path when possible."
-            )
+        if use_canonical_forward is not None:
+            interleave_self_attention = bool(use_canonical_forward)
+        self._interleave_self_attention = bool(interleave_self_attention)
         self.attention_head_dim = attention_head_dim
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
         self.gradient_checkpointing = False
@@ -237,7 +239,7 @@ class DiT(ModelMixin, ConfigMixin):
         all_blocks = []
         for idx in range(self.config.num_layers):
 
-            use_self_attn = idx % 2 == 1 and interleave_self_attention
+            use_self_attn = idx % 2 == 1 and self._interleave_self_attention
             curr_cross_attention_dim = cross_attention_dim if not use_self_attn else None
 
             all_blocks += [
@@ -294,7 +296,7 @@ class DiT(ModelMixin, ConfigMixin):
 
         # Process through transformer blocks
         for idx, block in enumerate(self.transformer_blocks):
-            if idx % 2 == 1 and self.config.interleave_self_attention and self.config.use_canonical_forward:
+            if idx % 2 == 1 and self._interleave_self_attention:
                 hidden_states = block(
                     hidden_states,
                     attention_mask=None,


### PR DESCRIPTION
## Summary

- Make QwenPI_v3 default to the historical legacy all-cross DiT path.
- Use interleave_self_attention as the single effective mode switch; keep use_canonical_forward only as a compatibility alias.
- Add a common runtime reproducibility warning for all framework evaluations. It explains that the repository is continuously updated and historical HF checkpoints should be reproduced with the repository revision from the checkpoint release/training time and its own configuration.
- Propagate encoder_attention_mask through normal and realtime/RTC LayerwiseFM inference paths.

## Scope

- No Hugging Face checkpoint was modified.
- No README, launcher, or test files are changed.

## Validation

- Python compilation and git diff checks passed.
- Full tests were not run in this environment because torch/omegaconf are unavailable.