### PR TITLE
[perf] (Dataloader): opt-in DataLoader preprocessing for QwenPI (Qwen3.5), with optional fixed-length padding

### DIFF
--- a/starVLA/dataloader/__init__.py
+++ b/starVLA/dataloader/__init__.py
@@ -45,9 +45,25 @@ def build_dataloader(cfg, dataset_py="lerobot_datasets_oxe"): # TODO now here on
             balance_trajectory_weights=vla_dataset_cfg.get("balance_trajectory_weights", False),
         )
         num_workers = int(vla_dataset_cfg.get("num_workers", 4))
+        batch_collate = collate_fn
+        if bool(vla_dataset_cfg.get("preprocess_in_collate", False)):
+            # Ask the framework for its preprocessing collate (CPU work moves
+            # into DataLoader workers). Frameworks opt in by overriding
+            # baseframework.build_collate; everything else keeps raw examples.
+            from starVLA.model.framework.base_framework import _auto_import_framework_modules
+            from starVLA.model.tools import FRAMEWORK_REGISTRY
+
+            _auto_import_framework_modules()
+            batch_collate = FRAMEWORK_REGISTRY[cfg.framework.name].build_collate(cfg)
+            if batch_collate is None:
+                raise ValueError(
+                    f"datasets.vla_data.preprocess_in_collate is not supported by framework "
+                    f"{cfg.framework.name!r} with this configuration (no build_collate implementation "
+                    "or an unverified VLM backend); remove the flag or use a supported setup"
+                )
         dataloader_kwargs = {
             "batch_size": cfg.datasets.vla_data.per_device_batch_size,
-            "collate_fn": collate_fn,
+            "collate_fn": batch_collate,
             "num_workers": num_workers,
             "pin_memory": bool(vla_dataset_cfg.get("pin_memory", True)),
             # shuffle=True

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -7,6 +7,7 @@ A lightweight implementation that Qwen2.5-vl + Flow-matching head to directly pr
 Flow-matching header is copyright from GR00T N1.5, but a sample MoE inspired by PI_0
 """
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
@@ -164,13 +165,44 @@ class Qwen_PI(baseframework):
         # only ever read `action_horizon` here.
         self.action_horizon = int(self.config.framework.action_model.action_horizon)
 
+    @classmethod
+    def build_collate(cls, cfg):
+        # Only backends whose processor path is equivalence-verified against
+        # the in-forward tokenization (token-exact tests) are eligible;
+        # currently that is Qwen3.5 only.
+        base_vlm = cfg.framework.qwenvl.base_vlm
+        if "Qwen3.5" not in base_vlm:
+            return None
+        from starVLA.model.framework.VLM4A.qwenpi_collate import QwenPIPreprocessCollate
+
+        vla = cfg.datasets.vla_data
+        return QwenPIPreprocessCollate(
+            base_vlm=base_vlm,
+            cot_prompt=vla.get("CoT_prompt", None) if "CoT_prompt" in vla else None,
+            obs_image_size=vla.get("obs_image_size", None),
+        )
+
+    @staticmethod
+    def _is_prepared_batch(examples) -> bool:
+        """True for a batch preprocessed by the DataLoader collate."""
+        return isinstance(examples, Mapping) and "input_ids" in examples
+
+    def _unpack_prepared_batch(self, examples):
+        """Move a prepared batch to the model device; returns (qwen_inputs, actions, state)."""
+        device = next(self.qwen_vl_interface.model.parameters()).device
+        batch = {k: v.to(device, non_blocking=True) for k, v in examples.items()}
+        actions = batch.pop("action", None)
+        state = batch.pop("state", None)
+        return batch, actions, state
+
     def _encode_vl_hidden_states(
-        self, batch_images: List, instructions: List[str]
+        self, batch_images: List = None, instructions: List[str] = None, qwen_inputs: dict = None
     ) -> tuple:
         """Run QwenVL and return (layer-wise hidden states, attention_mask) for the Action DiT."""
-        qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
-            images=batch_images, instructions=instructions
-        )
+        if qwen_inputs is None:
+            qwen_inputs = self.qwen_vl_interface.build_qwenvl_inputs(
+                images=batch_images, instructions=instructions
+            )
         attention_mask = qwen_inputs.get("attention_mask", None)
         with torch.autocast("cuda", dtype=torch.bfloat16):
             qwenvl_outputs = self.qwen_vl_interface(
@@ -198,22 +230,26 @@ class Qwen_PI(baseframework):
             dict:
                 action_loss (torch.Tensor): Scalar diffusion noise prediction loss.
         """
-        batch_images = [example["image"] for example in examples]  #  [B, [PLT]]
-        instructions = [example["lang"] for example in examples]  # [B, str]
-        actions = [example["action"] for example in examples]  # label [B, len, 7]
+        if self._is_prepared_batch(examples):
+            batch, actions, state = self._unpack_prepared_batch(examples)
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(qwen_inputs=batch)
+        else:
+            batch_images = [example["image"] for example in examples]  #  [B, [PLT]]
+            instructions = [example["lang"] for example in examples]  # [B, str]
+            actions = [example["action"] for example in examples]  # label [B, len, 7]
 
-        state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
+            state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
 
-        # Step 1: encode through QwenVL
-        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
+            # Step 1: encode through QwenVL
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
 
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
             # Label alignment: take the last chunk_len segment
-            actions = torch.tensor(
-                np.array(actions), device=base_hidden.device, dtype=base_hidden.dtype
-            )  # [B, T_full, action_dim]
+            if not torch.is_tensor(actions):
+                actions = torch.tensor(np.array(actions))
+            actions = actions.to(device=base_hidden.device, dtype=base_hidden.dtype)  # [B, T_full, action_dim]
             actions_target = actions[:, -self.action_horizon :, :]  # (B, action_horizon, action_dim)
 
             repeated_diffusion_steps = (
@@ -232,7 +268,9 @@ class Qwen_PI(baseframework):
 
             state_repeated = None
             if state is not None:
-                state = torch.tensor(np.array(state), device=base_hidden.device, dtype=base_hidden.dtype)
+                if not torch.is_tensor(state):
+                    state = torch.tensor(np.array(state))
+                state = state.to(device=base_hidden.device, dtype=base_hidden.dtype)
                 state_repeated = state.repeat(repeated_diffusion_steps, 1, 1)
 
             action_loss = self.action_model(
@@ -262,29 +300,31 @@ class Qwen_PI(baseframework):
             dict:
                 normalized_actions (np.ndarray): Shape [B, T, action_dim], diffusion-sampled normalized actions.
         """
-        if type(examples) is not list:
-            examples = [examples]
+        if self._is_prepared_batch(examples):
+            batch, _, state = self._unpack_prepared_batch(examples)
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(qwen_inputs=batch)
+        else:
+            if type(examples) is not list:
+                examples = [examples]
 
-        batch_images = [to_pil_preserve(example["image"]) for example in examples]  #  [B, [PLT]]
-        instructions = [example["lang"] for example in examples]  # [B, str]
+            batch_images = [to_pil_preserve(example["image"]) for example in examples]  #  [B, [PLT]]
+            instructions = [example["lang"] for example in examples]  # [B, str]
 
-        state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
+            state = [example["state"] for example in examples] if "state" in examples[0] else None  # [B, 1, state_dim]
 
-        train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
-        if train_obs_image_size:
-            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+            train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
+            if train_obs_image_size:
+                batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
-        # Step 1: encode through QwenVL
-        vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
+            # Step 1: encode through QwenVL
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
         base_hidden = vl_embs_list[-1]
         if backbone_attention_mask is not None:
             backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
 
-        state = (
-            torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
-            if state is not None
-            else None
-        )
+        if state is not None and not torch.is_tensor(state):
+            state = torch.from_numpy(np.array(state))
+        state = state.to(base_hidden.device, dtype=base_hidden.dtype) if state is not None else None
         # Step 4: Action Expert Forward and Loss
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action(
@@ -325,29 +365,38 @@ class Qwen_PI(baseframework):
         if prev_action_chunk_normalized is None or inference_delay <= 0:
             return self.predict_action(examples)
 
-        if type(examples) is not list:
-            examples = [examples]
+        if self._is_prepared_batch(examples):
+            batch, _, state_t = self._unpack_prepared_batch(examples)
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(qwen_inputs=batch)
+            base_hidden = vl_embs_list[-1]
+            state_t = state_t.to(base_hidden.device, dtype=base_hidden.dtype) if state_t is not None else None
+        else:
+            if type(examples) is not list:
+                examples = [examples]
 
-        batch_images = [to_pil_preserve(example["image"]) for example in examples]
-        instructions = [example["lang"] for example in examples]
-        state = [example["state"] for example in examples] if "state" in examples[0] else None
+            batch_images = [to_pil_preserve(example["image"]) for example in examples]
+            instructions = [example["lang"] for example in examples]
+            state = [example["state"] for example in examples] if "state" in examples[0] else None
 
-        train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
-        if train_obs_image_size:
-            batch_images = resize_images(batch_images, target_size=train_obs_image_size)
+            train_obs_image_size = getattr(self.config.datasets.vla_data, "obs_image_size", None)
+            if train_obs_image_size:
+                batch_images = resize_images(batch_images, target_size=train_obs_image_size)
 
-        vl_embs_list, _ = self._encode_vl_hidden_states(batch_images, instructions)
-        base_hidden = vl_embs_list[-1]
+            vl_embs_list, backbone_attention_mask = self._encode_vl_hidden_states(batch_images, instructions)
+            base_hidden = vl_embs_list[-1]
 
-        state_t = (
-            torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
-            if state is not None
-            else None
-        )
+            state_t = (
+                torch.from_numpy(np.array(state)).to(base_hidden.device, dtype=base_hidden.dtype)
+                if state is not None
+                else None
+            )
 
         prev_chunk_t = torch.from_numpy(np.array(prev_action_chunk_normalized)).to(
             base_hidden.device, dtype=torch.float32
         )
+
+        if backbone_attention_mask is not None:
+            backbone_attention_mask = backbone_attention_mask.to(dtype=torch.bool)
 
         with torch.autocast("cuda", dtype=torch.float32):
             pred_actions = self.action_model.predict_action_realtime(
@@ -355,6 +404,7 @@ class Qwen_PI(baseframework):
                 state_t,
                 prev_action_chunk=prev_chunk_t,
                 inference_delay=inference_delay,
+                encoder_attention_mask=backbone_attention_mask,
                 **kwargs,
             )
 

--- a/starVLA/model/framework/VLM4A/QwenPI.py
+++ b/starVLA/model/framework/VLM4A/QwenPI.py
@@ -179,6 +179,7 @@ class Qwen_PI(baseframework):
         return QwenPIPreprocessCollate(
             base_vlm=base_vlm,
             cot_prompt=vla.get("CoT_prompt", None) if "CoT_prompt" in vla else None,
+            pad_to=vla.get("collate_pad_to", 0),
             obs_image_size=vla.get("obs_image_size", None),
         )
 

--- a/starVLA/model/framework/VLM4A/qwenpi_collate.py
+++ b/starVLA/model/framework/VLM4A/qwenpi_collate.py
@@ -19,12 +19,22 @@ class QwenPIPreprocessCollate:
     inside workers it overlaps with training. Output tokens are identical to
     the in-forward path (same processor, same message construction; the same
     ``obs_image_size`` resize the prediction paths apply is applied here).
+
+    ``pad_to`` > 0 pads every batch to that fixed length (manually, after a
+    single processor pass) so downstream shape-keyed kernel caches see one
+    sequence length. Skipped for batch_size 1 — the current Qwen3.5
+    linear-attention layers only apply the padding mask when batch > 1
+    (huggingface/transformers#46773), so singleton left-pads would leak into
+    the recurrent state. Over-long batches keep their dynamic length after a
+    one-time warning.
     """
 
-    def __init__(self, base_vlm, cot_prompt=None, obs_image_size=None):
+    def __init__(self, base_vlm, cot_prompt=None, pad_to=0, obs_image_size=None):
         self.base_vlm = base_vlm
         self.cot_prompt = cot_prompt
+        self.pad_to = int(pad_to or 0)
         self.obs_image_size = obs_image_size
+        self._warned = set()
         # Built eagerly in the parent so fork-started workers share it
         # copy-on-write; __getstate__ drops it so spawn workers rebuild.
         self._processor = self._build_processor()
@@ -38,6 +48,11 @@ class QwenPIPreprocessCollate:
 
     def __getstate__(self):
         return {**self.__dict__, "_processor": None}
+
+    def _warn_once(self, key, msg):
+        if key not in self._warned:
+            self._warned.add(key)
+            logger.warning(msg)
 
     def __call__(self, batch):
         import numpy as np
@@ -63,6 +78,20 @@ class QwenPIPreprocessCollate:
             messages, tokenize=True, padding=True, add_generation_prompt=True, return_dict=True, return_tensors="pt"
         )
         out = dict(inputs)
+        seq_len = out["input_ids"].shape[1]
+        if self.pad_to and len(batch) == 1:
+            self._warn_once("singleton", "collate_pad_to skipped for batch_size 1 (padding-mask gate in the backbone)")
+        elif self.pad_to and seq_len > self.pad_to:
+            self._warn_once(
+                "too_long", f"collate_pad_to={self.pad_to} is shorter than a sample (length {seq_len}); "
+                "this batch keeps its dynamic length"
+            )
+        elif self.pad_to and seq_len < self.pad_to:
+            pad = self.pad_to - seq_len
+            fills = {"input_ids": self._processor.tokenizer.pad_token_id, "attention_mask": 0, "mm_token_type_ids": 0}
+            for key, fill in fills.items():
+                if key in out:  # left-pad, matching the tokenizer's padding_side
+                    out[key] = torch.nn.functional.pad(out[key], (pad, 0), value=fill)
         if "pixel_values" in out:
             # Qwen3.5 consumes pixels under bf16 autocast (the first op casts
             # them anyway); shipping bf16 halves the worker-to-main IPC volume.

--- a/starVLA/model/framework/VLM4A/qwenpi_collate.py
+++ b/starVLA/model/framework/VLM4A/qwenpi_collate.py
@@ -1,0 +1,73 @@
+"""DataLoader-side preprocessing for QwenPI (datasets.vla_data.preprocess_in_collate).
+
+QwenPI-specific by design: it encodes QwenPI's prompt construction, its
+action/state batch layout, and the Qwen3.5 processor semantics. Other
+frameworks opt in to the same mechanism by overriding
+``baseframework.build_collate`` with their own collate.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class QwenPIPreprocessCollate:
+    """Runs the QwenVL processor inside DataLoader workers instead of forward.
+
+    On the main process the processor (chat template + image resize + packing)
+    costs ~50 ms (bs=16) to ~100 ms (bs=32) per step with the GPU fully idle;
+    inside workers it overlaps with training. Output tokens are identical to
+    the in-forward path (same processor, same message construction; the same
+    ``obs_image_size`` resize the prediction paths apply is applied here).
+    """
+
+    def __init__(self, base_vlm, cot_prompt=None, obs_image_size=None):
+        self.base_vlm = base_vlm
+        self.cot_prompt = cot_prompt
+        self.obs_image_size = obs_image_size
+        # Built eagerly in the parent so fork-started workers share it
+        # copy-on-write; __getstate__ drops it so spawn workers rebuild.
+        self._processor = self._build_processor()
+
+    def _build_processor(self):
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained(self.base_vlm)
+        processor.tokenizer.padding_side = "left"
+        return processor
+
+    def __getstate__(self):
+        return {**self.__dict__, "_processor": None}
+
+    def __call__(self, batch):
+        import numpy as np
+        import torch
+
+        if self._processor is None:  # spawn-started worker
+            self._processor = self._build_processor()
+        from deployment.model_server.tools.image_tools import to_pil_preserve
+
+        from starVLA.model.modules.vlm.qwenvl_messages import build_qwenvl_messages
+
+        images = [to_pil_preserve(ex["image"]) for ex in batch]
+        if self.obs_image_size:
+            # Same resize the raw prediction paths apply before the processor.
+            from starVLA.training.trainer_utils.trainer_tools import resize_images
+
+            images = resize_images(images, target_size=self.obs_image_size)
+        messages = build_qwenvl_messages(images, [ex["lang"] for ex in batch], self.cot_prompt)
+
+        # Single processor pass (dynamic pad-to-longest); the fixed length is
+        # applied by hand below so over-long batches are never processed twice.
+        inputs = self._processor.apply_chat_template(
+            messages, tokenize=True, padding=True, add_generation_prompt=True, return_dict=True, return_tensors="pt"
+        )
+        out = dict(inputs)
+        if "pixel_values" in out:
+            # Qwen3.5 consumes pixels under bf16 autocast (the first op casts
+            # them anyway); shipping bf16 halves the worker-to-main IPC volume.
+            out["pixel_values"] = out["pixel_values"].to(torch.bfloat16)
+        out["action"] = torch.from_numpy(np.array([ex["action"] for ex in batch]))
+        if "state" in batch[0]:
+            out["state"] = torch.from_numpy(np.array([ex["state"] for ex in batch]))
+        return out

--- a/starVLA/model/framework/base_framework.py
+++ b/starVLA/model/framework/base_framework.py
@@ -124,6 +124,13 @@ def build_framework(cfg): # The single entry point for building different model 
 
 
 class baseframework(PreTrainedModel):
+
+    @classmethod
+    def build_collate(cls, cfg):
+        """Optional DataLoader collate producing batches this framework's
+        forward can consume directly (CPU preprocessing moved into workers).
+        Return None (default) to keep the raw-example collate."""
+        return None
     """
     Lightweight base class for higher-level VLA model assemblies.
     Subclasses are expected to:

--- a/starVLA/model/modules/vlm/QWen3_5.py
+++ b/starVLA/model/modules/vlm/QWen3_5.py
@@ -35,6 +35,10 @@ _ACTION_TOKEN_MAX = (
 import torch.nn as nn
 
 
+
+from starVLA.model.modules.vlm.qwenvl_messages import build_qwenvl_messages
+
+
 class _QWen3_5_VL_Interface(nn.Module):
     """
     This exists because of the diversity of VLMs, so we encapsulate the changes here.
@@ -124,26 +128,8 @@ class _QWen3_5_VL_Interface(nn.Module):
         Build model inputs from raw data (images + instructions + optional solutions).
         Follow Oficial Qwen3.5-VL Instruct format: https://huggingface.co/Qwen/Qwen3.5-VL-4B-Instruct
         """
-
-        # Create messages: one message per sample
-        messages = []
-        assert len(images) == len(instructions), "Images and instructions must have the same length"
-        for imgs, instruction in zip(images, instructions):
-            content = [{"type": "image", "image": img} for img in imgs]
-
-            if "CoT_prompt" in self.config.datasets.vla_data:  # If using a grounding prompt to task
-                CoT_prompt = self.config.datasets.vla_data.get("CoT_prompt", "")
-                prompt = CoT_prompt.replace("{instruction}", instruction)
-            else:
-                prompt = instruction
-
-            content.append({"type": "text", "text": prompt})
-            msg = [{"role": "user", "content": content}]
-
-            if solutions is not None:
-                solution = solutions[len(messages)]
-                msg.append({"role": "assistant", "content": [{"type": "text", "text": solution}]})
-            messages.append(msg)
+        cot_prompt = self.config.datasets.vla_data.get("CoT_prompt", "") if "CoT_prompt" in self.config.datasets.vla_data else None
+        messages = build_qwenvl_messages(images, instructions, cot_prompt, solutions=solutions)
 
         # Preparation for inference
 

--- a/starVLA/model/modules/vlm/qwenvl_messages.py
+++ b/starVLA/model/modules/vlm/qwenvl_messages.py
@@ -1,0 +1,18 @@
+# Dependency-free helper shared by the in-forward tokenization path and the
+# DataLoader preprocessing collate. Lives in its own leaf module so DataLoader
+# workers can import it without pulling in the full model module.
+
+
+def build_qwenvl_messages(images, instructions, cot_prompt=None, solutions=None):
+    """Chat-template messages for a batch: one user message per sample."""
+    messages = []
+    assert len(images) == len(instructions), "Images and instructions must have the same length"
+    for imgs, instruction in zip(images, instructions):
+        content = [{"type": "image", "image": img} for img in imgs]
+        prompt = cot_prompt.replace("{instruction}", instruction) if cot_prompt is not None else instruction
+        content.append({"type": "text", "text": prompt})
+        msg = [{"role": "user", "content": content}]
+        if solutions is not None:
+            msg.append({"role": "assistant", "content": [{"type": "text", "text": solutions[len(messages)]}]})
+        messages.append(msg)
+    return messages

--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -373,7 +373,10 @@ class VLATrainer(TrainerUtils):
     def eval_action_model(self, step_metrics: dict = None) -> float:
         """Run simple action-eval on current batch and attach score to metrics."""
         examples = self._get_next_batch()
-        actions = [example["action"] for example in examples]
+        if isinstance(examples, dict) and "input_ids" in examples:
+            actions = examples["action"].cpu().numpy()
+        else:
+            actions = [example["action"] for example in examples]
         output_dict = self.accelerator.unwrap_model(self.model).predict_action(
             examples=examples, use_ddim=True, num_ddim_steps=20
         )

--- a/starVLA/training/train_starvla_cotrain.py
+++ b/starVLA/training/train_starvla_cotrain.py
@@ -332,7 +332,10 @@ class VLAMTrainer(TrainerUtils):
         """Evaluate action prediction with current model."""
         if self.accelerator.is_main_process:
             examples, _ = self._get_next_batch()
-            actions = [example["action"] for example in examples]
+            if isinstance(examples, dict) and "input_ids" in examples:
+                actions = examples["action"].cpu().numpy()
+            else:
+                actions = [example["action"] for example in examples]
 
             output_dict = self.accelerator.unwrap_model(self.model).predict_action(examples=examples)
             normalized_actions = output_dict["normalized_actions"]

--- a/tests/test_preprocess_collate.py
+++ b/tests/test_preprocess_collate.py
@@ -65,6 +65,59 @@ def test_collate_matches_in_forward_path():
 
 
 @needs_model
+def test_collate_pad_to_fixed_length():
+    batch = make_batch()
+    free = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)
+    fixed = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT, pad_to=192)(batch)
+    assert fixed["input_ids"].shape[1] == 192 > free["input_ids"].shape[1]
+    assert torch.equal(fixed["attention_mask"].sum(1), free["attention_mask"].sum(1))
+    n = free["input_ids"].shape[1]
+    assert torch.equal(fixed["input_ids"][:, -n:], free["input_ids"][:, -n:])  # left-padded
+
+
+@needs_model
+def test_collate_pad_to_matches_processor_maxlen():
+    """Manual left-padding must be byte-identical to the processor's own
+    max_length padding (guards the hand-pad against tokenizer drift)."""
+    from starVLA.model.modules.vlm.qwenvl_messages import build_qwenvl_messages
+    from transformers import AutoProcessor
+
+    batch = make_batch()
+    out = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT, pad_to=192)(batch)
+    proc = AutoProcessor.from_pretrained(MODEL_DIR)
+    proc.tokenizer.padding_side = "left"
+    ref = proc.apply_chat_template(
+        build_qwenvl_messages([ex["image"] for ex in batch], [ex["lang"] for ex in batch], COT),
+        tokenize=True, padding="max_length", max_length=192,
+        add_generation_prompt=True, return_dict=True, return_tensors="pt",
+    )
+    for key in ("input_ids", "attention_mask"):
+        assert torch.equal(out[key], ref[key]), key
+
+
+@needs_model
+def test_collate_pad_to_too_short_falls_back():
+    batch = make_batch()
+    ref = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)
+    short = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT, pad_to=8)
+    out = short(batch)
+    assert "too_long" in short._warned  # warned once, batch keeps dynamic length
+    assert torch.equal(out["input_ids"], ref["input_ids"])
+
+
+@needs_model
+def test_singleton_batch_skips_fixed_pad():
+    """Qwen3.5's linear-attention mask gate ignores padding when B == 1
+    (transformers #46773), so fixed padding must be skipped for singletons."""
+    batch = make_batch(n=1)
+    c = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT, pad_to=192)
+    out = c(batch)
+    free = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)
+    assert out["input_ids"].shape == free["input_ids"].shape  # no pads added
+    assert "singleton" in c._warned
+
+
+@needs_model
 def test_text_only_batch_has_no_pixel_values():
     batch = make_batch()
     for ex in batch:

