### PR TITLE
[fix] (openpi): support Transformers 5.x Gemma APIs

### DIFF
--- a/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
+++ b/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
@@ -39,7 +39,17 @@ from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple
 from transformers.utils.deprecation import deprecate_kwarg
-from transformers.utils.generic import check_model_inputs
+
+try:
+    from transformers.utils.generic import check_model_inputs
+except ImportError:
+    from transformers.utils.generic import merge_with_config_defaults
+    from transformers.utils.output_capturing import capture_outputs
+
+    def check_model_inputs(forward):
+        return merge_with_config_defaults(capture_outputs(forward))
+
+
 from .configuration_gemma import GemmaConfig
 
 
@@ -110,11 +120,23 @@ class GemmaRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        if self.rope_type == "default":
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS.get("default", self.compute_default_rope_parameters)
+        else:
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.original_inv_freq = self.inv_freq
+
+    @staticmethod
+    def compute_default_rope_parameters(config: GemmaConfig, device=None, seq_len=None):
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * getattr(config, "partial_rotary_factor", 1.0))
+        inv_freq = 1.0 / (
+            config.rope_theta ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, 1.0
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
@@ -412,11 +434,14 @@ class GemmaModel(GemmaPreTrainedModel):
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
+        # Transformers 5 renamed `input_embeds` to `inputs_embeds`, and later
+        # made the cache arguments keyword-only. Keep the renamed input
+        # positional while spelling out the stable cache argument names.
         causal_mask = create_causal_mask(
-            config=self.config,
-            input_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            cache_position=cache_position,
+            self.config,
+            inputs_embeds,
+            attention_mask,
+            cache_position,
             past_key_values=past_key_values,
             position_ids=position_ids,
         )
@@ -448,7 +473,7 @@ class GemmaModel(GemmaPreTrainedModel):
 
 @auto_docstring
 class GemmaForCausalLM(GemmaPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
+++ b/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
@@ -19,6 +19,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 from typing import Callable, Optional, Union
 
 import torch
@@ -41,16 +42,19 @@ from transformers.utils import TransformersKwargs, auto_docstring, can_return_tu
 from transformers.utils.deprecation import deprecate_kwarg
 
 try:
-    from transformers.utils.generic import check_model_inputs
-except ImportError:
     from transformers.utils.generic import merge_with_config_defaults
     from transformers.utils.output_capturing import capture_outputs
+except ImportError:
+    from transformers.utils.generic import check_model_inputs
+else:
 
     def check_model_inputs(forward):
         return merge_with_config_defaults(capture_outputs(forward))
 
 
 from .configuration_gemma import GemmaConfig
+
+_CREATE_CAUSAL_MASK_SUPPORTS_CACHE_POSITION = "cache_position" in inspect.signature(create_causal_mask).parameters
 
 
 class GemmaRMSNorm(nn.Module):
@@ -434,16 +438,19 @@ class GemmaModel(GemmaPreTrainedModel):
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
-        # Transformers 5 renamed `input_embeds` to `inputs_embeds`, and later
-        # made the cache arguments keyword-only. Keep the renamed input
-        # positional while spelling out the stable cache argument names.
+        # Transformers 5 renamed `input_embeds` to `inputs_embeds`, made the
+        # cache arguments keyword-only, and later removed `cache_position`.
+        causal_mask_kwargs = {
+            "past_key_values": past_key_values,
+            "position_ids": position_ids,
+        }
+        if _CREATE_CAUSAL_MASK_SUPPORTS_CACHE_POSITION:
+            causal_mask_kwargs["cache_position"] = cache_position
         causal_mask = create_causal_mask(
             self.config,
             inputs_embeds,
             attention_mask,
-            cache_position,
-            past_key_values=past_key_values,
-            position_ids=position_ids,
+            **causal_mask_kwargs,
         )
 
         # embed positions

--- a/tests/test_openpi_gemma_transformers_compat.py
+++ b/tests/test_openpi_gemma_transformers_compat.py
@@ -1,8 +1,10 @@
 import unittest
+from unittest import mock
 
 import torch
 
 from starVLA.model.modules.action_model.OpenPI_ActionHead import GemmaDims, OpenPIGemma
+from starVLA.model.modules.vlm.openpi_transformers.gemma import modeling_gemma
 
 
 class OpenPIGemmaTransformersCompatTest(unittest.TestCase):
@@ -24,18 +26,65 @@ class OpenPIGemmaTransformersCompatTest(unittest.TestCase):
                 action_expert = OpenPIGemma(config, use_adarms=use_adarms).eval()
                 action_expert.model.config._attn_implementation = "eager"
                 adarms_cond = torch.zeros(1, config.width) if use_adarms else None
+                forward_kwargs = {
+                    "inputs_embeds": inputs_embeds,
+                    "attention_mask": attention_mask,
+                    "position_ids": position_ids,
+                    "use_cache": False,
+                    "adarms_cond": adarms_cond,
+                }
 
                 with torch.no_grad():
                     output = action_expert.model.forward(
-                        inputs_embeds=inputs_embeds,
-                        attention_mask=attention_mask,
-                        position_ids=position_ids,
-                        use_cache=False,
-                        adarms_cond=adarms_cond,
+                        **forward_kwargs,
+                        output_hidden_states=True,
+                        output_attentions=True,
                     )
+                    tuple_output = action_expert.model.forward(**forward_kwargs, return_dict=False)
 
                 self.assertEqual(output.last_hidden_state.shape, inputs_embeds.shape)
                 self.assertTrue(torch.isfinite(output.last_hidden_state).all())
+                self.assertEqual(len(output.hidden_states), config.depth + 1)
+                self.assertEqual(len(output.attentions), config.depth)
+                self.assertIsInstance(tuple_output, tuple)
+
+    def test_forward_without_cache_position_mask_parameter(self):
+        config = GemmaDims(width=16, depth=1, mlp_dim=32, num_heads=2, num_kv_heads=1, head_dim=8)
+        action_expert = OpenPIGemma(config, use_adarms=False).eval()
+        action_expert.model.config._attn_implementation = "eager"
+        inputs_embeds = torch.randn(1, 3, config.width)
+        attention_mask = torch.zeros(1, 1, 3, 3)
+        position_ids = torch.arange(3).unsqueeze(0)
+
+        def create_causal_mask_without_cache_position(
+            config,
+            inputs_embeds,
+            attention_mask,
+            past_key_values,
+            position_ids=None,
+        ):
+            return attention_mask
+
+        with (
+            mock.patch.object(modeling_gemma, "_CREATE_CAUSAL_MASK_SUPPORTS_CACHE_POSITION", False),
+            mock.patch.object(
+                modeling_gemma,
+                "create_causal_mask",
+                side_effect=create_causal_mask_without_cache_position,
+            ) as create_mask,
+            torch.no_grad(),
+        ):
+            output = action_expert.model.forward(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=False,
+                adarms_cond=None,
+            )
+
+        self.assertEqual(output.last_hidden_state.shape, inputs_embeds.shape)
+        self.assertNotIn("cache_position", create_mask.call_args.kwargs)
+        self.assertIn("past_key_values", create_mask.call_args.kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/test_openpi_gemma_transformers_compat.py
+++ b/tests/test_openpi_gemma_transformers_compat.py
@@ -1,0 +1,42 @@
+import unittest
+
+import torch
+
+from starVLA.model.modules.action_model.OpenPI_ActionHead import GemmaDims, OpenPIGemma
+
+
+class OpenPIGemmaTransformersCompatTest(unittest.TestCase):
+    def test_tiny_action_expert_forward(self):
+        config = GemmaDims(
+            width=16,
+            depth=1,
+            mlp_dim=32,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=8,
+        )
+        inputs_embeds = torch.randn(1, 3, config.width)
+        attention_mask = torch.zeros(1, 1, 3, 3)
+        position_ids = torch.arange(3).unsqueeze(0)
+
+        for use_adarms in (False, True):
+            with self.subTest(use_adarms=use_adarms):
+                action_expert = OpenPIGemma(config, use_adarms=use_adarms).eval()
+                action_expert.model.config._attn_implementation = "eager"
+                adarms_cond = torch.zeros(1, config.width) if use_adarms else None
+
+                with torch.no_grad():
+                    output = action_expert.model.forward(
+                        inputs_embeds=inputs_embeds,
+                        attention_mask=attention_mask,
+                        position_ids=position_ids,
+                        use_cache=False,
+                        adarms_cond=adarms_cond,
+                    )
+
+                self.assertEqual(output.last_hidden_state.shape, inputs_embeds.shape)
+                self.assertTrue(torch.isfinite(output.last_hidden_state).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Make the vendored OpenPI Gemma implementation compatible with both the repository-pinned Transformers 4.57 API and Transformers 5.x environments required by Qwen3.5.

## Motivation

Closes #438

On the current `starVLA_dev` baseline, importing the module succeeds with Transformers 4.57.0 but fails with 5.2.0 because `check_model_inputs` was removed. Exercising the real OpenPI action-expert path exposed additional 5.x protocol changes in default RoPE initialization, tied-weight metadata, output capture, and causal-mask arguments.

## Changes

- Prefer the official `merge_with_config_defaults` + `capture_outputs` composition whenever available, falling back to the legacy decorator only on older Transformers.
- Provide the default RoPE initializer expected by 5.x while preserving the 4.57 registry path.
- Use tied-weight metadata accepted by both APIs.
- Detect whether `create_causal_mask` accepts `cache_position`, covering the 4.57 name, 5.2 rename, 5.7 keyword-only cache argument, and current Transformers `main` removal.
- Add production-path tiny forward tests for both PI0 (`use_adarms=False`) and PI0.5 (`use_adarms=True`) action experts using `inputs_embeds` and a 4D mask.
- Cover hidden-state/attention capture, tuple returns, and a main-style causal-mask callable without `cache_position`.

## Testing

- [x] Regression tests pass with Transformers 4.57.0
- [x] Regression tests pass with Transformers 5.2.0
- [x] Regression tests pass with Transformers 5.3.0
- [x] Regression tests pass with Transformers 5.7.0
- [x] Main-style `create_causal_mask` signature without `cache_position` is covered directly
- [x] 11 focused CPU regression tests pass, including both compatibility tests
- [x] A800 CUDA forward passes on GPU 4 with PyTorch 2.5.1+cu121 and Transformers 4.57.6
- [x] `black --check` passes on both changed files
- [x] Ruff passes on the new test; the vendored file retains exactly the same 8 historical Ruff findings as the upstream baseline

The A800 host cannot reach public PyPI and its configured mirror does not provide Transformers 5.2, so the 5.2/5.3/5.7 matrix was run in isolated local CPU environments. The CUDA run separately validates the same PI0/PI0.5 tensor path and backward compatibility on the repository 4.57 line. No checkpoint or external model download is required.

## Breaking Changes

None. The default `requirements.txt` pin remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] No shared dataloader, trainer, or config files modified
- [x] Regression tests included
