### PR TITLE
[framework] add QwenPI_v4 fused self-cross DiT

### DIFF
--- a/starVLA/model/framework/VLM4A/QwenPI_v4.py
+++ b/starVLA/model/framework/VLM4A/QwenPI_v4.py
@@ -1,0 +1,106 @@
+"""QwenPI_v4: Qwen VLM with a fixed dual-attention layer-wise DiT.
+
+QwenPI_v4 keeps the QwenPI_v3 VLM input, layer selection, projectors, flow
+matching loss, sampler, and VLM-token masking.  Its action head is separate:
+every DiT block always performs self-attention followed by VLM cross-attention
+and then an FFN.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch.nn as nn
+
+from starVLA.model.framework.base_framework import baseframework
+from starVLA.model.framework.share_tools import merge_framework_config, populate_layerwise_dit_cfg
+from starVLA.model.framework.VLM4A.QwenPI_v3 import (
+    QwenPI_v3DefaultConfig,
+    Qwen_PI_v3,
+)
+from starVLA.model.modules.action_model.LayerwiseFM_ActionHeader_v4 import (
+    LayerwiseFlowmatchingActionHeadV4,
+    get_action_model_v4,
+)
+from starVLA.model.modules.vlm import get_vlm_model
+from starVLA.model.tools import FRAMEWORK_REGISTRY
+
+
+@dataclass
+class QwenPI_v4DefaultConfig(QwenPI_v3DefaultConfig):
+    """Defaults for the fixed-topology QwenPI_v4 action head."""
+
+    name: str = "QwenPI_v4"
+    action_model: dict = field(
+        default_factory=lambda: {
+            "action_model_type": "LayerwiseFM_v4",
+            "action_dim": 7,
+            "state_dim": 7,
+            "action_horizon": 16,
+            "repeated_diffusion_steps": 2,
+            "num_inference_timesteps": 4,
+            "add_pos_embed": True,
+            "max_seq_len": 1024,
+            "num_target_vision_tokens": 32,
+            "noise_beta_alpha": 1.5,
+            "noise_beta_beta": 1.0,
+            "noise_s": 0.999,
+            "num_timestep_buckets": 1000,
+            "diffusion_model_cfg": {
+                "action_dit_hidden_dim": 1024,
+                "dropout": 0.2,
+                "final_dropout": True,
+                "norm_type": "ada_norm",
+                "positional_embeddings": None,
+                "attention_head_dim": 64,
+            },
+        }
+    )
+
+
+@FRAMEWORK_REGISTRY.register("QwenPI_v4")
+class Qwen_PI_v4(Qwen_PI_v3):
+    """Qwen VLM + independent fixed self/cross-attention DiT action head."""
+
+    def __init__(self, config: Optional[dict] = None, **kwargs) -> None:
+        # QwenPI_v3's methods are reused for the VLM-side data flow, but its
+        # constructor is intentionally not called because it would build the
+        # legacy action head before we can install the v4 head.
+        baseframework.__init__(self)
+        self.config = merge_framework_config(QwenPI_v4DefaultConfig, config)
+        self.qwen_vl_interface = get_vlm_model(config=self.config)
+
+        vlm_hf_cfg = self.qwen_vl_interface.model.config
+        text_cfg = getattr(vlm_hf_cfg, "text_config", vlm_hf_cfg)
+        num_vl_layers = int(text_cfg.num_hidden_layers)
+        llm_hidden_size = int(vlm_hf_cfg.hidden_size)
+        self.config.framework.qwenvl.vl_hidden_dim = llm_hidden_size
+        self.config.framework.qwenvl.num_vl_layers = num_vl_layers
+
+        diffusion_model_cfg = self.config.framework.action_model.diffusion_model_cfg
+        action_dit_hidden_dim = diffusion_model_cfg.get("action_dit_hidden_dim", None)
+        if action_dit_hidden_dim is None:
+            action_dit_hidden_dim = llm_hidden_size
+        self.action_dit_hidden_dim = int(action_dit_hidden_dim)
+        populate_layerwise_dit_cfg(
+            self.config,
+            dit_hidden_dim=self.action_dit_hidden_dim,
+            num_dit_layers=num_vl_layers,
+        )
+
+        self.action_model: LayerwiseFlowmatchingActionHeadV4 = get_action_model_v4(config=self.config)
+        self.num_action_dit_layers = len(self.action_model.model.transformer_blocks)
+
+        self.project_layers = nn.ModuleList(
+            [
+                (
+                    nn.Identity()
+                    if llm_hidden_size == self.action_dit_hidden_dim
+                    else nn.Sequential(
+                        nn.LayerNorm(llm_hidden_size),
+                        nn.Linear(llm_hidden_size, self.action_dit_hidden_dim),
+                    )
+                )
+                for _ in range(self.num_action_dit_layers)
+            ]
+        )
+        self.action_horizon = int(self.config.framework.action_model.action_horizon)

--- a/starVLA/model/framework/VLM4A/QwenPI_v4.py
+++ b/starVLA/model/framework/VLM4A/QwenPI_v4.py
@@ -1,9 +1,9 @@
-"""QwenPI_v4: Qwen VLM with a fixed dual-attention layer-wise DiT.
+"""QwenPI_v4: Qwen VLM with a fused self/cross-attention layer-wise DiT.
 
 QwenPI_v4 keeps the QwenPI_v3 VLM input, layer selection, projectors, flow
 matching loss, sampler, and VLM-token masking.  Its action head is separate:
-every DiT block always performs self-attention followed by VLM cross-attention
-and then an FFN.
+every DiT block uses action/state tokens as queries and the concatenation of
+action/state and VLM tokens as keys/values, followed by an FFN.
 """
 
 from dataclasses import dataclass, field