--- a/tests/test_preprocess_collate.py
+++ b/tests/test_preprocess_collate.py
@@ -1,0 +1,142 @@
+"""Tests for the DataLoader preprocessing collate (preprocess_in_collate).
+
+Most tests need a local Qwen-VL checkpoint with processor files; set
+STARVLA_TEST_VLM to its directory (they skip otherwise, e.g. in CI without
+model weights). test_forward_dispatch_* run everywhere (no weights needed).
+"""
+
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from starVLA.model.framework.VLM4A.qwenpi_collate import QwenPIPreprocessCollate
+
+MODEL_DIR = os.environ.get("STARVLA_TEST_VLM", "")
+needs_model = pytest.mark.skipif(not os.path.isdir(MODEL_DIR), reason="STARVLA_TEST_VLM not set")
+
+COT = "Your task is {instruction}. To identify the key objects for your task. Locate their bounding boxes in [x1,y1,x2,y2] format."
+
+
+def make_batch(n=3):
+    rng = np.random.default_rng(0)
+    return [
+        {
+            "image": [Image.fromarray(rng.integers(0, 255, (224, 224, 3), dtype=np.uint8)) for _ in range(2)],
+            "lang": ["turn on the stove", "put the bowl on the plate", "open the top drawer and put the bowl inside"][i % 3],
+            "action": rng.standard_normal((16, 7)).astype(np.float32),
+            "state": rng.standard_normal((1, 7)).astype(np.float32),
+        }
+        for i in range(n)
+    ]
+
+
+@needs_model
+def test_collate_matches_in_forward_path():
+    """Collate output must be token-exact vs the REAL in-forward path
+    (_QWen3_5_VL_Interface.build_qwenvl_inputs run unbound with a stub self)."""
+    from omegaconf import OmegaConf
+
+    from starVLA.model.modules.vlm.QWen3_5 import _QWen3_5_VL_Interface
+    from transformers import AutoProcessor
+
+    batch = make_batch()
+    out = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)
+
+    proc = AutoProcessor.from_pretrained(MODEL_DIR)
+    proc.tokenizer.padding_side = "left"
+    stub = SimpleNamespace(
+        processor=proc,
+        config=OmegaConf.create({"datasets": {"vla_data": {"CoT_prompt": COT}}}),
+        model=SimpleNamespace(device="cpu"),
+    )
+    ref = _QWen3_5_VL_Interface.build_qwenvl_inputs(
+        stub, images=[ex["image"] for ex in batch], instructions=[ex["lang"] for ex in batch]
+    )
+    for key in ("input_ids", "attention_mask", "image_grid_thw"):
+        assert torch.equal(out[key], ref[key]), key
+    # pixels ship as bf16 (the model casts them there anyway under autocast)
+    assert torch.equal(out["pixel_values"], ref["pixel_values"].to(torch.bfloat16))
+    assert torch.equal(out["action"], torch.from_numpy(np.stack([ex["action"] for ex in batch])))
+    assert torch.equal(out["state"], torch.from_numpy(np.stack([ex["state"] for ex in batch])))
+
+
+@needs_model
+def test_text_only_batch_has_no_pixel_values():
+    batch = make_batch()
+    for ex in batch:
+        ex["image"] = []
+    out = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)  # must not raise
+    assert "input_ids" in out and "pixel_values" not in out
+
+
+@needs_model
+def test_build_collate_backend_gate():
+    from omegaconf import OmegaConf
+
+    from starVLA.model.framework.VLM4A.QwenPI import Qwen_PI
+
+    ok = OmegaConf.create({"framework": {"qwenvl": {"base_vlm": MODEL_DIR}},
+                           "datasets": {"vla_data": {"CoT_prompt": COT, "collate_pad_to": 192}}})
+    assert MODEL_DIR.endswith("Qwen3.5-4B") and Qwen_PI.build_collate(ok) is not None
+    for unverified in ("/models/gemma-4-9b", "/models/Qwen2.5-VL-7B"):
+        bad = OmegaConf.create({"framework": {"qwenvl": {"base_vlm": unverified}},
+                                "datasets": {"vla_data": {}}})
+        assert Qwen_PI.build_collate(bad) is None  # unverified backend -> no collate
+
+
+@needs_model
+def test_obs_image_size_resize_applied():
+    """The collate applies the same obs_image_size resize the raw prediction
+    paths apply, so prepared and raw predictions see identical pixels."""
+    batch = make_batch(n=2)
+    # note: sizes below the processor's min_pixels get upscaled back by
+    # smart_resize, so use a larger target to make the resize observable.
+    big = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT, obs_image_size=(448, 448))(batch)
+    full = QwenPIPreprocessCollate(MODEL_DIR, cot_prompt=COT)(batch)
+    assert big["image_grid_thw"][:, 1:].prod(1).sum() > full["image_grid_thw"][:, 1:].prod(1).sum()
+
+
+def _stub_qwenpi(record):
+    """Weights-free Qwen_PI with stubbed encoder to test forward dispatch."""
+    from starVLA.model.framework.VLM4A.QwenPI import Qwen_PI
+
+    m = object.__new__(Qwen_PI)
+    param = torch.nn.Parameter(torch.zeros(1))
+    m.qwen_vl_interface = SimpleNamespace(model=SimpleNamespace(parameters=lambda: iter([param])))
+
+    def encode(batch_images=None, instructions=None, qwen_inputs=None):
+        record["qwen_inputs"] = qwen_inputs
+        record["raw"] = batch_images is not None
+        raise RuntimeError("stop-after-dispatch")
+
+    m._encode_vl_hidden_states = encode
+    return m
+
+
+def test_forward_dispatch_preprocessed_dict():
+    record = {}
+    m = _stub_qwenpi(record)
+    batch = {
+        "input_ids": torch.ones(2, 5, dtype=torch.long),
+        "attention_mask": torch.ones(2, 5, dtype=torch.long),
+        "action": torch.zeros(2, 16, 7),
+        "state": torch.zeros(2, 1, 7),
+    }
+    with pytest.raises(RuntimeError, match="stop-after-dispatch"):
+        m.forward(batch)
+    assert record["qwen_inputs"] is not None and not record.get("raw")
+    # action/state must be popped before the VLM sees the batch
+    assert set(record["qwen_inputs"]) == {"input_ids", "attention_mask"}
+
+
+def test_forward_dispatch_raw_examples():
+    record = {}
+    m = _stub_qwenpi(record)
+    examples = [{"image": [], "lang": "x", "action": np.zeros((16, 7))}]
+    with pytest.raises(RuntimeError, match="stop-after-dispatch"):
+        m.forward(examples)
+    assert record.get("raw") is True and record["qwen_inputs"] is None


