### PR TITLE
[fix] (openpi): support Transformers 5 cached denoise

### DIFF
--- a/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
+++ b/starVLA/model/modules/vlm/openpi_transformers/gemma/modeling_gemma.py
@@ -286,8 +286,14 @@ class GemmaAttention(nn.Module):
                 cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
                 key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
             else:
-                key_states = torch.cat([past_key_values[self.layer_idx][0], key_states], dim=2)
-                value_states = torch.cat([past_key_values[self.layer_idx][1], value_states], dim=2)
+                # Cache.__getitem__ was removed in Transformers 5; `layers` is shared by 4.57 and 5.x.
+                if isinstance(past_key_values, Cache):
+                    cache_layer = past_key_values.layers[self.layer_idx]
+                    cached_key_states, cached_value_states = cache_layer.keys, cache_layer.values
+                else:
+                    cached_key_states, cached_value_states = past_key_values[self.layer_idx]
+                key_states = torch.cat([cached_key_states, key_states], dim=2)
+                value_states = torch.cat([cached_value_states, value_states], dim=2)
 
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":

--- a/tests/test_openpi_gemma_transformers_compat.py
+++ b/tests/test_openpi_gemma_transformers_compat.py
@@ -8,6 +8,42 @@ from starVLA.model.modules.vlm.openpi_transformers.gemma import modeling_gemma
 
 
 class OpenPIGemmaTransformersCompatTest(unittest.TestCase):
+    def test_cached_suffix_forward(self):
+        config = GemmaDims(width=16, depth=1, mlp_dim=32, num_heads=2, num_kv_heads=1, head_dim=8)
+        prefix_embeds = torch.randn(1, 2, config.width)
+        suffix_embeds = torch.randn(1, 3, config.width)
+        prefix_model = OpenPIGemma(config, use_adarms=False).eval()
+        prefix_model.model.config._attn_implementation = "eager"
+
+        with torch.no_grad():
+            prefix_output = prefix_model.model.forward(
+                inputs_embeds=prefix_embeds,
+                attention_mask=torch.zeros(1, 1, 2, 2),
+                position_ids=torch.arange(2).unsqueeze(0),
+                use_cache=True,
+                adarms_cond=None,
+            )
+        prefix_cache = prefix_output.past_key_values
+
+        for use_adarms in (False, True):
+            with self.subTest(use_adarms=use_adarms):
+                action_expert = OpenPIGemma(config, use_adarms=use_adarms).eval()
+                action_expert.model.config._attn_implementation = "eager"
+
+                with torch.no_grad():
+                    suffix_output = action_expert.model.forward(
+                        inputs_embeds=suffix_embeds,
+                        attention_mask=torch.zeros(1, 1, 3, 5),
+                        position_ids=torch.arange(2, 5).unsqueeze(0),
+                        past_key_values=prefix_cache,
+                        use_cache=False,
+                        adarms_cond=torch.zeros(1, config.width) if use_adarms else None,
+                    )
+
+                self.assertEqual(prefix_cache.get_seq_length(), prefix_embeds.shape[1])
+                self.assertEqual(suffix_output.last_hidden_state.shape, suffix_embeds.shape)
+                self.assertTrue(torch.isfinite(suffix_output.last_hidden_state).all())
+
     def test_tiny_action_expert_forward(self):
         config = GemmaDims(
             width=16,


### PR DESCRIPTION
## Description

Fix cached PI0 and PI0.5 suffix denoising with Transformers 5 `Cache` objects.

## Motivation

Closes #455

This is a focused follow-up to the post-review concern on #448: https://github.com/starVLA/starVLA/pull/448#discussion_r3840916820

The real inference path builds a prefix `DynamicCache` with `use_cache=True`, then reuses it for every suffix denoise step with `use_cache=False`. Transformers 5 removed `Cache.__getitem__`, but the vendored Gemma attention still indexed `past_key_values[layer_idx]`, causing both PI0 and PI0.5 denoising to fail.

## Changes

- Read cached key/value tensors from `Cache.layers[layer_idx].keys/values`, the API shared by Transformers 4.57 and 5.x.
- Keep the existing indexed fallback for non-`Cache` callers.
- Add a production-shaped regression that creates a real prefix cache and reuses it for PI0 and PI0.5 suffix forwards.
- Assert the suffix path does not extend or mutate the prefix cache length.

## Testing

RED on the upstream baseline:

- Transformers 4.57.0: cached suffix regression passes because `DynamicCache` remains subscriptable.
- Transformers 5.2.0 and 5.7.0: both PI0 and PI0.5 fail with `TypeError: DynamicCache object is not subscriptable`.

GREEN after this change:

- [x] Full OpenPI compatibility test passes with Transformers 4.57.0
- [x] Full OpenPI compatibility test passes with Transformers 5.2.0
- [x] Full OpenPI compatibility test passes with Transformers 5.3.0
- [x] Full OpenPI compatibility test passes with Transformers 5.7.0
- [x] 14 focused CPU regression tests pass
- [x] Cached prefix-to-suffix GPU forward passes for PI0 and PI0.5
- [x] `black --check` passes on both changed files
- [x] Ruff passes on the test; the vendored file keeps exactly the same 8 historical Ruff findings as upstream

The multi-version CPU matrix validates the Transformers cache API transition, while the GPU run validates the same cached tensor path and backward compatibility. No checkpoint or model download is required.

## Breaking Changes

None.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

## Checklist

- [x] No unrelated changes mixed in
- [x] No secrets, API keys, or large binaries committed
- [x] No shared dataloader, trainer, or config files modified
- [x] Regression test included