@@ -59,7 +59,7 @@ class QwenPI_v4DefaultConfig(QwenPI_v3DefaultConfig):
 
 @FRAMEWORK_REGISTRY.register("QwenPI_v4")
 class Qwen_PI_v4(Qwen_PI_v3):
-    """Qwen VLM + independent fixed self/cross-attention DiT action head."""
+    """Qwen VLM + independent fused self/cross-attention DiT action head."""
 
     def __init__(self, config: Optional[dict] = None, **kwargs) -> None:
         # QwenPI_v3's methods are reused for the VLM-side data flow, but its

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
@@ -1,4 +1,4 @@
-"""QwenPI_v4 action head backed by the fixed dual-attention DiT."""
+"""QwenPI_v4 action head backed by the fused self/cross-attention DiT."""
 
 import torch
 from torch import nn
@@ -15,7 +15,7 @@ from starVLA.model.modules.action_model.flow_matching_head.cross_attention_dit_v
 
 
 class LayerwiseFlowmatchingActionHeadV4(LayerwiseFlowmatchingActionHead):
-    """Layer-wise flow-matching head with QwenPI_v4's fixed DiT.
+    """Layer-wise flow-matching head with QwenPI_v4's fused DiT.
 
     The sampling and loss code is shared with the existing layer-wise head,
     while construction is intentionally separate so QwenPI_v4 cannot fall

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
@@ -1,0 +1,100 @@
+"""QwenPI_v4 action head backed by the fixed dual-attention DiT."""
+
+from torch import nn
+
+from starVLA.model.modules.action_model.LayerwiseFM_ActionHeader import (
+    ActionEncoder,
+    DiTConfig,
+    LayerwiseFlowmatchingActionHead,
+    MLP,
+)
+from starVLA.model.modules.action_model.flow_matching_head.cross_attention_dit_v4 import (
+    QwenPIv4DiT,
+)
+
+
+class LayerwiseFlowmatchingActionHeadV4(LayerwiseFlowmatchingActionHead):
+    """Layer-wise flow-matching head with QwenPI_v4's fixed DiT.
+
+    The sampling and loss code is shared with the existing layer-wise head,
+    while construction is intentionally separate so QwenPI_v4 cannot fall
+    back to the legacy DiT or its forward-mode switches.
+    """
+
+    def __init__(self, global_config, **kwargs):
+        # This class intentionally initializes nn.Module directly.  The parent
+        # implementation hard-codes the legacy DiT; the rest of its methods
+        # are architecture-agnostic and are reused below.
+        nn.Module.__init__(self)
+
+        action_config = global_config.framework.action_model
+        diffusion_model_cfg = action_config.diffusion_model_cfg
+        for key, value in DiTConfig.items():
+            if diffusion_model_cfg.get(key, None) is None:
+                diffusion_model_cfg[key] = value
+
+        # These are framework hints for old DiT variants, not v4 controls.
+        # Drop them if a copied/legacy YAML happens to carry them so v4 always
+        # has one fixed attention topology.
+        ignored_legacy_keys = {
+            "action_dit_hidden_dim",
+            "interleave_self_attention",
+            "use_canonical_forward",
+        }
+        diffusion_model_cfg_kwargs = {
+            key: value
+            for key, value in diffusion_model_cfg.items()
+            if key not in ignored_legacy_keys
+        }
+
+        self.input_embedding_dim = diffusion_model_cfg_kwargs["input_embedding_dim"]
+        self.model = QwenPIv4DiT(**diffusion_model_cfg_kwargs)
+        self.dit_out_hidden_size = self.input_embedding_dim
+        self.action_dim = action_config.action_dim
+        self.action_horizon = int(action_config.action_horizon)
+        self.num_inference_timesteps = action_config.num_inference_timesteps
+
+        self.state_encoder = (
+            MLP(
+                input_dim=action_config.state_dim,
+                output_dim=self.input_embedding_dim,
+            )
+            if action_config.state_dim
+            else None
+        )
+        self.action_encoder = ActionEncoder(
+            action_dim=action_config.action_dim,
+            hidden_size=self.input_embedding_dim,
+        )
+        self.action_decoder = MLP(
+            input_dim=self.input_embedding_dim,
+            hidden_dim=1024,
+            output_dim=self.action_dim,
+        )
+        self.future_tokens = nn.Embedding(
+            action_config.num_target_vision_tokens,
+            self.input_embedding_dim,
+        )
+        nn.init.normal_(self.future_tokens.weight, mean=0.0, std=0.02)
+
+        if action_config.add_pos_embed:
+            self.position_embedding = nn.Embedding(
+                action_config.max_seq_len,
+                self.input_embedding_dim,
+            )
+            nn.init.normal_(self.position_embedding.weight, mean=0.0, std=0.02)
+
+        from torch.distributions import Beta
+
+        self.beta_dist = Beta(
+            action_config.noise_beta_alpha,
+            action_config.noise_beta_beta,
+        )
+        self.num_timestep_buckets = action_config.num_timestep_buckets
+        self.config = action_config
+
+
+def get_action_model_v4(config=None):
+    """Build the fixed-topology QwenPI_v4 action head."""
+
+    return LayerwiseFlowmatchingActionHeadV4(global_config=config)