### PR DESCRIPTION
## Description

Specific data pipeline optimization for QwenPI model: move the data processing from ``QwenPI.forward()`` to CPU worker, 
enabling the parallelization of CPU and GPU workers. This PR consists of two commits: one builds the decoupled preprocessing path (collate + dispatch), and the other adds optional fixed-length padding (`collate_pad_to`).

## Motivation

Currently the QwenVL processor (chat template, image resize, packing, tokenization) runs inside `QwenPI.forward` on the main process, which makes the GPU pipeline idling after each training iteration. According to our benchmark on H200, this serial host work accounts for ~4-5% of every training step's wall time (with the GPU fully idle meanwhile), and moving it into DataLoader workers improves p50 step time by ~16% at both bs=16 and bs=32 (see Performance).

## Changes

- **Commit 1 — decoupled preprocessing path.** Implement a specific helper class: `QwenPIPreprocessCollate`, which executes the logic of processing data samples as it is in ``_QWen3_5_VL_Interface.build_qwenvl_inputs()`` and constructs a dict containing the output tensor. This specific class is materialized in ``build_dataloader()`` during training initialization. The fetcher within PyTorch dataloader invokes ``collate_fn(list)`` and was dispatched to our ``QwenPIPreprocessCollate.__call__``.
  - Frameworks opt in by overriding `baseframework.build_collate` (default None keeps raw examples); QwenPI's implementation is limited to the equivalence-verified Qwen3.5 backend.
  - Every consumer of the VLA dataloader is dual-mode (preprocessed dict / raw examples): `forward`, `predict_action`, `predict_action_realtime`, and both trainers' eval paths.
  - **Config:** Set `datasets.vla_data.preprocess_in_collate: true` in the training YAML (or pass `--datasets.vla_data.preprocess_in_collate true` on the command line) to enable it; the default is off and preserves today's behavior exactly.
