### PR TITLE
[docs] fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The codebase was originally forked from [InternVLA-M1](https://github.com/Intern
 ## Star History
 Here's how our community has grown over time:
 
-[![Star History Chart](https://api.star-history.com/svg?repos=starVLA/starVLA&type=date&legend=bottom-right)](https://www.star-history.com/#starVLA/starVLA&type=date&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=starVLA/starVLA&type=date&legend=bottom-right)](https://star-history.dera.page/#starVLA/starVLA&type=date&legend=bottom-right)
 
 
 <!-- *Chart updates automatically. Click to interact with the full timeline.* -->


### PR DESCRIPTION
The star history chart in the README no longer renders because the upstream stargazer API it relied on is restricted. This PR updates the chart to use the star-history.dera.page endpoint, restoring a working, automatically updating view of our community growth.

A fix is necessary because the current chart is broken for visitors, so let's bring it back.