### PR TITLE
feat(sim): add RoboDojo benchmark integration via XPolicyLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ In StarVLA (also a pun on "start VLA" ),  each functional component (model, data
 
 > **💡 Tip:** Files under any `**/bar/` directory are git-ignored, so you can place your custom scripts there (e.g., `examples/simBenchmarks/LIBERO/train_files/bar/my_train.sh`) without polluting the repo.
 
+**[2026/08/09]** 🤖 StarVLA now supports [RoboDojo through XPolicyLab](examples/simBenchmarks/RoboDojo). The example provides training recipes for the official RoboDojo dataset and a path-based entry point for evaluating the released checkpoints with XPolicyLab.
+
 **[2026/06/22]** 🔥 We are creating a [StarVLA Contributors Group](https://github.com/starVLA/starVLA/issues/393) to make contributor communication easier and discuss contributor list before each release. Welcome everyone to help maintain StarVLA's open-source infrastructure together.
 
 **[2026/05/30]** 🔥 StarVLA now supports [VLA training with **Qwen-series backbones** on **Ascend NPU**](https://github.com/starVLA/starVLA/pull/336). See the [related discussion](https://github.com/starVLA/starVLA/issues/341) for details and feedback.
@@ -139,6 +141,7 @@ Achieve **state-of-the-art (SOTA) performance** on a variety of benchmarks, as f
 - [x] **DOMINO**
 - [x] **BEHAVIOR**
 - [x] **Calvin**
+- [x] **RoboDojo**
 - [ ] **SO101**
 - [ ] **RLBench**
 

--- a/examples/simBenchmarks/RoboDojo/README.md
+++ b/examples/simBenchmarks/RoboDojo/README.md
@@ -1,51 +1,33 @@
-# RoboDojo via XPolicyLab
+# RoboDojo
 
-StarVLA supports [RoboDojo](https://github.com/RoboDojo-Benchmark/RoboDojo), an Isaac Sim
-benchmark for generalist robot-manipulation policies, through the companion
-[XPolicyLab StarVLA integration](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval)
-and the three released Hugging Face checkpoints.
+StarVLA supports [RoboDojo](https://github.com/RoboDojo-Benchmark/RoboDojo)
+training and, through
+[XPolicyLab](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval).
+This directory provides the StarVLA-side data registration, reproducible
+training recipes, and a thin launcher for evaluating the released Hugging Face
+checkpoints. RoboDojo remains the source of the simulator, tasks, assets, and
+official scoring; XPolicyLab maintains the policy adapter and evaluation
+runtime.
 
-As with the RoboTwin integration, the simulator is a separate checkout and its
-environment is passed into the launcher as a path. Most executable integration
-code intentionally lives outside this StarVLA repository:
+The released policies share the same observation/action contract:
 
-| Repository | Responsibility |
+| Item | Value |
 |---|---|
-| StarVLA | Data registration, training recipes, released checkpoint documentation, and a thin evaluation entry point. |
-| XPolicyLab | StarVLA policy adapter, checkpoint preparation, policy-server launch, evaluation scripts, and runtime checks. |
-| RoboDojo | Isaac Sim environment, tasks, assets, layouts, videos, and scoring. |
+| Base VLM | `Qwen/Qwen3-VL-4B-Instruct` |
+| Training data | RoboDojo LeRobot v2.1, 3,500 episodes, 35 training tasks |
+| RGB observations | Head, left wrist, right wrist; resized to 224 x 224 |
+| Robot state | Raw 14D ARX X5 absolute-joint state |
+| Action | 14D absolute joint position (`abs_qpos`) |
+| Normalization | Saved `arx_x5` q99 statistics, including continuous grippers |
+| Predicted action horizon | 50 |
+| Evaluation replanning interval | Execute 16 actions, then request a new chunk |
 
-The companion launcher is the recommended way to evaluate the public
-RoboDojo checkpoints. It pins the Hugging Face revisions, verifies the weight,
-configuration, and normalization hashes, starts the matching vendored StarVLA
-server, checks its metadata handshake, and only then starts RoboDojo. Do not
-start a second `deployment/model_server/server_policy.py` process from an
-arbitrary StarVLA checkout for these released checkpoints.
+## Training
 
-## Training data and released checkpoints
+### Download the official dataset
 
-The three public policies were trained end to end from
-`Qwen/Qwen3-VL-4B-Instruct` on the same 35-task RoboDojo LeRobot v2.1 mixture.
-They use three RGB observations (head, left wrist, and right wrist), raw 14D
-ARX X5 joint state, 14D absolute-joint actions, a 50-action prediction horizon,
-and the saved `arx_x5` q99 normalization statistics.
-
-| Variant | Training step | Action head | Released checkpoint |
-|---|---:|---|---|
-| QwenOFT | 100,000 | MLP/L1 regression | [Qwen3vl4b-OFT-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-OFT-RoboDojo) |
-| QwenGR00T | 130,000 | 16-layer flow-matching DiT | [Qwen3vl4b-GR00T-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-GR00T-RoboDojo) |
-| QwenPI_v3 | 100,000 | 36-layer LayerwiseFM | [StarVLA-Qwen3vl4b-PIv3-RoboDojo](https://huggingface.co/StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo) |
-
-Each Hugging Face repository contains the evaluated weight plus
-`config.yaml`, `config.full.yaml`, and `dataset_statistics.json`. Keep that
-run-directory structure intact; the model server uses the sidecars to rebuild
-the framework and unnormalize its actions.
-
-### Train on the official RoboDojo dataset
-
-Training uses RoboDojo's directly downloadable 64 GB LeRobot v2.1 export; no
-conversion step is required. It contains 3,500 episodes from 35 tasks. Download
-it from the RoboDojo checkout into a shared dataset directory:
+The recipes read RoboDojo's official 64 GB LeRobot v2.1 export directly. No
+StarVLA data conversion is required.
 
 ```bash
 cd /absolute/path/to/RoboDojo
@@ -54,17 +36,33 @@ ROBO_DOJO_DATA_ROOT=/absolute/path/to/shared-datasets \
   bash scripts/RoboDojo/download_data.sh huggingface lerobot_v2.1
 ```
 
-This creates
-`/absolute/path/to/shared-datasets/RoboDojo_lerobot_v21_video`. Select one of
-the checked-in recipes:
+The downloader creates:
 
-| Variant | Training config | Released step |
-|---|---|---:|
-| QwenOFT | `starvla_robodojo_v21_qwenoft_h50_q99.yaml` | 100,000 |
-| QwenGR00T | `starvla_robodojo_v21_qwengroot_h50_q99.yaml` | 130,000 |
-| QwenPI_v3 | `starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml` | 100,000 |
+```text
+/absolute/path/to/shared-datasets/RoboDojo_lerobot_v21_video
+```
 
-Then launch training from the StarVLA repository root. For example:
+The checked-in
+[`modality.json`](train_files/modality.json) matches the metadata shipped with
+that physical dataset. The data registry selects the three RGB streams used by
+the released policies and ignores additional cameras.
+
+### Select a recipe
+
+| Variant | Action head | Recipe | Released step |
+|---|---|---|---:|
+| QwenOFT | MLP with L1 action regression | `starvla_robodojo_v21_qwenoft_h50_q99.yaml` | 100,000 |
+| QwenGR00T | 16-layer DiT-B flow-matching head | `starvla_robodojo_v21_qwengroot_h50_q99.yaml` | 130,000 |
+| QwenPI_v3 | 36-layer LayerwiseFM head | `starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml` | 100,000 |
+
+All recipes train the VLM, VLM interface, and action head end to end. Shared
+optimization settings are a per-GPU batch size of 16, AdamW with betas
+`(0.9, 0.95)`, VLM learning rate `1e-5`, action-model learning rate
+`1e-4`, 5,000 warmup steps, and a cosine schedule.
+
+### Launch training
+
+Run from the StarVLA repository root. For example, to train QwenPI_v3:
 
 ```bash
 config_yaml=examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml \
@@ -72,30 +70,40 @@ robodojo_data_root=/absolute/path/to/shared-datasets \
 bash examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh
 ```
 
-The launcher uses all locally visible GPUs by default. Use `NUM_PROCESSES`,
-`NUM_MACHINES`, `MACHINE_RANK`, `MAIN_PROCESS_IP`, and `MAIN_PROCESS_PORT` for
-explicit Accelerate topology, and `DRY_RUN=1` to inspect the resolved command.
-Arguments after the script are forwarded to `train_starvla.py`.
+The launcher uses all visible GPUs by default. The following variables control
+the Accelerate topology:
 
-The benchmark-specific data registry is auto-discovered from
+| Variable | Purpose |
+|---|---|
+| `NUM_PROCESSES` | Total number of Accelerate processes |
+| `NUM_MACHINES` | Number of training machines; default 1 |
+| `MACHINE_RANK` | Rank of the current machine |
+| `MAIN_PROCESS_IP` | Main-node address for multi-machine training |
+| `MAIN_PROCESS_PORT` | Main-node port; default 29500 |
+| `DRY_RUN=1` | Validate paths and print the resolved command without training |
+
+Arguments after the launcher are forwarded to `train_starvla.py`.
+
+The benchmark registry is auto-discovered from
 [`train_files/data_registry/data_config.py`](train_files/data_registry/data_config.py).
-It reads the official dataset in place and registers the three camera keys,
-14D state/action layout, 50-step chunks, and continuous-gripper q99 transform.
-The adjacent `modality.json` mirrors the metadata shipped with the physical
-dataset; neither file performs a conversion.
+It registers the 35-task mixture as `robodojo_v21_all_h50_q99`, with a
+50-action chunk and q99 transforms for all state/action dimensions.
 
-The QwenPI_v3 recipe explicitly sets
-`diffusion_model_cfg.interleave_self_attention: true`. This makes training use
-the canonical alternating self/cross-attention DiT forward even though current
-QwenPI_v3 defaults remain legacy-compatible for older checkpoints. The setting
-must remain `true` for the released RoboDojo PI-v3 architecture.
+The QwenPI_v3 recipe explicitly keeps:
 
-## Environment setup
+```yaml
+diffusion_model_cfg:
+  interleave_self_attention: true
+```
 
-Use separate StarVLA policy and RoboDojo evaluation environments. Follow the
-[RoboDojo installation guide](https://robodojo-benchmark.com/doc/usage/install-and-download/)
-for Isaac Sim 5.1 and its simulator environment, then place XPolicyLab directly
-inside the RoboDojo checkout:
+This is the canonical alternating self/cross-attention architecture used to
+train the released RoboDojo PI-v3 checkpoint.
+
+## Evaluation
+
+### Install RoboDojo and XPolicyLab
+
+Use separate policy and simulator environments:
 
 ```bash
 git clone https://github.com/RoboDojo-Benchmark/RoboDojo.git
@@ -105,124 +113,230 @@ git clone --single-branch \
   --branch fix/starvla-hf-robodojo-eval \
   https://github.com/JinhuiYE/XPolicyLab.git
 
-# Install the official benchmark assets once.
 bash scripts/init_assets.sh
 
-# Install the StarVLA policy environment.
 cd XPolicyLab/policy/starVLA
 bash install.sh
 ```
 
-Keep the two environment prefixes available for evaluation:
+Export the checkout and environment paths:
 
 ```bash
 export ROBODOJO_PATH=/absolute/path/to/RoboDojo
 export STARVLA_ENV_PATH=/absolute/path/to/starvla-policy-env
-export ROBODOJO_ENV_PATH=/absolute/path/to/robodojo-sim-env
+export ROBODOJO_ENV_PATH=/absolute/path/to/robodojo-simulator-env
 ```
 
-Conda environment names also work, but absolute prefixes are recommended for
-non-interactive cluster shells. XPolicyLab remains at
-`$ROBODOJO_PATH/XPolicyLab`; its scripts are the source of truth for the
-evaluation implementation.
+XPolicyLab must be located at `$ROBODOJO_PATH/XPolicyLab`. Absolute environment
+prefixes are recommended for non-interactive cluster jobs.
 
-The commands and results below were verified with RoboDojo
-`36bfcb7c580b149c6e39ed2eb77d60689152e570` and XPolicyLab
-`65da3de0ac99898f3540e76d74998af92cf372b0`.
+### Evaluate a released checkpoint
 
-## Evaluate a released Hugging Face checkpoint
-
-From the StarVLA repository root, use the thin wrapper in this example. Like the
-RoboTwin launcher, it accepts the external benchmark checkout and environment
-paths, then delegates to the scripts maintained with that integration. It
-starts both the model server and simulator; no second terminal or manual
-policy-server process is required.
+The StarVLA launcher delegates checkpoint download, hash verification, policy
+serving, simulator startup, and result collection to XPolicyLab:
 
 ```bash
 ROBODOJO_PATH=/absolute/path/to/RoboDojo \
 bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
-  pi_v3 build_tower 0 0 1 \
-  "$STARVLA_ENV_PATH" \
-  "$ROBODOJO_ENV_PATH" \
-  10
+  <oft|groot|pi_v3> <task> <seed> <policy_gpu> <sim_gpu> \
+  "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" \
+  <episode_count|native>
 ```
 
-Arguments after the script are:
-
-```text
-<oft|groot|pi_v3> <task> <seed> <policy_gpu> <sim_gpu>
-<starvla_env> <robodojo_env> [episode_count|native]
-```
-
-Use `native` for the task's official episode count. A 10-episode run is a quick
-contract check, not a replacement for the official 50-episode `build_tower`
-protocol.
-
-The wrapper above is equivalent to running the companion script directly:
+For example:
 
 ```bash
-cd "$ROBODOJO_PATH/XPolicyLab/policy/starVLA"
+# QwenOFT
+ROBODOJO_PATH="$ROBODOJO_PATH" \
+bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
+  oft build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
 
-bash scripts/eval_hf_robodojo.sh \
-  pi_v3 build_tower 0 0 1 \
-  "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" 10
+# QwenGR00T
+ROBODOJO_PATH="$ROBODOJO_PATH" \
+bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
+  groot build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
+
+# QwenPI_v3
+ROBODOJO_PATH="$ROBODOJO_PATH" \
+bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
+  pi_v3 build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
 ```
 
-QwenOFT and QwenGR00T commands, training entry points, and offline/cache
-controls are maintained in
-[XPolicyLab's StarVLA README](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval/policy/starVLA).
+Use an integer episode count for a short wiring check and `native` for the
+task's official count. A complete RoboDojo report evaluates all 42 tasks and
+uses RoboDojo's official aggregation script.
 
-### What a valid model startup proves
+The launcher prepares these public releases:
 
-Before RoboDojo moves the robot, the log must show that the downloaded files
-match the release manifest, the policy server is listening, and the handshake
-advertises the expected runtime contract:
+| Variant | Hugging Face checkpoint |
+|---|---|
+| `oft` | [StarVLA/Qwen3vl4b-OFT-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-OFT-RoboDojo) |
+| `groot` | [StarVLA/Qwen3vl4b-GR00T-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-GR00T-RoboDojo) |
+| `pi_v3` | [StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo](https://huggingface.co/StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo) |
 
-- RGB images in head, left-wrist, right-wrist order;
-- raw 14D ARX X5 state normalized exactly once by the server;
-- unnormalized 14D absolute-joint actions returned to RoboDojo;
-- a 50-action predicted chunk with 16 actions executed before replanning;
-- for the pinned QwenPI_v3 release, `pi_v3_forward=canonical_interleaved`.
+Keep each checkpoint's `config.yaml`, `config.full.yaml`, and
+`dataset_statistics.json` beside its `checkpoints/` directory. The dedicated
+launcher preserves this layout automatically. Do not start a second
+`deployment/model_server/server_policy.py` process: the launcher starts the
+matching server and validates the RGB, state-normalization, action, horizon,
+and PI-v3 forward contracts before simulation.
 
-PI-v3 supports checkpoints with different forward semantics. The companion
-manifest makes this requirement checkpoint-specific and rejects an incompatible
-server before simulation, instead of accepting a loaded model that produces
-invalid robot motion.
-
-## Reproduced `build_tower` results
-
-The public model cards report the official 50-episode references below. The
-same pinned artifacts were also checked on ten seed-0 layouts through the
-companion launcher.
-
-| Released checkpoint | Official success / score | Reproduced success / score | Unstable |
-|---|---:|---:|---:|
-| QwenOFT | 36% / 50.60 | 4/10 / 58.00 | 0 |
-| QwenGR00T | 14% / 20.80 | 1/10 / 20.00 | 0 |
-| QwenPI_v3 | 56% / 65.00 | 5/10 / 57.00 | 0 |
-
-As a final check of the StarVLA entry point shown above, QwenPI_v3 was rerun
-on four seed-0 layouts: 2/4 succeeded, the score was 65.00, and none were
-unstable.
-
-All three public weights and sidecars passed full manifest SHA256 verification.
-The model server reached its runtime handshake and RoboDojo reached
-`Simulation App Startup Complete` before episodes began.
-
-Near-zero success together with visibly abnormal arm motion is not treated as
-small-sample noise. Check the startup contract above, the exact checkpoint
-sidecars, and simulator health before interpreting the score.
-
-## Useful launcher controls
+Useful evaluation controls:
 
 | Variable | Purpose |
 |---|---|
-| `STARVLA_HF_ROOT` | Shared directory for downloaded checkpoint run directories. |
-| `STARVLA_HF_LOCAL_FILES_ONLY=1` | Disable network access and use the local HF cache. |
-| `STARVLA_HF_VERIFY_ONLY=1` | Verify an already-materialized run directory. |
-| `STARVLA_BASE_VLM` | Use a local `Qwen3-VL-4B-Instruct` directory. |
-| `STARVLA_ROBODOJO_NUM_ENVS` | Number of parallel Isaac environments; defaults to 1. |
+| `STARVLA_HF_ROOT` | Shared root for materialized Hugging Face run directories |
+| `STARVLA_HF_LOCAL_FILES_ONLY=1` | Disable network access and use local HF files |
+| `STARVLA_HF_VERIFY_ONLY=1` | Verify an already-materialized run directory |
+| `STARVLA_BASE_VLM` | Local `Qwen3-VL-4B-Instruct` path for offline runs |
+| `STARVLA_ROBODOJO_NUM_ENVS` | Number of parallel Isaac environments |
 
-For official task aggregation and leaderboard rules, follow the
-[RoboDojo documentation](https://robodojo-benchmark.com/doc/) and
-[leaderboard](https://robodojo-benchmark.com/leaderboard).
+## Released checkpoint results
+
+The tables below reproduce the results published in the three Hugging Face
+model cards. The protocol contains 42 evaluation tasks, 50 episodes per task,
+and 2,100 episodes per policy. Values are **success rate (%) / score**; higher
+is better for both. The policies train on 35 tasks, while the complete
+evaluation includes held-out and open tasks.
+
+### Overall and category summary
+
+| Policy | Average | Generalization | Precision | Long-Horizon | Memory | Open |
+|---|---:|---:|---:|---:|---:|---:|
+| QwenOFT | 4.86 / 8.01 | 4.33 / 6.42 | 11.75 / 17.54 | 5.50 / 12.95 | 1.67 / 1.77 | 0.50 / 0.60 |
+| QwenGR00T | 3.81 / 7.35 | 3.50 / 6.52 | 5.75 / 10.09 | 6.50 / 15.46 | 3.33 / 4.37 | 0.00 / 0.00 |
+| **QwenPI_v3** | **6.19 / 9.60** | **4.17 / 7.28** | **14.00 / 19.06** | **10.00 / 17.84** | **2.00 / 2.32** | **0.75 / 0.88** |
+
+### Per-task results
+
+| Group | Task | QwenOFT | QwenGR00T | QwenPI_v3 |
+|---|---|---:|---:|---:|
+| Generalization | `stack_bowls` | 18.00 / 21.00 | 10.00 / 14.80 | 14.00 / 16.70 |
+| Generalization | `push_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Generalization | `pack_objects_into_box` | 0.00 / 3.10 | 0.00 / 7.80 | 0.00 / 6.80 |
+| Generalization | `fold_clothes` | 10.00 / 12.80 | 8.00 / 12.40 | 2.00 / 9.60 |
+| Generalization | `hang_mugs` | 0.00 / 3.60 | 0.00 / 3.00 | 0.00 / 3.50 |
+| Generalization | `sweep_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 2.00 / 2.00 |
+| Generalization | `pour_liquid_into_cup` | 14.00 / 14.00 | 14.00 / 14.00 | 12.00 / 12.00 |
+| Generalization | `make_toast` | 0.00 / 1.00 | 2.00 / 5.00 | 2.00 / 5.00 |
+| Generalization | `arrange_largest_number` | 0.00 / 1.90 | 2.00 / 4.10 | 2.00 / 5.70 |
+| Generalization | `sort_nesting_dolls_by_size` | 0.00 / 0.00 | 4.00 / 4.00 | 6.00 / 6.00 |
+| Generalization | `store_laptop_and_headphones` | 4.00 / 11.20 | 0.00 / 7.20 | 2.00 / 8.40 |
+| Generalization | `stack_blocks` | 6.00 / 8.40 | 2.00 / 5.90 | 8.00 / 11.60 |
+| Precision | `fasten_screws` | 4.00 / 8.00 | 0.00 / 2.00 | 0.00 / 6.00 |
+| Precision | `plug_in_charger` | 6.00 / 6.00 | 2.00 / 2.00 | 4.00 / 4.00 |
+| Precision | `insert_tubes` | 40.00 / 51.60 | 28.00 / 40.40 | 44.00 / 56.80 |
+| Precision | `pour_balls_into_vase` | 8.00 / 8.00 | 0.00 / 0.00 | 2.00 / 2.00 |
+| Precision | `play_Xylophone` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Precision | `deposit_coin` | 0.00 / 3.20 | 2.00 / 5.60 | 6.00 / 7.60 |
+| Precision | `insert_key` | 0.00 / 12.90 | 0.00 / 9.90 | 0.00 / 11.10 |
+| Precision | `build_tower` | 36.00 / 50.60 | 14.00 / 20.80 | 56.00 / 65.00 |
+| Long-Horizon | `put_bottles_into_dustbin` | 22.00 / 40.90 | 26.00 / 44.40 | 64.00 / 73.60 |
+| Long-Horizon | `fill_pen_holder` | 4.00 / 11.70 | 6.00 / 14.40 | 8.00 / 23.00 |
+| Long-Horizon | `classify_objects` | 2.00 / 5.50 | 6.00 / 11.50 | 0.00 / 7.50 |
+| Long-Horizon | `play_tic_tac_toe` | 0.00 / 12.40 | 2.00 / 16.40 | 0.00 / 6.80 |
+| Long-Horizon | `fill_egg_holder` | 0.00 / 0.60 | 0.00 / 0.00 | 0.00 / 0.80 |
+| Long-Horizon | `organize_table` | 0.00 / 16.50 | 0.00 / 25.00 | 4.00 / 27.00 |
+| Long-Horizon | `make_kong` | 16.00 / 16.00 | 12.00 / 12.00 | 4.00 / 4.00 |
+| Long-Horizon | `play_stacking_toy` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Memory | `cover_blocks` | 0.00 / 0.60 | 6.00 / 12.10 | 0.00 / 1.50 |
+| Memory | `match_and_pick_from_conveyor` | 10.00 / 10.00 | 14.00 / 14.00 | 12.00 / 12.00 |
+| Memory | `swap_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Memory | `swap_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Memory | `press_by_number` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Memory | `imitate_sorting_sequence` | 0.00 / 0.00 | 0.00 / 0.10 | 0.00 / 0.40 |
+| Open | `align_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Open | `general_pickup` | 4.00 / 4.00 | 0.00 / 0.00 | 6.00 / 6.00 |
+| Open | `stack_blocks_by_language` | 0.00 / 0.80 | 0.00 / 0.00 | 0.00 / 0.80 |
+| Open | `solve_equation` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Open | `classify_objects_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.20 |
+| Open | `pick_from_conveyor_by_image` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Open | `store_tools_in_toolbox` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Open | `pour_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+
+## Improvement opportunities
+
+### Scope of the released baseline
+
+These three checkpoints intentionally measure a plain StarVLA baseline. They
+start from the general-purpose `Qwen3-VL-4B-Instruct` VLM, but **do not start
+from a robot/action-policy pretrained checkpoint**. The action heads are trained
+from scratch on the RoboDojo mixture. The recipes also use one shared policy
+without task-specific heads, task planners, reward shaping, per-task
+fine-tuning, curriculum scheduling, or task-dependent inference rules.
+
+This makes the released results a clean measurement of the StarVLA
+architectures, but it also leaves several known sources of performance unused.
+
+### What the leaderboard suggests
+
+The official [RoboDojo leaderboard](https://robodojo-benchmark.com/leaderboard)
+shows the following category profile for several leading entries. Values are
+again **success rate (%) / score**. The leaderboard snapshot is dated
+2026-08-04. The final row is the released QwenPI_v3 model-card result shown
+above; it should not be confused with the separate `StarVLA` submission on the
+leaderboard.
+
+| Policy | Average | Generalization | Precision | Long-Horizon | Memory | Open |
+|---|---:|---:|---:|---:|---:|---:|
+| GalaxeaVLA (G0.5) | 14.88 / 20.23 | 12.83 / 18.46 | 20.42 / 28.25 | 32.25 / 44.12 | 7.33 / 8.61 | 1.58 / 1.73 |
+| Xiaomi-Robotics-1 | 13.93 / 20.07 | 17.00 / 23.55 | 18.83 / 26.69 | 23.67 / 38.39 | 6.56 / 7.81 | 3.58 / 3.94 |
+| Hy-Embodied-0.5-VLA | 8.80 / 13.07 | 8.39 / 11.77 | 8.00 / 13.81 | 14.92 / 25.74 | 12.11 / 13.37 | 0.58 / 0.65 |
+| Spatial Forcing | 8.04 / 12.38 | 9.33 / 14.12 | 10.58 / 17.33 | 14.58 / 23.26 | 4.11 / 5.43 | 1.58 / 1.78 |
+| Pi-05 | 6.91 / 11.41 | 8.17 / 13.37 | 5.50 / 12.40 | 14.67 / 23.54 | 4.56 / 5.78 | 1.67 / 1.98 |
+| InternVLA-A1.5 | 7.14 / 11.15 | 6.83 / 10.36 | 10.17 / 15.23 | 13.75 / 23.80 | 3.56 / 4.93 | 1.42 / 1.43 |
+| **StarVLA QwenPI_v3 (this release)** | **6.19 / 9.60** | **4.17 / 7.28** | **14.00 / 19.06** | **10.00 / 17.84** | **2.00 / 2.32** | **0.75 / 0.88** |
+
+Based on the category gaps and the public training configurations, the most
+promising next steps are:
+
+1. **Add robot-policy pretraining before RoboDojo adaptation.** Several
+   competitive public configurations initialize from robot-pretrained policies
+   such as `G0Plus_3B-base`, `pi05_base`,
+   `Hy-Embodied-0.5-VLA-UMI`, or `X-VLA-Pt`; the released StarVLA recipes
+   initialize only from a vision-language model. A controlled comparison should
+   initialize StarVLA from an OXE/generalist robot checkpoint, then fine-tune on
+   the unchanged 35-task RoboDojo mixture.
+
+2. **Provide explicit temporal memory.** QwenPI_v3 scores 2.32 in Memory,
+   whereas Hy-Embodied-0.5-VLA scores 13.37. The latter's published
+   configuration samples six historical images at 20-step intervals. StarVLA
+   can test history-frame tokens, a compact recurrent state, or cached
+   layer-wise features while keeping one task-agnostic policy.
+
+3. **Improve long-horizon progress modeling.** The largest absolute category
+   gap is Long-Horizon: 17.84 for QwenPI_v3 versus 44.12 for the leading entry.
+   Useful ablations include task-phase or subgoal prediction, progress
+   estimation, temporally abstract action chunks, and training losses that
+   preserve consistency across consecutive replans.
+
+4. **Strengthen spatial precision and multi-view fusion.** Precision is the
+   strongest StarVLA category, but it still trails the leading score. Higher
+   resolution wrist crops, multi-scale visual tokens, calibrated cross-view
+   fusion, optional depth/3D features, and endpoint-aware action losses are
+   direct candidates for insertion and assembly tasks.
+
+5. **Rebalance difficult tasks without hard-coded solutions.** The per-task
+   table exposes many zero-success tasks even when partial score is non-zero.
+   Task-balanced sampling, failure-trajectory mining, stage-aware data
+   augmentation, and curriculum scheduling can target this long tail while
+   retaining a single generalist policy.
+
+6. **Improve open-task language and goal grounding.** Open remains the weakest
+   category for almost every leaderboard entry. Instruction paraphrasing,
+   reference-image conditioning, object-relation supervision, and
+   language-conditioned goal/progress prediction are preferable to
+   task-specific inference rules.
+
+These directions should be evaluated as controlled ablations under the same
+42-task protocol, reporting both category averages and the full per-task table
+rather than optimizing only `build_tower`.
+
+## References
+
+- [RoboDojo documentation](https://robodojo-benchmark.com/doc/)
+- [RoboDojo leaderboard](https://robodojo-benchmark.com/leaderboard)
+- [XPolicyLab StarVLA integration](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval/policy/starVLA)
+- [QwenOFT RoboDojo checkpoint](https://huggingface.co/StarVLA/Qwen3vl4b-OFT-RoboDojo)
+- [QwenGR00T RoboDojo checkpoint](https://huggingface.co/StarVLA/Qwen3vl4b-GR00T-RoboDojo)
+- [QwenPI_v3 RoboDojo checkpoint](https://huggingface.co/StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo)

--- a/examples/simBenchmarks/RoboDojo/README.md
+++ b/examples/simBenchmarks/RoboDojo/README.md
@@ -1,0 +1,228 @@
+# RoboDojo via XPolicyLab
+
+StarVLA supports [RoboDojo](https://github.com/RoboDojo-Benchmark/RoboDojo), an Isaac Sim
+benchmark for generalist robot-manipulation policies, through the companion
+[XPolicyLab StarVLA integration](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval)
+and the three released Hugging Face checkpoints.
+
+As with the RoboTwin integration, the simulator is a separate checkout and its
+environment is passed into the launcher as a path. Most executable integration
+code intentionally lives outside this StarVLA repository:
+
+| Repository | Responsibility |
+|---|---|
+| StarVLA | Data registration, training recipes, released checkpoint documentation, and a thin evaluation entry point. |
+| XPolicyLab | StarVLA policy adapter, checkpoint preparation, policy-server launch, evaluation scripts, and runtime checks. |
+| RoboDojo | Isaac Sim environment, tasks, assets, layouts, videos, and scoring. |
+
+The companion launcher is the recommended way to evaluate the public
+RoboDojo checkpoints. It pins the Hugging Face revisions, verifies the weight,
+configuration, and normalization hashes, starts the matching vendored StarVLA
+server, checks its metadata handshake, and only then starts RoboDojo. Do not
+start a second `deployment/model_server/server_policy.py` process from an
+arbitrary StarVLA checkout for these released checkpoints.
+
+## Training data and released checkpoints
+
+The three public policies were trained end to end from
+`Qwen/Qwen3-VL-4B-Instruct` on the same 35-task RoboDojo LeRobot v2.1 mixture.
+They use three RGB observations (head, left wrist, and right wrist), raw 14D
+ARX X5 joint state, 14D absolute-joint actions, a 50-action prediction horizon,
+and the saved `arx_x5` q99 normalization statistics.
+
+| Variant | Training step | Action head | Released checkpoint |
+|---|---:|---|---|
+| QwenOFT | 100,000 | MLP/L1 regression | [Qwen3vl4b-OFT-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-OFT-RoboDojo) |
+| QwenGR00T | 130,000 | 16-layer flow-matching DiT | [Qwen3vl4b-GR00T-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-GR00T-RoboDojo) |
+| QwenPI_v3 | 100,000 | 36-layer LayerwiseFM | [StarVLA-Qwen3vl4b-PIv3-RoboDojo](https://huggingface.co/StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo) |
+
+Each Hugging Face repository contains the evaluated weight plus
+`config.yaml`, `config.full.yaml`, and `dataset_statistics.json`. Keep that
+run-directory structure intact; the model server uses the sidecars to rebuild
+the framework and unnormalize its actions.
+
+### Train on the official RoboDojo dataset
+
+Training uses RoboDojo's directly downloadable 64 GB LeRobot v2.1 export; no
+conversion step is required. It contains 3,500 episodes from 35 tasks. Download
+it from the RoboDojo checkout into a shared dataset directory:
+
+```bash
+cd /absolute/path/to/RoboDojo
+
+ROBO_DOJO_DATA_ROOT=/absolute/path/to/shared-datasets \
+  bash scripts/RoboDojo/download_data.sh huggingface lerobot_v2.1
+```
+
+This creates
+`/absolute/path/to/shared-datasets/RoboDojo_lerobot_v21_video`. Select one of
+the checked-in recipes:
+
+| Variant | Training config | Released step |
+|---|---|---:|
+| QwenOFT | `starvla_robodojo_v21_qwenoft_h50_q99.yaml` | 100,000 |
+| QwenGR00T | `starvla_robodojo_v21_qwengroot_h50_q99.yaml` | 130,000 |
+| QwenPI_v3 | `starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml` | 100,000 |
+
+Then launch training from the StarVLA repository root. For example:
+
+```bash
+config_yaml=examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml \
+robodojo_data_root=/absolute/path/to/shared-datasets \
+bash examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh
+```
+
+The launcher uses all locally visible GPUs by default. Use `NUM_PROCESSES`,
+`NUM_MACHINES`, `MACHINE_RANK`, `MAIN_PROCESS_IP`, and `MAIN_PROCESS_PORT` for
+explicit Accelerate topology, and `DRY_RUN=1` to inspect the resolved command.
+Arguments after the script are forwarded to `train_starvla.py`.
+
+The benchmark-specific data registry is auto-discovered from
+[`train_files/data_registry/data_config.py`](train_files/data_registry/data_config.py).
+It reads the official dataset in place and registers the three camera keys,
+14D state/action layout, 50-step chunks, and continuous-gripper q99 transform.
+The adjacent `modality.json` mirrors the metadata shipped with the physical
+dataset; neither file performs a conversion.
+
+The QwenPI_v3 recipe explicitly sets
+`diffusion_model_cfg.interleave_self_attention: true`. This makes training use
+the canonical alternating self/cross-attention DiT forward even though current
+QwenPI_v3 defaults remain legacy-compatible for older checkpoints. The setting
+must remain `true` for the released RoboDojo PI-v3 architecture.
+
+## Environment setup
+
+Use separate StarVLA policy and RoboDojo evaluation environments. Follow the
+[RoboDojo installation guide](https://robodojo-benchmark.com/doc/usage/install-and-download/)
+for Isaac Sim 5.1 and its simulator environment, then place XPolicyLab directly
+inside the RoboDojo checkout:
+
+```bash
+git clone https://github.com/RoboDojo-Benchmark/RoboDojo.git
+cd RoboDojo
+
+git clone --single-branch \
+  --branch fix/starvla-hf-robodojo-eval \
+  https://github.com/JinhuiYE/XPolicyLab.git
+
+# Install the official benchmark assets once.
+bash scripts/init_assets.sh
+
+# Install the StarVLA policy environment.
+cd XPolicyLab/policy/starVLA
+bash install.sh
+```
+
+Keep the two environment prefixes available for evaluation:
+
+```bash
+export ROBODOJO_PATH=/absolute/path/to/RoboDojo
+export STARVLA_ENV_PATH=/absolute/path/to/starvla-policy-env
+export ROBODOJO_ENV_PATH=/absolute/path/to/robodojo-sim-env
+```
+
+Conda environment names also work, but absolute prefixes are recommended for
+non-interactive cluster shells. XPolicyLab remains at
+`$ROBODOJO_PATH/XPolicyLab`; its scripts are the source of truth for the
+evaluation implementation.
+
+The commands and results below were verified with RoboDojo
+`36bfcb7c580b149c6e39ed2eb77d60689152e570` and XPolicyLab
+`65da3de0ac99898f3540e76d74998af92cf372b0`.
+
+## Evaluate a released Hugging Face checkpoint
+
+From the StarVLA repository root, use the thin wrapper in this example. Like the
+RoboTwin launcher, it accepts the external benchmark checkout and environment
+paths, then delegates to the scripts maintained with that integration. It
+starts both the model server and simulator; no second terminal or manual
+policy-server process is required.
+
+```bash
+ROBODOJO_PATH=/absolute/path/to/RoboDojo \
+bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
+  pi_v3 build_tower 0 0 1 \
+  "$STARVLA_ENV_PATH" \
+  "$ROBODOJO_ENV_PATH" \
+  10
+```
+
+Arguments after the script are:
+
+```text
+<oft|groot|pi_v3> <task> <seed> <policy_gpu> <sim_gpu>
+<starvla_env> <robodojo_env> [episode_count|native]
+```
+
+Use `native` for the task's official episode count. A 10-episode run is a quick
+contract check, not a replacement for the official 50-episode `build_tower`
+protocol.
+
+The wrapper above is equivalent to running the companion script directly:
+
+```bash
+cd "$ROBODOJO_PATH/XPolicyLab/policy/starVLA"
+
+bash scripts/eval_hf_robodojo.sh \
+  pi_v3 build_tower 0 0 1 \
+  "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" 10
+```
+
+QwenOFT and QwenGR00T commands, training entry points, and offline/cache
+controls are maintained in
+[XPolicyLab's StarVLA README](https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval/policy/starVLA).
+
+### What a valid model startup proves
+
+Before RoboDojo moves the robot, the log must show that the downloaded files
+match the release manifest, the policy server is listening, and the handshake
+advertises the expected runtime contract:
+
+- RGB images in head, left-wrist, right-wrist order;
+- raw 14D ARX X5 state normalized exactly once by the server;
+- unnormalized 14D absolute-joint actions returned to RoboDojo;
+- a 50-action predicted chunk with 16 actions executed before replanning;
+- for the pinned QwenPI_v3 release, `pi_v3_forward=canonical_interleaved`.
+
+PI-v3 supports checkpoints with different forward semantics. The companion
+manifest makes this requirement checkpoint-specific and rejects an incompatible
+server before simulation, instead of accepting a loaded model that produces
+invalid robot motion.
+
+## Reproduced `build_tower` results
+
+The public model cards report the official 50-episode references below. The
+same pinned artifacts were also checked on ten seed-0 layouts through the
+companion launcher.
+
+| Released checkpoint | Official success / score | Reproduced success / score | Unstable |
+|---|---:|---:|---:|
+| QwenOFT | 36% / 50.60 | 4/10 / 58.00 | 0 |
+| QwenGR00T | 14% / 20.80 | 1/10 / 20.00 | 0 |
+| QwenPI_v3 | 56% / 65.00 | 5/10 / 57.00 | 0 |
+
+As a final check of the StarVLA entry point shown above, QwenPI_v3 was rerun
+on four seed-0 layouts: 2/4 succeeded, the score was 65.00, and none were
+unstable.
+
+All three public weights and sidecars passed full manifest SHA256 verification.
+The model server reached its runtime handshake and RoboDojo reached
+`Simulation App Startup Complete` before episodes began.
+
+Near-zero success together with visibly abnormal arm motion is not treated as
+small-sample noise. Check the startup contract above, the exact checkpoint
+sidecars, and simulator health before interpreting the score.
+
+## Useful launcher controls
+
+| Variable | Purpose |
+|---|---|
+| `STARVLA_HF_ROOT` | Shared directory for downloaded checkpoint run directories. |
+| `STARVLA_HF_LOCAL_FILES_ONLY=1` | Disable network access and use the local HF cache. |
+| `STARVLA_HF_VERIFY_ONLY=1` | Verify an already-materialized run directory. |
+| `STARVLA_BASE_VLM` | Use a local `Qwen3-VL-4B-Instruct` directory. |
+| `STARVLA_ROBODOJO_NUM_ENVS` | Number of parallel Isaac environments; defaults to 1. |
+
+For official task aggregation and leaderboard rules, follow the
+[RoboDojo documentation](https://robodojo-benchmark.com/doc/) and
+[leaderboard](https://robodojo-benchmark.com/leaderboard).

--- a/examples/simBenchmarks/RoboDojo/README.md
+++ b/examples/simBenchmarks/RoboDojo/README.md
@@ -70,34 +70,11 @@ robodojo_data_root=/absolute/path/to/shared-datasets \
 bash examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh
 ```
 
-The launcher uses all visible GPUs by default. The following variables control
-the Accelerate topology:
-
-| Variable | Purpose |
-|---|---|
-| `NUM_PROCESSES` | Total number of Accelerate processes |
-| `NUM_MACHINES` | Number of training machines; default 1 |
-| `MACHINE_RANK` | Rank of the current machine |
-| `MAIN_PROCESS_IP` | Main-node address for multi-machine training |
-| `MAIN_PROCESS_PORT` | Main-node port; default 29500 |
-| `DRY_RUN=1` | Validate paths and print the resolved command without training |
-
-Arguments after the launcher are forwarded to `train_starvla.py`.
-
 The benchmark registry is auto-discovered from
 [`train_files/data_registry/data_config.py`](train_files/data_registry/data_config.py).
 It registers the 35-task mixture as `robodojo_v21_all_h50_q99`, with a
 50-action chunk and q99 transforms for all state/action dimensions.
 
-The QwenPI_v3 recipe explicitly keeps:
-
-```yaml
-diffusion_model_cfg:
-  interleave_self_attention: true
-```
-
-This is the canonical alternating self/cross-attention architecture used to
-train the released RoboDojo PI-v3 checkpoint.
 
 ## Evaluation
 
@@ -143,54 +120,6 @@ bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
   <episode_count|native>
 ```
 
-For example:
-
-```bash
-# QwenOFT
-ROBODOJO_PATH="$ROBODOJO_PATH" \
-bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
-  oft build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
-
-# QwenGR00T
-ROBODOJO_PATH="$ROBODOJO_PATH" \
-bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
-  groot build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
-
-# QwenPI_v3
-ROBODOJO_PATH="$ROBODOJO_PATH" \
-bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
-  pi_v3 build_tower 0 0 1 "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" native
-```
-
-Use an integer episode count for a short wiring check and `native` for the
-task's official count. A complete RoboDojo report evaluates all 42 tasks and
-uses RoboDojo's official aggregation script.
-
-The launcher prepares these public releases:
-
-| Variant | Hugging Face checkpoint |
-|---|---|
-| `oft` | [StarVLA/Qwen3vl4b-OFT-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-OFT-RoboDojo) |
-| `groot` | [StarVLA/Qwen3vl4b-GR00T-RoboDojo](https://huggingface.co/StarVLA/Qwen3vl4b-GR00T-RoboDojo) |
-| `pi_v3` | [StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo](https://huggingface.co/StarVLA/StarVLA-Qwen3vl4b-PIv3-RoboDojo) |
-
-Keep each checkpoint's `config.yaml`, `config.full.yaml`, and
-`dataset_statistics.json` beside its `checkpoints/` directory. The dedicated
-launcher preserves this layout automatically. Do not start a second
-`deployment/model_server/server_policy.py` process: the launcher starts the
-matching server and validates the RGB, state-normalization, action, horizon,
-and PI-v3 forward contracts before simulation.
-
-Useful evaluation controls:
-
-| Variable | Purpose |
-|---|---|
-| `STARVLA_HF_ROOT` | Shared root for materialized Hugging Face run directories |
-| `STARVLA_HF_LOCAL_FILES_ONLY=1` | Disable network access and use local HF files |
-| `STARVLA_HF_VERIFY_ONLY=1` | Verify an already-materialized run directory |
-| `STARVLA_BASE_VLM` | Local `Qwen3-VL-4B-Instruct` path for offline runs |
-| `STARVLA_ROBODOJO_NUM_ENVS` | Number of parallel Isaac environments |
-
 ## Released checkpoint results
 
 The tables below reproduce the results published in the three Hugging Face
@@ -209,128 +138,119 @@ evaluation includes held-out and open tasks.
 
 ### Per-task results
 
-| Group | Task | QwenOFT | QwenGR00T | QwenPI_v3 |
-|---|---|---:|---:|---:|
-| Generalization | `stack_bowls` | 18.00 / 21.00 | 10.00 / 14.80 | 14.00 / 16.70 |
-| Generalization | `push_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Generalization | `pack_objects_into_box` | 0.00 / 3.10 | 0.00 / 7.80 | 0.00 / 6.80 |
-| Generalization | `fold_clothes` | 10.00 / 12.80 | 8.00 / 12.40 | 2.00 / 9.60 |
-| Generalization | `hang_mugs` | 0.00 / 3.60 | 0.00 / 3.00 | 0.00 / 3.50 |
-| Generalization | `sweep_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 2.00 / 2.00 |
-| Generalization | `pour_liquid_into_cup` | 14.00 / 14.00 | 14.00 / 14.00 | 12.00 / 12.00 |
-| Generalization | `make_toast` | 0.00 / 1.00 | 2.00 / 5.00 | 2.00 / 5.00 |
-| Generalization | `arrange_largest_number` | 0.00 / 1.90 | 2.00 / 4.10 | 2.00 / 5.70 |
-| Generalization | `sort_nesting_dolls_by_size` | 0.00 / 0.00 | 4.00 / 4.00 | 6.00 / 6.00 |
-| Generalization | `store_laptop_and_headphones` | 4.00 / 11.20 | 0.00 / 7.20 | 2.00 / 8.40 |
-| Generalization | `stack_blocks` | 6.00 / 8.40 | 2.00 / 5.90 | 8.00 / 11.60 |
-| Precision | `fasten_screws` | 4.00 / 8.00 | 0.00 / 2.00 | 0.00 / 6.00 |
-| Precision | `plug_in_charger` | 6.00 / 6.00 | 2.00 / 2.00 | 4.00 / 4.00 |
-| Precision | `insert_tubes` | 40.00 / 51.60 | 28.00 / 40.40 | 44.00 / 56.80 |
-| Precision | `pour_balls_into_vase` | 8.00 / 8.00 | 0.00 / 0.00 | 2.00 / 2.00 |
-| Precision | `play_Xylophone` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Precision | `deposit_coin` | 0.00 / 3.20 | 2.00 / 5.60 | 6.00 / 7.60 |
-| Precision | `insert_key` | 0.00 / 12.90 | 0.00 / 9.90 | 0.00 / 11.10 |
-| Precision | `build_tower` | 36.00 / 50.60 | 14.00 / 20.80 | 56.00 / 65.00 |
-| Long-Horizon | `put_bottles_into_dustbin` | 22.00 / 40.90 | 26.00 / 44.40 | 64.00 / 73.60 |
-| Long-Horizon | `fill_pen_holder` | 4.00 / 11.70 | 6.00 / 14.40 | 8.00 / 23.00 |
-| Long-Horizon | `classify_objects` | 2.00 / 5.50 | 6.00 / 11.50 | 0.00 / 7.50 |
-| Long-Horizon | `play_tic_tac_toe` | 0.00 / 12.40 | 2.00 / 16.40 | 0.00 / 6.80 |
-| Long-Horizon | `fill_egg_holder` | 0.00 / 0.60 | 0.00 / 0.00 | 0.00 / 0.80 |
-| Long-Horizon | `organize_table` | 0.00 / 16.50 | 0.00 / 25.00 | 4.00 / 27.00 |
-| Long-Horizon | `make_kong` | 16.00 / 16.00 | 12.00 / 12.00 | 4.00 / 4.00 |
-| Long-Horizon | `play_stacking_toy` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Memory | `cover_blocks` | 0.00 / 0.60 | 6.00 / 12.10 | 0.00 / 1.50 |
-| Memory | `match_and_pick_from_conveyor` | 10.00 / 10.00 | 14.00 / 14.00 | 12.00 / 12.00 |
-| Memory | `swap_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Memory | `swap_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Memory | `press_by_number` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Memory | `imitate_sorting_sequence` | 0.00 / 0.00 | 0.00 / 0.10 | 0.00 / 0.40 |
-| Open | `align_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Open | `general_pickup` | 4.00 / 4.00 | 0.00 / 0.00 | 6.00 / 6.00 |
-| Open | `stack_blocks_by_language` | 0.00 / 0.80 | 0.00 / 0.00 | 0.00 / 0.80 |
-| Open | `solve_equation` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Open | `classify_objects_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.20 |
-| Open | `pick_from_conveyor_by_image` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Open | `store_tools_in_toolbox` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
-| Open | `pour_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| Task | QwenOFT | QwenGR00T | QwenPI_v3 |
+|---|---:|---:|---:|
+| **Generalization average** | **4.33 / 6.42** | **3.50 / 6.52** | **4.17 / 7.28** |
+| `stack_bowls` | 18.00 / 21.00 | 10.00 / 14.80 | 14.00 / 16.70 |
+| `push_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `pack_objects_into_box` | 0.00 / 3.10 | 0.00 / 7.80 | 0.00 / 6.80 |
+| `fold_clothes` | 10.00 / 12.80 | 8.00 / 12.40 | 2.00 / 9.60 |
+| `hang_mugs` | 0.00 / 3.60 | 0.00 / 3.00 | 0.00 / 3.50 |
+| `sweep_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 2.00 / 2.00 |
+| `pour_liquid_into_cup` | 14.00 / 14.00 | 14.00 / 14.00 | 12.00 / 12.00 |
+| `make_toast` | 0.00 / 1.00 | 2.00 / 5.00 | 2.00 / 5.00 |
+| `arrange_largest_number` | 0.00 / 1.90 | 2.00 / 4.10 | 2.00 / 5.70 |
+| `sort_nesting_dolls_by_size` | 0.00 / 0.00 | 4.00 / 4.00 | 6.00 / 6.00 |
+| `store_laptop_and_headphones` | 4.00 / 11.20 | 0.00 / 7.20 | 2.00 / 8.40 |
+| `stack_blocks` | 6.00 / 8.40 | 2.00 / 5.90 | 8.00 / 11.60 |
+| **Precision average** | **11.75 / 17.54** | **5.75 / 10.09** | **14.00 / 19.06** |
+| `fasten_screws` | 4.00 / 8.00 | 0.00 / 2.00 | 0.00 / 6.00 |
+| `plug_in_charger` | 6.00 / 6.00 | 2.00 / 2.00 | 4.00 / 4.00 |
+| `insert_tubes` | 40.00 / 51.60 | 28.00 / 40.40 | 44.00 / 56.80 |
+| `pour_balls_into_vase` | 8.00 / 8.00 | 0.00 / 0.00 | 2.00 / 2.00 |
+| `play_Xylophone` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `deposit_coin` | 0.00 / 3.20 | 2.00 / 5.60 | 6.00 / 7.60 |
+| `insert_key` | 0.00 / 12.90 | 0.00 / 9.90 | 0.00 / 11.10 |
+| `build_tower` | 36.00 / 50.60 | 14.00 / 20.80 | 56.00 / 65.00 |
+| **Long-Horizon average** | **5.50 / 12.95** | **6.50 / 15.46** | **10.00 / 17.84** |
+| `put_bottles_into_dustbin` | 22.00 / 40.90 | 26.00 / 44.40 | 64.00 / 73.60 |
+| `fill_pen_holder` | 4.00 / 11.70 | 6.00 / 14.40 | 8.00 / 23.00 |
+| `classify_objects` | 2.00 / 5.50 | 6.00 / 11.50 | 0.00 / 7.50 |
+| `play_tic_tac_toe` | 0.00 / 12.40 | 2.00 / 16.40 | 0.00 / 6.80 |
+| `fill_egg_holder` | 0.00 / 0.60 | 0.00 / 0.00 | 0.00 / 0.80 |
+| `organize_table` | 0.00 / 16.50 | 0.00 / 25.00 | 4.00 / 27.00 |
+| `make_kong` | 16.00 / 16.00 | 12.00 / 12.00 | 4.00 / 4.00 |
+| `play_stacking_toy` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| **Memory average** | **1.67 / 1.77** | **3.33 / 4.37** | **2.00 / 2.32** |
+| `cover_blocks` | 0.00 / 0.60 | 6.00 / 12.10 | 0.00 / 1.50 |
+| `match_and_pick_from_conveyor` | 10.00 / 10.00 | 14.00 / 14.00 | 12.00 / 12.00 |
+| `swap_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `swap_T` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `press_by_number` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `imitate_sorting_sequence` | 0.00 / 0.00 | 0.00 / 0.10 | 0.00 / 0.40 |
+| **Open average** | **0.50 / 0.60** | **0.00 / 0.00** | **0.75 / 0.88** |
+| `align_blocks` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `general_pickup` | 4.00 / 4.00 | 0.00 / 0.00 | 6.00 / 6.00 |
+| `stack_blocks_by_language` | 0.00 / 0.80 | 0.00 / 0.00 | 0.00 / 0.80 |
+| `solve_equation` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `classify_objects_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.20 |
+| `pick_from_conveyor_by_image` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `store_tools_in_toolbox` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
+| `pour_by_language` | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
 
-## Improvement opportunities
+## Comparison with public RoboDojo policies
 
-### Scope of the released baseline
+> **Research note (2026-08-09).** This comparison covers the released StarVLA
+> QwenPI_v3 recipe and the public XPolicyLab implementations of
+> Xiaomi-Robotics-1, Hy-Embodied-0.5-VLA, and Spatial Forcing as available on
+> that date. Only parameters visible in the released code and configurations
+> are included.
 
-These three checkpoints intentionally measure a plain StarVLA baseline. They
-start from the general-purpose `Qwen3-VL-4B-Instruct` VLM, but **do not start
-from a robot/action-policy pretrained checkpoint**. The action heads are trained
-from scratch on the RoboDojo mixture. The recipes also use one shared policy
-without task-specific heads, task planners, reward shaping, per-task
-fine-tuning, curriculum scheduling, or task-dependent inference rules.
+Here, **robot-policy pretraining** means initialization from a checkpoint that
+already predicts robot actions. Initializing only the vision-language backbone
+does not count.
 
-This makes the released results a clean measurement of the StarVLA
-architectures, but it also leaves several known sources of performance unused.
+| Policy / model | Initialization and action model | RGB input | State input | Action output | Chunk / replanning | Additional input or supervision |
+|---|---|---|---|---|---|---|
+| **StarVLA QwenPI_v3** | `Qwen3-VL-4B-Instruct` + 36-layer LayerwiseFM; action modules start from scratch | Current head + two wrist frames, 224 x 224 | 14D absolute joint position | 50 x 14 absolute joint position | Predict 50; execute 16 | Current observation only; no separate temporal or geometry objective |
+| [Xiaomi-Robotics-1](https://github.com/XPolicyLab/XPolicyLab/tree/main/policy/Xiaomi_Robotics_1) | Pretrained `Xiaomi-Robotics-1-5B` robot policy | Current head + two wrist frames; resize/crop to 320 x 256 | Dual-arm joint position and grippers packed into 60D; unused slots are zero | 30 x 60 relative end-effector deltas; active slots encode two poses and grippers | Predict 30; current deployment executes 10 | Current observation only |
+| [Hy-Embodied-0.5-VLA](https://github.com/XPolicyLab/XPolicyLab/tree/main/policy/Hy_Embodied_05_VLA) | Pretrained `Hy-Embodied-0.5-VLA-UMI` robot policy with video encoder | Head + two wrist streams, including history frames | 16D dual-arm end-effector pose and grippers, converted to the model's pose representation | Relative dual-arm end-effector pose and gripper actions in the UMI frame | Current deployment executes 10 | Six history frames sampled at 20-step intervals |
+| [Spatial Forcing](https://github.com/XPolicyLab/XPolicyLab/tree/main/policy/Spatial_Forcing) | Pretrained `pi05_base` robot policy with a VGGT-1B alignment branch | Current head + two wrist frames | Packed dual-arm joint state | Absolute joint action | Public adapter returns the predicted chunk | VGGT feature alignment loss (`0.2`); no explicit temporal history |
 
-### What the leaderboard suggests
+### Observed gaps
 
-The official [RoboDojo leaderboard](https://robodojo-benchmark.com/leaderboard)
-shows the following category profile for several leading entries. Values are
-again **success rate (%) / score**. The leaderboard snapshot is dated
-2026-08-04. The final row is the released QwenPI_v3 model-card result shown
-above; it should not be confused with the separate `StarVLA` submission on the
-leaderboard.
+- **The camera contract is not the main differentiator.** All four public
+  integrations use the same head-and-two-wrist RGB layout. The larger
+  differences are how state and actions are represented and what the policy was
+  trained on before RoboDojo.
+- **Robot-policy pretraining is the clearest shared difference.** Every compared
+  higher-scoring recipe starts from a robot/action checkpoint. QwenPI_v3 starts
+  from a general-purpose VLM and learns its action-policy modules only from the
+  35-task RoboDojo mixture. This is a correlation in the available releases,
+  not proof that pretraining alone causes the score gap.
+- **The output interface differs substantially.** QwenPI_v3 and Spatial Forcing
+  emit absolute joint targets. Xiaomi-Robotics-1 and Hy-Embodied emit relative
+  end-effector targets and require coordinate-frame transforms. The released
+  results do not isolate this variable, so they cannot establish that one
+  action representation is intrinsically better.
+- **Some competitors add information or supervision absent from this StarVLA
+  baseline.** Hy-Embodied supplies explicit temporal history, while Spatial
+  Forcing adds VGGT-based spatial alignment. QwenPI_v3 uses the current RGB and
+  joint state only, without a separate memory input or geometry-alignment
+  objective.
 
-| Policy | Average | Generalization | Precision | Long-Horizon | Memory | Open |
-|---|---:|---:|---:|---:|---:|---:|
-| GalaxeaVLA (G0.5) | 14.88 / 20.23 | 12.83 / 18.46 | 20.42 / 28.25 | 32.25 / 44.12 | 7.33 / 8.61 | 1.58 / 1.73 |
-| Xiaomi-Robotics-1 | 13.93 / 20.07 | 17.00 / 23.55 | 18.83 / 26.69 | 23.67 / 38.39 | 6.56 / 7.81 | 3.58 / 3.94 |
-| Hy-Embodied-0.5-VLA | 8.80 / 13.07 | 8.39 / 11.77 | 8.00 / 13.81 | 14.92 / 25.74 | 12.11 / 13.37 | 0.58 / 0.65 |
-| Spatial Forcing | 8.04 / 12.38 | 9.33 / 14.12 | 10.58 / 17.33 | 14.58 / 23.26 | 4.11 / 5.43 | 1.58 / 1.78 |
-| Pi-05 | 6.91 / 11.41 | 8.17 / 13.37 | 5.50 / 12.40 | 14.67 / 23.54 | 4.56 / 5.78 | 1.67 / 1.98 |
-| InternVLA-A1.5 | 7.14 / 11.15 | 6.83 / 10.36 | 10.17 / 15.23 | 13.75 / 23.80 | 3.56 / 4.93 | 1.42 / 1.43 |
-| **StarVLA QwenPI_v3 (this release)** | **6.19 / 9.60** | **4.17 / 7.28** | **14.00 / 19.06** | **10.00 / 17.84** | **2.00 / 2.32** | **0.75 / 0.88** |
+These are differences observable in the released artifacts. They should not be
+read as claims about unpublished model internals or as isolated explanations of
+leaderboard performance.
 
-Based on the category gaps and the public training configurations, the most
-promising next steps are:
+### Suggested controlled comparisons
 
-1. **Add robot-policy pretraining before RoboDojo adaptation.** Several
-   competitive public configurations initialize from robot-pretrained policies
-   such as `G0Plus_3B-base`, `pi05_base`,
-   `Hy-Embodied-0.5-VLA-UMI`, or `X-VLA-Pt`; the released StarVLA recipes
-   initialize only from a vision-language model. A controlled comparison should
-   initialize StarVLA from an OXE/generalist robot checkpoint, then fine-tune on
-   the unchanged 35-task RoboDojo mixture.
-
-2. **Provide explicit temporal memory.** QwenPI_v3 scores 2.32 in Memory,
-   whereas Hy-Embodied-0.5-VLA scores 13.37. The latter's published
-   configuration samples six historical images at 20-step intervals. StarVLA
-   can test history-frame tokens, a compact recurrent state, or cached
-   layer-wise features while keeping one task-agnostic policy.
-
-3. **Improve long-horizon progress modeling.** The largest absolute category
-   gap is Long-Horizon: 17.84 for QwenPI_v3 versus 44.12 for the leading entry.
-   Useful ablations include task-phase or subgoal prediction, progress
-   estimation, temporally abstract action chunks, and training losses that
-   preserve consistency across consecutive replans.
-
-4. **Strengthen spatial precision and multi-view fusion.** Precision is the
-   strongest StarVLA category, but it still trails the leading score. Higher
-   resolution wrist crops, multi-scale visual tokens, calibrated cross-view
-   fusion, optional depth/3D features, and endpoint-aware action losses are
-   direct candidates for insertion and assembly tasks.
-
-5. **Rebalance difficult tasks without hard-coded solutions.** The per-task
-   table exposes many zero-success tasks even when partial score is non-zero.
-   Task-balanced sampling, failure-trajectory mining, stage-aware data
-   augmentation, and curriculum scheduling can target this long tail while
-   retaining a single generalist policy.
-
-6. **Improve open-task language and goal grounding.** Open remains the weakest
-   category for almost every leaderboard entry. Instruction paraphrasing,
-   reference-image conditioning, object-relation supervision, and
-   language-conditioned goal/progress prediction are preferable to
-   task-specific inference rules.
-
-These directions should be evaluated as controlled ablations under the same
-42-task protocol, reporting both category averages and the full per-task table
-rather than optimizing only `build_tower`.
+1. **Test robot-policy pretraining first.** Initialize QwenPI_v3 from an
+   OXE/generalist robot checkpoint while keeping the current three images, 14D
+   state, absolute-joint target, training mixture, and evaluation cadence
+   unchanged. This isolates the largest shared configuration difference.
+2. **Then isolate action representation.** Compare absolute and relative joint
+   targets with the same initialization and data before introducing an
+   end-effector interface, which also changes kinematics and coordinate-frame
+   handling. Report normalization and gripper treatment with each result.
+3. **Evaluate history only as a memory ablation.** Add a fixed observation
+   history to the otherwise unchanged policy and report the Memory tasks
+   separately. Hy-Embodied provides a concrete reference of six frames at
+   20-step intervals; this should be treated as a comparison setting, not an
+   assumed optimum for StarVLA.
+4. **Keep geometry supervision as a separate ablation.** Spatial Forcing mixes
+   `pi05_base` pretraining with VGGT alignment, so matching its alignment loss
+   while also changing initialization would not identify which change matters.
 
 ## References
 

--- a/examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh
+++ b/examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ROBODOJO_PATH=/path/to/RoboDojo \
+  bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
+    <oft|groot|pi_v3> <task_name> <seed> <policy_gpu> <sim_gpu> \
+    <starvla_env_path> <robodojo_env_path> [episode_count|native]
+
+RoboDojo must contain the companion checkout at:
+  $ROBODOJO_PATH/XPolicyLab
+
+The maintained evaluation scripts are provided by:
+  https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval
+
+They download and verify the complete Hugging Face run directory, start the
+matching policy server, check its runtime contract, and start RoboDojo. Do not
+start another StarVLA server manually.
+EOF
+}
+
+if [[ $# -lt 7 || $# -gt 8 ]]; then
+    usage >&2
+    exit 2
+fi
+
+if [[ -z "${ROBODOJO_PATH:-}" ]]; then
+    echo "[RoboDojo][ERROR] Set ROBODOJO_PATH to the RoboDojo checkout." >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -d "${ROBODOJO_PATH}" ]]; then
+    echo "[RoboDojo][ERROR] RoboDojo directory not found: ${ROBODOJO_PATH}" >&2
+    exit 1
+fi
+
+robodojo_root="$(cd "${ROBODOJO_PATH}" && pwd)"
+xpolicylab_root="${robodojo_root}/XPolicyLab"
+entrypoint="${xpolicylab_root}/policy/starVLA/scripts/eval_hf_robodojo.sh"
+manifest="${xpolicylab_root}/policy/starVLA/hf_robodojo_checkpoints.json"
+
+if [[ ! -f "${robodojo_root}/scripts/robodojo.sh" ]]; then
+    echo "[RoboDojo][ERROR] Invalid RoboDojo checkout: ${robodojo_root}" >&2
+    echo "[RoboDojo][ERROR] Missing ${robodojo_root}/scripts/robodojo.sh" >&2
+    exit 1
+fi
+
+if [[ ! -f "${entrypoint}" || ! -f "${manifest}" ]]; then
+    echo "[RoboDojo][ERROR] The XPolicyLab released-checkpoint launcher is missing." >&2
+    echo "[RoboDojo][ERROR] Clone the verified companion branch as:" >&2
+    echo "[RoboDojo][ERROR]   ${robodojo_root}/XPolicyLab" >&2
+    echo "[RoboDojo][ERROR] See https://github.com/JinhuiYE/XPolicyLab/tree/fix/starvla-hf-robodojo-eval" >&2
+    exit 1
+fi
+
+xpolicylab_commit="$(git -C "${xpolicylab_root}" rev-parse HEAD 2>/dev/null || echo unknown)"
+robodojo_commit="$(git -C "${robodojo_root}" rev-parse HEAD 2>/dev/null || echo unknown)"
+echo "[RoboDojo] XPolicyLab commit: ${xpolicylab_commit}"
+echo "[RoboDojo] RoboDojo commit: ${robodojo_commit}"
+echo "[RoboDojo] Delegating to ${entrypoint}"
+
+exec bash "${entrypoint}" "$@"

--- a/examples/simBenchmarks/RoboDojo/train_files/data_registry/data_config.py
+++ b/examples/simBenchmarks/RoboDojo/train_files/data_registry/data_config.py
@@ -1,0 +1,98 @@
+"""RoboDojo LeRobot v2.1 data registration for the dual-arm ARX X5."""
+
+from starVLA.dataloader.gr00t_lerobot.datasets import ModalityConfig
+from starVLA.dataloader.gr00t_lerobot.embodiment_tags import EmbodimentTag
+from starVLA.dataloader.gr00t_lerobot.transform.base import ComposedModalityTransform
+from starVLA.dataloader.gr00t_lerobot.transform.state_action import (
+    StateActionToTensor,
+    StateActionTransform,
+)
+
+
+class RoboDojoArxX5H50Q99DataConfig:
+    """Three-camera, 14D state/action format used by the released policies."""
+
+    embodiment_tag = EmbodimentTag.ARX_X5
+    video_keys = [
+        "video.cam_high",
+        "video.cam_left_wrist",
+        "video.cam_right_wrist",
+    ]
+    state_keys = [
+        "state.left_joints",
+        "state.left_gripper",
+        "state.right_joints",
+        "state.right_gripper",
+    ]
+    action_keys = [
+        "action.left_joints",
+        "action.left_gripper",
+        "action.right_joints",
+        "action.right_gripper",
+    ]
+    state_key_dims = {
+        "state.left_joints": 6,
+        "state.left_gripper": 1,
+        "state.right_joints": 6,
+        "state.right_gripper": 1,
+    }
+    action_key_dims = {
+        "action.left_joints": 6,
+        "action.left_gripper": 1,
+        "action.right_joints": 6,
+        "action.right_gripper": 1,
+    }
+    language_keys = ["annotation.human.action.task_description"]
+    observation_indices = [0]
+    action_indices = list(range(50))
+
+    def modality_config(self):
+        return {
+            "video": ModalityConfig(
+                delta_indices=self.observation_indices,
+                modality_keys=self.video_keys,
+            ),
+            "state": ModalityConfig(
+                delta_indices=self.observation_indices,
+                modality_keys=self.state_keys,
+            ),
+            "action": ModalityConfig(
+                delta_indices=self.action_indices,
+                modality_keys=self.action_keys,
+            ),
+            "language": ModalityConfig(
+                delta_indices=self.observation_indices,
+                modality_keys=self.language_keys,
+            ),
+        }
+
+    def transform(self):
+        state_modes = {key: "q99" for key in self.state_keys}
+        action_modes = {key: "q99" for key in self.action_keys}
+        return ComposedModalityTransform(
+            transforms=[
+                StateActionToTensor(apply_to=self.state_keys),
+                StateActionTransform(
+                    apply_to=self.state_keys,
+                    normalization_modes=state_modes,
+                ),
+                StateActionToTensor(apply_to=self.action_keys),
+                StateActionTransform(
+                    apply_to=self.action_keys,
+                    normalization_modes=action_modes,
+                ),
+            ]
+        )
+
+
+_ROBOT_TYPE = "robodojo_arx_x5_h50_q99"
+
+ROBOT_TYPE_CONFIG_MAP = {
+    _ROBOT_TYPE: RoboDojoArxX5H50Q99DataConfig(),
+}
+
+DATASET_NAMED_MIXTURES = {
+    "robodojo_v21_all_h50_q99": [
+        ("RoboDojo_lerobot_v21_video", 1.0, _ROBOT_TYPE),
+    ],
+}

--- a/examples/simBenchmarks/RoboDojo/train_files/modality.json
+++ b/examples/simBenchmarks/RoboDojo/train_files/modality.json
@@ -1,0 +1,62 @@
+{
+  "action": {
+    "left_joints": {
+      "start": 0,
+      "end": 6,
+      "original_key": "action"
+    },
+    "left_gripper": {
+      "start": 6,
+      "end": 7,
+      "original_key": "action"
+    },
+    "right_joints": {
+      "start": 7,
+      "end": 13,
+      "original_key": "action"
+    },
+    "right_gripper": {
+      "start": 13,
+      "end": 14,
+      "original_key": "action"
+    }
+  },
+  "state": {
+    "left_joints": {
+      "start": 0,
+      "end": 6,
+      "original_key": "observation.state"
+    },
+    "left_gripper": {
+      "start": 6,
+      "end": 7,
+      "original_key": "observation.state"
+    },
+    "right_joints": {
+      "start": 7,
+      "end": 13,
+      "original_key": "observation.state"
+    },
+    "right_gripper": {
+      "start": 13,
+      "end": 14,
+      "original_key": "observation.state"
+    }
+  },
+  "video": {
+    "cam_high": {
+      "original_key": "observation.images.cam_high"
+    },
+    "cam_left_wrist": {
+      "original_key": "observation.images.cam_left_wrist"
+    },
+    "cam_right_wrist": {
+      "original_key": "observation.images.cam_right_wrist"
+    }
+  },
+  "annotation": {
+    "human.action.task_description": {
+      "original_key": "task_index"
+    }
+  }
+}

--- a/examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh
+++ b/examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  config_yaml=<recipe.yaml> \
+  robodojo_data_root=/path/to/datasets \
+  bash examples/simBenchmarks/RoboDojo/train_files/run_robodojo_train.sh \
+    [train_starvla.py overrides...]
+
+Expected dataset:
+  <robodojo_data_root>/RoboDojo_lerobot_v21_video
+
+Useful variables:
+  NUM_PROCESSES       Total Accelerate process count (auto-detected by default)
+  NUM_MACHINES        Number of training machines (default: 1)
+  MACHINE_RANK        Rank of this machine (default: 0)
+  MAIN_PROCESS_IP     Required for multi-machine training
+  MAIN_PROCESS_PORT   Main process port (default: 29500)
+  DRY_RUN=1           Print the resolved command without starting training
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+config_yaml="${config_yaml:-examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenoft_h50_q99.yaml}"
+robodojo_data_root="${robodojo_data_root:-playground/Datasets}"
+dataset_dir="${robodojo_data_root}/RoboDojo_lerobot_v21_video"
+num_machines="${NUM_MACHINES:-1}"
+machine_rank="${MACHINE_RANK:-0}"
+main_process_ip="${MAIN_PROCESS_IP:-}"
+main_process_port="${MAIN_PROCESS_PORT:-29500}"
+
+if [[ ! -f "${config_yaml}" ]]; then
+    echo "[RoboDojo][ERROR] Training config not found: ${config_yaml}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${dataset_dir}/meta/info.json" || ! -f "${dataset_dir}/meta/modality.json" ]]; then
+    echo "[RoboDojo][ERROR] Official LeRobot v2.1 dataset not found: ${dataset_dir}" >&2
+    echo "[RoboDojo][ERROR] Download it with RoboDojo's scripts/RoboDojo/download_data.sh huggingface lerobot_v2.1." >&2
+    exit 1
+fi
+
+if [[ ! "${num_machines}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[RoboDojo][ERROR] NUM_MACHINES must be a positive integer: ${num_machines}" >&2
+    exit 2
+fi
+
+if [[ -n "${NUM_PROCESSES:-}" ]]; then
+    num_processes="${NUM_PROCESSES}"
+elif [[ -n "${CUDA_VISIBLE_DEVICES:-}" && "${CUDA_VISIBLE_DEVICES}" != "-1" ]]; then
+    IFS=',' read -r -a visible_devices <<< "${CUDA_VISIBLE_DEVICES}"
+    local_gpu_count="${#visible_devices[@]}"
+    num_processes="$((local_gpu_count * num_machines))"
+elif command -v nvidia-smi >/dev/null 2>&1; then
+    local_gpu_count="$(nvidia-smi -L | wc -l)"
+    num_processes="$((local_gpu_count * num_machines))"
+else
+    echo "[RoboDojo][ERROR] Cannot detect GPUs; set NUM_PROCESSES explicitly." >&2
+    exit 1
+fi
+
+if [[ ! "${num_processes}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[RoboDojo][ERROR] NUM_PROCESSES must be a positive integer: ${num_processes}" >&2
+    exit 2
+fi
+
+if (( num_machines > 1 )) && [[ -z "${main_process_ip}" ]]; then
+    echo "[RoboDojo][ERROR] MAIN_PROCESS_IP is required for multi-machine training." >&2
+    exit 2
+fi
+
+export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-false}"
+export HF_HOME="${HF_HOME:-${REPO_ROOT}/playground/Cache/huggingface}"
+
+cmd=(
+    accelerate launch
+    --config_file starVLA/config/deepseeds/deepspeed_zero2.yaml
+    --num_processes "${num_processes}"
+)
+
+if (( num_machines > 1 )); then
+    cmd+=(
+        --num_machines "${num_machines}"
+        --machine_rank "${machine_rank}"
+        --main_process_ip "${main_process_ip}"
+        --main_process_port "${main_process_port}"
+    )
+fi
+
+cmd+=(
+    starVLA/training/train_starvla.py
+    --config_yaml "${config_yaml}"
+    --datasets.vla_data.data_root_dir "${robodojo_data_root}"
+    "$@"
+)
+
+echo "[RoboDojo] config: ${config_yaml}"
+echo "[RoboDojo] dataset: ${dataset_dir}"
+echo "[RoboDojo] processes: ${num_processes}; machines: ${num_machines}; rank: ${machine_rank}"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '[RoboDojo] DRY_RUN command:'
+    printf ' %q' "${cmd[@]}"
+    printf '\n'
+    exit 0
+fi
+
+exec "${cmd[@]}"

--- a/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwengroot_h50_q99.yaml
+++ b/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwengroot_h50_q99.yaml
@@ -1,0 +1,90 @@
+run_id: robodojo_v21_all_h50_q99_qwengroot
+run_root_dir: playground/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: QwenGR00T
+  qwenvl:
+    base_vlm: Qwen/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+  action_model:
+    action_model_type: DiT-B
+    action_hidden_dim: 1024
+    hidden_size: 1024
+    add_pos_embed: true
+    max_seq_len: 1024
+    action_dim: 14
+    state_dim: 14
+    action_horizon: 50
+    repeated_diffusion_steps: 8
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    num_inference_timesteps: 4
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: ada_norm
+      num_layers: 16
+      output_dim: 1024
+      positional_embeddings: null
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: sharegpt4v_coco
+    eval_dataset: sharegpt4v_coco
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 50176
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+  vla_data:
+    dataset_py: lerobot_datasets
+    include_state: true
+    data_root_dir: playground/Datasets
+    data_mix: robodojo_v21_all_h50_q99
+    action_type: abs_qpos
+    action_mode: abs
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs_image_size: [224, 224]
+    video_backend: torchvision_av
+
+trainer:
+  max_train_steps: 130000
+  num_warmup_steps: 5000
+  save_interval: 10000
+  eval_interval: 100
+  learning_rate:
+    base: 1.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ""
+  loss_scale:
+    vla: 1.0
+    vlm: 0.0
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08

--- a/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenoft_h50_q99.yaml
+++ b/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenoft_h50_q99.yaml
@@ -1,0 +1,89 @@
+run_id: robodojo_v21_all_h50_q99_qwenoft
+run_root_dir: playground/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: QwenOFT
+  qwenvl:
+    base_vlm: Qwen/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+  action_model:
+    action_model_type: MLP
+    action_dim: 14
+    state_dim: 14
+    action_horizon: 50
+    hidden_size: 1024
+    add_pos_embed: true
+    max_seq_len: 1024
+    repeated_diffusion_steps: 8
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    num_inference_timesteps: 4
+    num_target_vision_tokens: 32
+    diffusion_model_cfg:
+      dropout: 0.2
+      final_dropout: true
+      interleave_self_attention: true
+      norm_type: ada_norm
+      num_layers: 16
+      output_dim: 2560
+      positional_embeddings: null
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: sharegpt4v_coco
+    eval_dataset: sharegpt4v_coco
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 50176
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+  vla_data:
+    dataset_py: lerobot_datasets
+    include_state: true
+    data_root_dir: playground/Datasets
+    data_mix: robodojo_v21_all_h50_q99
+    action_type: abs_qpos
+    action_mode: abs
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs_image_size: [224, 224]
+    video_backend: torchvision_av
+
+trainer:
+  max_train_steps: 100000
+  num_warmup_steps: 5000
+  save_interval: 10000
+  eval_interval: 100
+  learning_rate:
+    base: 1.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ""
+  loss_scale:
+    vla: 1.0
+    vlm: 0.0
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08

--- a/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml
+++ b/examples/simBenchmarks/RoboDojo/train_files/starvla_robodojo_v21_qwenpi_v3_h50_q99.yaml
@@ -1,0 +1,91 @@
+run_id: robodojo_v21_all_h50_q99_qwenpi_v3
+run_root_dir: playground/Checkpoints
+seed: 42
+wandb_entity: your_wandb_entity
+wandb_project: llavavla
+is_debug: false
+version_id: "0.21"
+
+framework:
+  name: QwenPI_v3
+  qwenvl:
+    base_vlm: Qwen/Qwen3-VL-4B-Instruct
+    attn_implementation: flash_attention_2
+    num_vl_layers: 36
+  action_model:
+    action_model_type: LayerwiseFM
+    action_dim: 14
+    state_dim: 14
+    action_horizon: 50
+    repeated_diffusion_steps: 2
+    num_inference_timesteps: 4
+    add_pos_embed: true
+    max_seq_len: 1024
+    num_target_vision_tokens: 32
+    noise_beta_alpha: 1.5
+    noise_beta_beta: 1.0
+    noise_s: 0.999
+    num_timestep_buckets: 1000
+    diffusion_model_cfg:
+      action_dit_hidden_dim: 1024
+      dropout: 0.2
+      final_dropout: true
+      # RoboDojo PI-v3 was trained with alternating cross/self-attention.
+      interleave_self_attention: true
+      norm_type: ada_norm
+      positional_embeddings: null
+      attention_head_dim: 64
+
+datasets:
+  vlm_data:
+    dataset_py: vlm_datasets
+    dataformat: llava_json
+    dataset_use: sharegpt4v_coco
+    eval_dataset: sharegpt4v_coco
+    data_flatten: false
+    base_interval: 2
+    max_pixels: 50176
+    min_pixels: 784
+    model_max_length: 2048
+    model_type: qwen2.5vl
+    per_device_batch_size: 4
+  vla_data:
+    dataset_py: lerobot_datasets
+    include_state: true
+    data_root_dir: playground/Datasets
+    data_mix: robodojo_v21_all_h50_q99
+    action_type: abs_qpos
+    action_mode: abs
+    per_device_batch_size: 16
+    load_all_data_for_training: true
+    obs_image_size: [224, 224]
+    video_backend: torchvision_av
+
+trainer:
+  max_train_steps: 100000
+  num_warmup_steps: 5000
+  save_interval: 10000
+  eval_interval: 100
+  learning_rate:
+    base: 1.0e-05
+    qwen_vl_interface: 1.0e-05
+    action_model: 1.0e-04
+  lr_scheduler_type: cosine_with_min_lr
+  scheduler_specific_kwargs:
+    min_lr: 5.0e-07
+  freeze_modules: ""
+  loss_scale:
+    vla: 1.0
+    vlm: 0.0
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  logging_frequency: 10
+  gradient_clipping: 1.0
+  gradient_accumulation_steps: 1
+  gradient_checkpointing: true
+  optimizer:
+    name: AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-08
+    weight_decay: 1.0e-08
+  repeated_diffusion_steps: 2

--- a/starVLA/dataloader/gr00t_lerobot/embodiment_tags.py
+++ b/starVLA/dataloader/gr00t_lerobot/embodiment_tags.py
@@ -65,6 +65,10 @@ class EmbodimentTag(Enum):
     """ The ARX5 single-arm robot.
     """
 
+    ARX_X5 = 'arx_x5'
+    """ The ARX X5 dual-arm robot used by RoboDojo.
+    """
+
     DOS_W1 = 'dos-w1'
     """ The DOS-W1 single-arm robot.
     """
@@ -81,6 +85,7 @@ EMBODIMENT_TAG_MAPPING = {
     EmbodimentTag.ALOHA.value: 7,
     EmbodimentTag.UR5.value: 8,
     EmbodimentTag.ARX5.value: 9,
+    EmbodimentTag.ARX_X5.value: 9,
     EmbodimentTag.DOS_W1.value: 10,
 }
 


### PR DESCRIPTION
## Summary

- add RoboDojo to `examples/simBenchmarks` and the project README;
- register the official RoboDojo LeRobot v2.1 dataset in place (three RGB views, raw 14D state, 14D absolute-joint action, horizon 50, continuous-gripper q99 normalization);
- add released-checkpoint training recipes for QwenOFT, QwenGR00T, and QwenPI_v3;
- add a thin path-based evaluation entry point that delegates to the maintained XPolicyLab integration;
- document the three public Hugging Face checkpoints, their runtime contract, and reproduced `build_tower` results.

The dataset is downloaded directly with RoboDojo's official downloader; this PR adds no conversion path. It also does **not** modify StarVLA model-forward code or rollout/action-execution step logic. Released-checkpoint preparation, policy serving, runtime checks, and RoboDojo launch remain in the companion [XPolicyLab PR #90](https://github.com/XPolicyLab/XPolicyLab/pull/90).

## PI-v3 compatibility

The released RoboDojo PI-v3 checkpoint uses the canonical alternating self/cross-attention forward. Its training recipe therefore explicitly sets:

```yaml
diffusion_model_cfg:
  interleave_self_attention: true
```

The companion launcher additionally verifies checkpoint/sidecar hashes and rejects a server unless its metadata handshake reports the expected RGB order, single state-normalization boundary, unnormalized 14D absolute actions, 50-action chunk, and `pi_v3_forward=canonical_interleaved`.

## Reproduce the first check

Place XPolicyLab inside the RoboDojo checkout as documented, then run from the StarVLA root:

```bash
ROBODOJO_PATH=/absolute/path/to/RoboDojo \
bash examples/simBenchmarks/RoboDojo/eval_files/start_eval.sh \
  pi_v3 build_tower 0 0 1 \
  "$STARVLA_ENV_PATH" "$ROBODOJO_ENV_PATH" 10
```

The wrapper starts both the matching policy server and simulator; do not start a second model server manually.

## Validation

Pinned integration revisions:

- RoboDojo: `36bfcb7c580b149c6e39ed2eb77d60689152e570`
- XPolicyLab: `65da3de0ac99898f3540e76d74998af92cf372b0`

| Released checkpoint | Model-card success / score | Reproduced success / score | Unstable |
|---|---:|---:|---:|
| QwenOFT | 36% / 50.60 | 4/10 / 58.00 | 0 |
| QwenGR00T | 14% / 20.80 | 1/10 / 20.00 | 0 |
| QwenPI_v3 | 56% / 65.00 | 5/10 / 57.00 | 0 |

The exact StarVLA entry point above was also rerun for PI-v3 on four seed-0 layouts: **2/4 success, score 65.00, unstable 0**. Isaac reached `Simulation App Startup Complete`, all four episodes completed, and all three camera videos were written.

Additional checks:

- the checked-in `modality.json` SHA256 matches the physical downloaded dataset metadata;
- registry auto-discovery succeeds in the StarVLA training environment;
- the training launcher resolves against the real 3,500-episode / 35-task dataset in `DRY_RUN=1` mode;
- shell syntax, YAML/JSON contracts, and `git diff --check` pass.