- **Commit 2 — optional fixed-length padding.** `datasets.vla_data.collate_pad_to: N` (e.g. 192) additionally pads every batch to a fixed length N instead of the batch max. With a constant sequence length, the shape-keyed Triton autotune in the GDN/linear-attention kernels runs once at startup instead of stalling all ranks for ~9 s whenever a new batch-max length first appears. Padding is applied manually after a single processor pass; over-long batches keep their dynamic length with a one-time warning, and batches of size 1 are left unpadded (the current backbone only applies the padding mask when batch > 1).

### Justification for shared-module edits

- `starVLA/dataloader/__init__.py` (+18): the collate dispatch has to be wired where the DataLoader is built; it is a no-op unless `preprocess_in_collate` is enabled, and any framework without a `build_collate` implementation gets an immediate, named error.
- `starVLA/training/train_starvla.py` / `train_starvla_cotrain.py` (+4 each): the eval paths index batches as `list[dict]` and would crash on a preprocessed dict; these are the minimal dual-mode guards.
- `starVLA/model/framework/base_framework.py` (+7): the opt-in `build_collate` hook (default returns None → existing behavior for every framework).

## Testing

- [x] Local training for N steps without errors (8×H200 ZeRO-2, 51-step and 121-step runs, loss curves indistinguishable from baseline)
- [x] Benchmark evaluation results