--- a/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
+++ b/starVLA/model/modules/action_model/LayerwiseFM_ActionHeader_v4.py
@@ -1,5 +1,6 @@
 """QwenPI_v4 action head backed by the fixed dual-attention DiT."""
 
+import torch
 from torch import nn
 
 from starVLA.model.modules.action_model.LayerwiseFM_ActionHeader import (
@@ -92,6 +93,75 @@ class LayerwiseFlowmatchingActionHeadV4(LayerwiseFlowmatchingActionHead):
         )
         self.num_timestep_buckets = action_config.num_timestep_buckets
         self.config = action_config
+
+    def _normalize_encoder_states(self, vl_embs):
+        """Accept QwenPI layer-wise states and GR00T single-layer states.
+
+        QwenPI supplies one encoder hidden-state tensor per DiT block.  The
+        GR00T action head supplies one tensor (the final VLM layer), which is
+        reused by every DiT block.  Keep the broadcast as a list of references
+        so the DiT sees the same fixed per-block interface without copying the
+        encoder activations.
+        """
+        if isinstance(vl_embs, torch.Tensor):
+            return [vl_embs] * len(self.model.transformer_blocks)
+        if isinstance(vl_embs, (list, tuple)):
+            return list(vl_embs)
+        raise TypeError(
+            "QwenPI_v4 expects VLM encoder states as a tensor or a list/tuple "
+            f"of tensors, got {type(vl_embs).__name__}."
+        )
+
+    def forward(
+        self,
+        vl_embs_list,
+        actions: torch.Tensor,
+        state: torch.Tensor = None,
+        encoder_attention_mask=None,
+    ):
+        return super().forward(
+            self._normalize_encoder_states(vl_embs_list),
+            actions,
+            state,
+            encoder_attention_mask=encoder_attention_mask,
+        )
+
+    @torch.no_grad()
+    def predict_action(
+        self,
+        vl_embs_list,
+        state: torch.Tensor = None,
+        encoder_attention_mask=None,
+    ) -> torch.Tensor:
+        return super().predict_action(
+            self._normalize_encoder_states(vl_embs_list),
+            state,
+            encoder_attention_mask=encoder_attention_mask,
+        )
+
+    def predict_action_realtime(
+        self,
+        vl_embs_list,
+        state: torch.Tensor = None,
+        prev_action_chunk: torch.Tensor = None,
+        inference_delay: int = 1,
+        mode: str = "pigdm",
+        suffix_length: int | None = None,
+        prefix_attention_schedule: str = "exp",
+        max_guidance_weight: float = 10.0,
+        encoder_attention_mask=None,
+    ) -> torch.Tensor:
+        return super().predict_action_realtime(
+            self._normalize_encoder_states(vl_embs_list),
+            state,
+            prev_action_chunk,
+            inference_delay,
+            mode,
+            suffix_length,
+            prefix_attention_schedule,
+            max_guidance_weight,
+            encoder_attention_mask=encoder_attention_mask,
+        )
 
 
 def get_action_model_v4(config=None):

