### PR TITLE
[fix] (vlm): use configured attn_implementation in QWen3_5 for VLA training

### DIFF
--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -59,7 +59,6 @@ class _QWen3_5_VL_Interface(nn.Module):
         model_id = qwenvl_config.get("base_vlm", "Qwen/Qwen3.5-VL-4B-Instruct")
         attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")
 
-        attn_implementation = "sdpa"
         # Fallback to sdpa if flash_attention_2 is requested but flash_attn is not installed
         if attn_implementation == "flash_attention_2":
             if not has_flash_attn():


### PR DESCRIPTION
# [fix] (vlm): use configured attn_implementation in QWen3_5 for VLA training

## Bug

`starVLA/model/modules/vlm/QWen3_5.py` reads the configured attention backend and then unconditionally overwrites it on the next line:

```python
attn_implementation = qwenvl_config.get("attn_implementation", "sdpa")

attn_implementation = "sdpa"        # <- overrides whatever was configured
```

Overwriting `attn_implementation` forces the model to use SDPA for attention computation, which may harm the performance (see below).

## Fix

Delete the override line. The existing flash-attn availability fallback remains the same.

## Performance

Measured on stock starVLA at this commit, Qwen3.5-VL-4B, single H200, bf16 autocast, LIBERO-shaped batches (2 images/sample @224px -> 256 patches/image, text+vision sequence padded to 192), p50 over 20-50 reps. Full VLM forward+backward:

| per-GPU batch | sdpa (forced today) | flash_attention_2 | best |
|---|---|---|---|
| 8 | 178.1 ms | **169.7 ms** | fa2, by 4.7% |
| 32 (large-batch training) | 586.3 ms | **517.1 ms** | fa2, by 13.4% |

The mechanism is in the vision tower: **the SDPA path runs one attention call per image per layer**, while the FA2 path batches all images into a single varlen kernel per layer. With many images (large batch), the SDPA method is launched repeatedly, incurring high kernel-launch overhead.

## Validation

- With this fix, `attn_implementation: flash_attention_2` is honored end to end (`model.config.text_config._attn_implementation == "flash_attention_2"` after `from_pretrained`; the old code silently produced sdpa).
- With flash_attn absent, the existing fallback still degrades to sdpa with a warning; no crash.
- No numerics change for any fixed backend choice; the default remains `sdpa`, so configs that do not set the key behave exactly as before.