| Benchmark | Metric | Result |
|-----------|--------|--------|
| LIBERO libero_goal (bs=16, 8×H200) | train step p50 | 1232 ms → 1057 ms (−14%) |
| LIBERO libero_goal (bs=32, 8×H200) | train step p50 | 2182 ms → 1833 ms (−16%) |
| LIBERO libero_goal (bs=16, +`collate_pad_to`) | train step p99 | 9306 ms → 1126 ms |

- **Checkpoint**: N/A (performance-only change; no framework/benchmark integration, numerics preserved — see Validation)
- **Config**: `examples/simBenchmarks/LIBERO/train_files/starvla_cotrain_libero.yaml` + the two new opt-in keys
- **Reproduce**: `accelerate launch --config_file <zero2 yaml> --num_processes 8 starVLA/training/train_starvla.py --config_yaml ./examples/simBenchmarks/LIBERO/train_files/starvla_cotrain_libero.yaml --framework.name QwenPI --datasets.vla_data.per_device_batch_size 16 --datasets.vla_data.num_workers 16 --datasets.vla_data.preprocess_in_collate true --datasets.vla_data.collate_pad_to 192` (drop the last two flags for the baseline arm; full details under Reproduction below)

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [ ] New features have example config in `examples/` (the two keys are opt-in and documented above; happy to add commented lines to the LIBERO example YAML if preferred)
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — shared-module edits are minimal and justified above
- [x] No modifications to shared files, or justified above
- [ ] If adding framework/benchmark: checkpoint uploaded to personal HF (N/A)