--- a/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit_v4.py
+++ b/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit_v4.py
@@ -2,17 +2,20 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The fixed dual-attention DiT used by :mod:`QwenPI_v4`.
+"""The fused self/cross-attention DiT used by :mod:`QwenPI_v4`.
 
 This module deliberately has its own implementation instead of extending the
-legacy DiT.  A QwenPI_v4 transformer block always runs the same sequence:
+legacy DiT.  A QwenPI_v4 transformer block uses action/state tokens as the
+query and concatenates them with the VLM tokens for the key/value sequence:
 
-    self-attention -> VLM cross-attention -> feed-forward
+    query = action/state tokens
+    key/value = [action/state tokens, VLM tokens]
 
-There is no interleaving/mode flag in this implementation.  The
-``encoder_attention_mask`` is passed to the VLM cross-attention in every
-block; the self-attention has its own optional mask and never consumes the
-VLM encoder mask.
+This fuses action-token self-attention and VLM cross-attention into one
+attention operation per block.  The action-token portion of the key/value
+mask is all valid, while the VLM portion uses ``encoder_attention_mask``.
+There is no interleaving/mode flag in this implementation and the VLM model
+itself is not changed.
 """
 
 from typing import Optional
@@ -72,7 +75,7 @@ class QwenPIv4AdaLayerNorm(nn.Module):
 
 
 class QwenPIv4TransformerBlock(nn.Module):
-    """One fixed self-attention + cross-attention + FFN transformer block."""
+    """One fused action/VLM attention block followed by an FFN."""
 
     def __init__(
         self,
@@ -125,26 +128,14 @@ class QwenPIv4TransformerBlock(nn.Module):
                 elementwise_affine=norm_elementwise_affine,
             )
 
