### PR TITLE
[fix] (model): pad mixed-resolution images

### DIFF
--- a/starVLA/model/tools.py
+++ b/starVLA/model/tools.py
@@ -409,7 +409,7 @@ def preprocess_images(image_list, target_size, mode="crop"):  #  [B, [PLT]]
 
             shapes.add((img.shape[1], img.shape[2]))
             epi_images.append(img)
-        batch_images.append(torch.stack(epi_images))
+        batch_images.append(epi_images)
 
     # Check if we have different shapes
     # In theory our model can also work well with different shapes
@@ -420,24 +420,27 @@ def preprocess_images(image_list, target_size, mode="crop"):  #  [B, [PLT]]
         max_width = max(shape[1] for shape in shapes)
 
         # Pad images if necessary
-        padded_images = []
-        for img in batch_images:
-            h_padding = max_height - img.shape[1]
-            w_padding = max_width - img.shape[2]
+        padded_batch_images = []
+        for epi_images in batch_images:
+            padded_images = []
+            for img in epi_images:
+                h_padding = max_height - img.shape[1]
+                w_padding = max_width - img.shape[2]
 
-            if h_padding > 0 or w_padding > 0:
-                pad_top = h_padding // 2
-                pad_bottom = h_padding - pad_top
-                pad_left = w_padding // 2
-                pad_right = w_padding - pad_left
+                if h_padding > 0 or w_padding > 0:
+                    pad_top = h_padding // 2
+                    pad_bottom = h_padding - pad_top
+                    pad_left = w_padding // 2
+                    pad_right = w_padding - pad_left
 
-                img = torch.nn.functional.pad(
-                    img, (pad_left, pad_right, pad_top, pad_bottom), mode="constant", value=1.0
-                )
-            padded_images.append(img)
-        batch_images = padded_images
+                    img = torch.nn.functional.pad(
+                        img, (pad_left, pad_right, pad_top, pad_bottom), mode="constant", value=1.0
+                    )
+                padded_images.append(img)
+            padded_batch_images.append(padded_images)
+        batch_images = padded_batch_images
 
-    batch_images = torch.stack(batch_images)  # concatenate images
+    batch_images = torch.stack([torch.stack(images) for images in batch_images])
 
     # Ensure correct shape when single image
     if len(image_list) == 1:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,0 +1,36 @@
+import unittest
+
+import torch
+from PIL import Image
+
+from starVLA.model.tools import preprocess_images
+
+
+class PreprocessImagesTest(unittest.TestCase):
+    def test_different_view_resolutions_are_padded_before_stacking(self):
+        images = [
+            [
+                Image.new("RGB", (640, 480), "red"),
+                Image.new("RGB", (640, 320), "blue"),
+            ]
+        ]
+
+        result = preprocess_images(images, target_size=224, mode="crop")
+
+        self.assertEqual(result.shape, (1, 2, 3, 168, 224))
+        self.assertTrue(torch.all(result[0, 1, :, :28, :] == 1))
+        self.assertTrue(torch.all(result[0, 1, :, -28:, :] == 1))
+
+    def test_different_sample_resolutions_are_padded_before_stacking(self):
+        images = [
+            [Image.new("RGB", (640, 480), "red")],
+            [Image.new("RGB", (640, 320), "blue")],
+        ]
+
+        result = preprocess_images(images, target_size=224, mode="crop")
+
+        self.assertEqual(result.shape, (2, 1, 3, 168, 224))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Pad each resized image before stacking ABot-M0's view and batch dimensions, so mixed camera or sample resolutions produce a valid VGGT input tensor.

## Motivation

Closes #451.

`preprocess_images` currently stacks each sample's views before its different-shape padding branch. Mixed-resolution views therefore fail immediately. When resolutions differ across samples instead, the branch receives four-dimensional tensors and interprets their channel and height dimensions as height and width, producing incompatible padded shapes.

## Changes

- keep resized images as individual `(C, H, W)` tensors until dimensions are known
- apply the existing centered white padding to each image before stacking views and samples
- add regressions for different resolutions within one multi-view sample and across samples

## Testing

- `python -m unittest discover -s tests -p 'test_*.py' -v` (`35 passed`)
- confirmed both new tests fail on unmodified `starVLA_dev`
- H100 smoke: produced and transferred `(1, 2, 3, 168, 224)` output to CUDA
- Black check passes for the modified function and the new test file
- Ruff passes for the new test file; `starVLA/model/tools.py` retains its 23 pre-existing whole-file Ruff findings, with no new finding in the modified region
- `git diff --check`

The change is covered without loading ABot-M0 or VGGT weights because the failure occurs entirely in the deterministic image preprocessing step before the VGGT aggregator.

## Breaking Changes

None. Uniform-resolution inputs keep the same shape and preprocessing behavior.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/`
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated - the shared model utility change is limited to the broken stacking block
- [x] The required shared-file modification is justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (public)

## Screenshots / Logs (optional)

Before:

```text
RuntimeError: stack expects each tensor to be equal size, but got
[3, 168, 224] at entry 0 and [3, 112, 224] at entry 1
```

After:

```text
H100 smoke: shape=(1, 2, 3, 168, 224), dtype=torch.float32, device=cuda:0
```