## Performance

8×H200 single node (all rows same node), ZeRO-2 (`overlap_comm: true, reduce_scatter: false, reduce_bucket_size: 1.5e9, allgather_bucket_size: 5e8` — see Reproduction), Qwen3.5-VL-4B, QwenPI, full unfreeze, LIBERO libero_goal, `num_workers 16`. Three arms isolate the two commits: **A** = today's behavior, **B** = commit 1 only (`preprocess_in_collate`), **C** = commits 1+2 (`+ collate_pad_to 192`). Steps 21–51 (long rows 61–121); per-step times include autotune stalls, which is why p99 matters.

| arm (bs=16) | p50 | p95 | p99 | mean |
|---|---|---|---|---|
| A off | 1232 ms | 6457 | 9306 | 1762 |
| B collate | 1057 ms | 6218 | 8984 | 1554 |
| **C collate+pad** | 1076 ms | **1101** | **1126** | **1078** |

| arm (bs=32) | p50 | p95 | p99 | mean |
|---|---|---|---|---|
| A off | 2182 ms | 2256 | 2269 | 2184 |
| **B collate** | **1833 ms** | 1865 | 1869 | **1837** |
| C collate+pad | 1882 ms | 1913 | 1919 | 1886 |

121-step long window (bs=16): mean **A 1568 / B 1401 / C 1076 ms** — B still pays two ~9 s autotune stalls inside the window; C has zero stalls across all 121 steps.