-        # This attention is always self-attention.  In particular, it never
-        # receives encoder_attention_mask from the VLM.
-        self.self_attn = Attention(
-            query_dim=dim,
-            heads=num_attention_heads,
-            dim_head=attention_head_dim,
-            dropout=dropout,
-            bias=attention_bias,
-            cross_attention_dim=None,
-            upcast_attention=upcast_attention,
-            out_bias=attention_out_bias,
+        # A single cross-attention module receives action/state tokens and VLM
+        # tokens as its KV sequence.  If a GR00T-style configuration keeps a
+        # different cross-attention input dimension, project action/state KV
+        # tokens to that dimension before concatenation.
+        self.action_kv_proj = (
+            nn.Identity() if cross_attention_dim == dim else nn.Linear(dim, cross_attention_dim)
         )
-
-        self.norm2 = nn.LayerNorm(
-            dim,
-            eps=norm_eps,
-            elementwise_affine=norm_elementwise_affine,
-        )
-        # This attention is always VLM cross-attention.
-        self.cross_attn = Attention(
+        self.fused_cross_attn = Attention(
             query_dim=dim,
             heads=num_attention_heads,
             dim_head=attention_head_dim,
@@ -173,7 +164,6 @@ class QwenPIv4TransformerBlock(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        self_attention_mask: Optional[torch.Tensor] = None,
         encoder_hidden_states: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         temb: Optional[torch.Tensor] = None,
@@ -181,7 +171,9 @@ class QwenPIv4TransformerBlock(nn.Module):
         if encoder_hidden_states is None:
             raise ValueError("QwenPI_v4 requires VLM encoder states in every transformer block.")
 
-        # 1. Self-attention over action/state/future tokens.
+        # 1. Fused attention: action/state queries attend to both action/state
+        # keys and valid VLM keys.  The action-token mask is deliberately all
+        # ones; only VLM padding positions are masked out.
         if self.norm_type == "ada_norm":
             norm_hidden_states = self.norm1(hidden_states, temb)
         else:
@@ -189,37 +181,67 @@ class QwenPIv4TransformerBlock(nn.Module):
         if self.pos_embed is not None:
             norm_hidden_states = self.pos_embed(norm_hidden_states)
 
-        self_output = self.self_attn(
+        action_kv = self.action_kv_proj(norm_hidden_states)
+        fused_encoder_hidden_states = torch.cat(
+            [action_kv, encoder_hidden_states],
+            dim=1,
+        )
+        fused_attention_mask = self._build_fused_attention_mask(
+            encoder_attention_mask,
+            batch_size=hidden_states.shape[0],
+            action_length=hidden_states.shape[1],
+            device=hidden_states.device,
+        )
+        attn_output = self.fused_cross_attn(
             norm_hidden_states,
-            encoder_hidden_states=None,
-            attention_mask=self_attention_mask,
+            encoder_hidden_states=fused_encoder_hidden_states,
+            attention_mask=fused_attention_mask,
         )
         if self.final_dropout is not None:
-            self_output = self.final_dropout(self_output)
-        hidden_states = hidden_states + self_output
+            attn_output = self.final_dropout(attn_output)
+        hidden_states = hidden_states + attn_output
 
-        # 2. Cross-attention over the VLM tokens.  The VLM token mask is kept
-        # separate from the self-attention mask and is applied at every layer.
-        norm_hidden_states = self.norm2(hidden_states)
-        cross_output = self.cross_attn(
-            norm_hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            attention_mask=encoder_attention_mask,
-        )
-        if self.final_dropout is not None:
-            cross_output = self.final_dropout(cross_output)
-        hidden_states = hidden_states + cross_output
-
-        # 3. Feed-forward network.
+        # 2. Feed-forward network.
         ff_output = self.ff(self.norm3(hidden_states))
         hidden_states = hidden_states + ff_output
         if hidden_states.ndim == 4:
             hidden_states = hidden_states.squeeze(1)
         return hidden_states
 
+    @staticmethod
+    def _build_fused_attention_mask(
+        encoder_attention_mask: Optional[torch.Tensor],
+        batch_size: int,
+        action_length: int,
+        device: torch.device,
+    ) -> Optional[torch.Tensor]:
+        """Prefix the VLM padding mask with an all-valid action-token mask."""
+        if encoder_attention_mask is None:
+            return None
+        if encoder_attention_mask.ndim != 2:
+            raise ValueError(
+                "QwenPI_v4 fused attention expects a 2D VLM padding mask "
+                "with shape (batch, vlm_tokens)."
+            )
+        if encoder_attention_mask.shape[0] != batch_size:
+            raise ValueError(
+                "QwenPI_v4 fused attention mask batch size does not match "
+                f"hidden_states: {encoder_attention_mask.shape[0]} vs {batch_size}."
+            )
+        action_attention_mask = torch.ones(
+            batch_size,
+            action_length,
+            dtype=encoder_attention_mask.dtype,
+            device=device,
+        )
+        return torch.cat(
+            [action_attention_mask, encoder_attention_mask.to(device=device)],
+            dim=1,
+        )
+
 
 class QwenPIv4DiT(ModelMixin, ConfigMixin):
-    """Independent fixed dual-attention DiT for QwenPI_v4."""
+    """Independent fused self/cross-attention DiT for QwenPI_v4."""
 
     _supports_gradient_checkpointing = True
 
@@ -297,15 +319,15 @@ class QwenPIv4DiT(ModelMixin, ConfigMixin):
         encoder_hidden_states: torch.Tensor,
         timestep: Optional[torch.LongTensor] = None,
         return_all_hidden_states: bool = False,
-        self_attention_mask: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         return_pre_output: bool = False,
     ):
-        """Run every block with self-attention followed by VLM cross-attention.
+        """Run every block with fused action/VLM attention.
 
         ``encoder_hidden_states`` may be one tensor shared by all blocks or a
         list/tuple with one VLM hidden state tensor per block.  In both cases,
-        ``encoder_attention_mask`` is forwarded to every block's cross-attn.
+        ``encoder_attention_mask`` masks only the VLM segment of every block's
+        concatenated key/value sequence.  Action/state keys are always valid.
         """
         if timestep is None:
             raise ValueError("QwenPI_v4 requires a timestep tensor.")
@@ -331,7 +353,6 @@ class QwenPIv4DiT(ModelMixin, ConfigMixin):
             )
             hidden_states = block(
                 hidden_states,
-                self_attention_mask=self_attention_mask,
                 encoder_hidden_states=block_encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
                 temb=temb,

--- a/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit_v4.py
+++ b/starVLA/model/modules/action_model/flow_matching_head/cross_attention_dit_v4.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The fixed dual-attention DiT used by :mod:`QwenPI_v4`.
+
+This module deliberately has its own implementation instead of extending the
+legacy DiT.  A QwenPI_v4 transformer block always runs the same sequence:
+
+    self-attention -> VLM cross-attention -> feed-forward
+
+There is no interleaving/mode flag in this implementation.  The
+``encoder_attention_mask`` is passed to the VLM cross-attention in every
+block; the self-attention has its own optional mask and never consumes the
+VLM encoder mask.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from diffusers import ConfigMixin, ModelMixin
+from diffusers.configuration_utils import register_to_config
+from diffusers.models.attention import Attention, FeedForward
+from diffusers.models.embeddings import (
+    SinusoidalPositionalEmbedding,
+    TimestepEmbedding,
+    Timesteps,
+)
+from torch import nn
+
+
+class QwenPIv4TimestepEncoder(nn.Module):
+    def __init__(self, embedding_dim: int, compute_dtype=torch.float32):
+        super().__init__()
+        self.time_proj = Timesteps(
+            num_channels=256,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=1,
+        )
+        self.timestep_embedder = TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+        )
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        dtype = next(self.parameters()).dtype
+        timesteps_proj = self.time_proj(timesteps).to(dtype)
+        return self.timestep_embedder(timesteps_proj)
+
+
+class QwenPIv4AdaLayerNorm(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        norm_elementwise_affine: bool = False,
+        norm_eps: float = 1e-5,
+    ):
+        super().__init__()
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(embedding_dim, 2 * embedding_dim)
+        self.norm = nn.LayerNorm(
+            embedding_dim,
+            eps=norm_eps,
+            elementwise_affine=norm_elementwise_affine,
+        )
+
+    def forward(self, hidden_states: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        scale, shift = self.linear(self.silu(temb)).chunk(2, dim=1)
+        hidden_states = self.norm(hidden_states)
+        return hidden_states * (1 + scale[:, None]) + shift[:, None]
+
+
+class QwenPIv4TransformerBlock(nn.Module):
+    """One fixed self-attention + cross-attention + FFN transformer block."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        dropout: float = 0.0,
+        cross_attention_dim: Optional[int] = None,
+        activation_fn: str = "geglu",
+        attention_bias: bool = False,
+        upcast_attention: bool = False,
+        norm_elementwise_affine: bool = True,
+        norm_type: str = "ada_norm",
+        norm_eps: float = 1e-5,
+        final_dropout: bool = False,
+        positional_embeddings: Optional[str] = None,
+        num_positional_embeddings: Optional[int] = None,
+        ff_inner_dim: Optional[int] = None,
+        ff_bias: bool = True,
+        attention_out_bias: bool = True,
+    ):
+        super().__init__()
+        if cross_attention_dim is None:
+            cross_attention_dim = dim
+        if positional_embeddings and num_positional_embeddings is None:
+            raise ValueError(
+                "num_positional_embeddings is required when positional_embeddings is set."
+            )
+
+        self.norm_type = norm_type
+        self.pos_embed = (
+            SinusoidalPositionalEmbedding(
+                dim,
+                max_seq_length=num_positional_embeddings,
+            )
+            if positional_embeddings == "sinusoidal"
+            else None
+        )
+
+        if norm_type == "ada_norm":
+            self.norm1 = QwenPIv4AdaLayerNorm(
+                dim,
+                norm_elementwise_affine=norm_elementwise_affine,
+                norm_eps=norm_eps,
+            )
+        else:
+            self.norm1 = nn.LayerNorm(
+                dim,
+                eps=norm_eps,
+                elementwise_affine=norm_elementwise_affine,
+            )
+
+        # This attention is always self-attention.  In particular, it never
+        # receives encoder_attention_mask from the VLM.
+        self.self_attn = Attention(
+            query_dim=dim,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            dropout=dropout,
+            bias=attention_bias,
+            cross_attention_dim=None,
+            upcast_attention=upcast_attention,
+            out_bias=attention_out_bias,
+        )
+
+        self.norm2 = nn.LayerNorm(
+            dim,
+            eps=norm_eps,
+            elementwise_affine=norm_elementwise_affine,
+        )
+        # This attention is always VLM cross-attention.
+        self.cross_attn = Attention(
+            query_dim=dim,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            dropout=dropout,
+            bias=attention_bias,
+            cross_attention_dim=cross_attention_dim,
+            upcast_attention=upcast_attention,
+            out_bias=attention_out_bias,
+        )
+
+        self.norm3 = nn.LayerNorm(
+            dim,
+            eps=norm_eps,
+            elementwise_affine=norm_elementwise_affine,
+        )
+        self.ff = FeedForward(
+            dim,
+            dropout=dropout,
+            activation_fn=activation_fn,
+            final_dropout=final_dropout,
+            inner_dim=ff_inner_dim,
+            bias=ff_bias,
+        )
+        self.final_dropout = nn.Dropout(dropout) if final_dropout else None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        self_attention_mask: Optional[torch.Tensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if encoder_hidden_states is None:
+            raise ValueError("QwenPI_v4 requires VLM encoder states in every transformer block.")
+
+        # 1. Self-attention over action/state/future tokens.
+        if self.norm_type == "ada_norm":
+            norm_hidden_states = self.norm1(hidden_states, temb)
+        else:
+            norm_hidden_states = self.norm1(hidden_states)
+        if self.pos_embed is not None:
+            norm_hidden_states = self.pos_embed(norm_hidden_states)
+
+        self_output = self.self_attn(
+            norm_hidden_states,
+            encoder_hidden_states=None,
+            attention_mask=self_attention_mask,
+        )
+        if self.final_dropout is not None:
+            self_output = self.final_dropout(self_output)
+        hidden_states = hidden_states + self_output
+
+        # 2. Cross-attention over the VLM tokens.  The VLM token mask is kept
+        # separate from the self-attention mask and is applied at every layer.
+        norm_hidden_states = self.norm2(hidden_states)
+        cross_output = self.cross_attn(
+            norm_hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_mask=encoder_attention_mask,
+        )
+        if self.final_dropout is not None:
+            cross_output = self.final_dropout(cross_output)
+        hidden_states = hidden_states + cross_output
+
+        # 3. Feed-forward network.
+        ff_output = self.ff(self.norm3(hidden_states))
+        hidden_states = hidden_states + ff_output
+        if hidden_states.ndim == 4:
+            hidden_states = hidden_states.squeeze(1)
+        return hidden_states
+
+
+class QwenPIv4DiT(ModelMixin, ConfigMixin):
+    """Independent fixed dual-attention DiT for QwenPI_v4."""
+
+    _supports_gradient_checkpointing = True
+
+    @register_to_config
+    def __init__(
+        self,
+        num_attention_heads: int = 8,
+        attention_head_dim: int = 64,
+        output_dim: int = 26,
+        num_layers: int = 12,
+        dropout: float = 0.1,
+        attention_bias: bool = True,
+        activation_fn: str = "gelu-approximate",
+        num_embeds_ada_norm: Optional[int] = 1000,
+        upcast_attention: bool = False,
+        norm_type: str = "ada_norm",
+        norm_elementwise_affine: bool = False,
+        norm_eps: float = 1e-5,
+        max_num_positional_embeddings: int = 512,
+        compute_dtype=torch.float32,
+        final_dropout: bool = True,
+        positional_embeddings: Optional[str] = "sinusoidal",
+        input_embedding_dim: Optional[int] = None,
+        cross_attention_dim: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.inner_dim = num_attention_heads * attention_head_dim
+        if input_embedding_dim is not None and int(input_embedding_dim) != self.inner_dim:
+            raise ValueError(
+                "QwenPI_v4 diffusion_model_cfg.input_embedding_dim must equal "
+                "num_attention_heads * attention_head_dim."
+            )
+        if cross_attention_dim is None:
+            cross_attention_dim = self.inner_dim
+
+        self.gradient_checkpointing = False
+        self.timestep_encoder = QwenPIv4TimestepEncoder(
+            embedding_dim=self.inner_dim,
+            compute_dtype=compute_dtype,
+        )
+        self.transformer_blocks = nn.ModuleList(
+            [
+                QwenPIv4TransformerBlock(
+                    dim=self.inner_dim,
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    dropout=dropout,
+                    cross_attention_dim=cross_attention_dim,
+                    activation_fn=activation_fn,
+                    attention_bias=attention_bias,
+                    upcast_attention=upcast_attention,
+                    norm_type=norm_type,
+                    norm_elementwise_affine=norm_elementwise_affine,
+                    norm_eps=norm_eps,
+                    positional_embeddings=positional_embeddings,
+                    num_positional_embeddings=max_num_positional_embeddings,
+                    final_dropout=final_dropout,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.norm_out = nn.LayerNorm(self.inner_dim, elementwise_affine=False, eps=1e-6)
+        self.proj_out_1 = nn.Linear(self.inner_dim, 2 * self.inner_dim)
+        self.proj_out_2 = nn.Linear(self.inner_dim, output_dim)
+        print(
+            "Total number of QwenPIv4DiT parameters: ",
+            sum(p.numel() for p in self.parameters() if p.requires_grad),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: Optional[torch.LongTensor] = None,
+        return_all_hidden_states: bool = False,
+        self_attention_mask: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        return_pre_output: bool = False,
+    ):
+        """Run every block with self-attention followed by VLM cross-attention.
+
+        ``encoder_hidden_states`` may be one tensor shared by all blocks or a
+        list/tuple with one VLM hidden state tensor per block.  In both cases,
+        ``encoder_attention_mask`` is forwarded to every block's cross-attn.
+        """
+        if timestep is None:
+            raise ValueError("QwenPI_v4 requires a timestep tensor.")
+
+        temb = self.timestep_encoder(timestep)
+        hidden_states = hidden_states.contiguous()
+        is_layerwise_encoder = isinstance(encoder_hidden_states, (list, tuple))
+        if is_layerwise_encoder:
+            if len(encoder_hidden_states) != len(self.transformer_blocks):
+                raise ValueError(
+                    "QwenPI_v4 expects one layer-wise VLM encoder state per DiT block: "
+                    f"got {len(encoder_hidden_states)} states for "
+                    f"{len(self.transformer_blocks)} blocks."
+                )
+            encoder_hidden_states = [state.contiguous() for state in encoder_hidden_states]
+        else:
+            encoder_hidden_states = encoder_hidden_states.contiguous()
+
+        all_hidden_states = [hidden_states]
+        for idx, block in enumerate(self.transformer_blocks):
+            block_encoder_hidden_states = (
+                encoder_hidden_states[idx] if is_layerwise_encoder else encoder_hidden_states
+            )
+            hidden_states = block(
+                hidden_states,
+                self_attention_mask=self_attention_mask,
+                encoder_hidden_states=block_encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                temb=temb,
+            )
+            all_hidden_states.append(hidden_states)
+
+        if return_pre_output:
+            if return_all_hidden_states:
+                return hidden_states, all_hidden_states
+            return hidden_states
+
+        shift, scale = self.proj_out_1(F.silu(temb)).chunk(2, dim=1)
+        hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[:, None]
+        output = self.proj_out_2(hidden_states)
+        if return_all_hidden_states:
+            return output, all_hidden_states
+        return output


### PR DESCRIPTION
## Summary
- add an independent QwenPI_v4 action DiT implementation
- fuse action/state self-attention and VLM cross-attention into one attention call per DiT block
- build the KV mask as `[all-valid action/state keys, VLM encoder padding mask]`
- accept both QwenPI layer-wise encoder states and GR00T-style single-layer encoder states
- keep QwenPI/QwenPI_v3 and their checkpoint paths unchanged

## Validation
- `py_compile` passes for the three new modules
- constructed and ran the fused v4 DiT on 4090-01
- verified masked VLM tokens do not affect the output
- verified the action/state mask prefix is fully valid
- verified list input, single-tensor GR00T input, cross-dimension projection, action loss, and sampler

This is intentionally a separate framework/topology; existing QwenPI_v3 checkpoints are not being converted. The fused attention is contained inside DiT and does not modify the VLM forward.