### PR TITLE
Fix ZeRO-3 state dict gathering across ranks

### DIFF
--- a/starVLA/training/train_starvla.py
+++ b/starVLA/training/train_starvla.py
@@ -275,11 +275,14 @@ class VLATrainer(TrainerUtils):
 
     def _save_checkpoint(self):
         """Save current training state."""
+        # ZeRO-3 consolidates parameters with collectives and therefore every
+        # rank must enter get_state_dict(). Only rank 0 should serialize the
+        # resulting full state dict to disk.
+        state_dict = _get_state_dict(self.accelerator, self.model)
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             checkpoint_path = os.path.join(self.checkpoint_dir, f"steps_{self.completed_steps}")
 
-            state_dict = _get_state_dict(self.accelerator, self.model)
             if save_format == "safetensors":
                 from safetensors.torch import save_file
 
@@ -442,11 +445,13 @@ class VLATrainer(TrainerUtils):
 
     def _finalize_training(self):
         """Training end processing."""
+        # DeepSpeed ZeRO-3 requires all ranks to participate in the parameter
+        # gathers performed by get_state_dict(); rank 0 alone writes the file.
+        state_dict = _get_state_dict(self.accelerator, self.model)
         if self.accelerator.is_main_process:
             save_format = getattr(self.config.trainer, "save_format", "pt")
             final_checkpoint = os.path.join(self.config.output_dir, "final_model")
             os.makedirs(final_checkpoint, exist_ok=True)
-            state_dict = _get_state_dict(self.accelerator, self.model)
             if save_format == "safetensors":
                 from safetensors.torch import save_file
 


### PR DESCRIPTION
# 修复 ZeRO-3 训练结束保存阶段的分布式死锁

## 变更概述

修复 StarVLA 使用 DeepSpeed ZeRO-3 训练时，在定期 checkpoint 保存和训练结束保存阶段可能发生的分布式死锁。

本次修改只调整项目侧的保存调用顺序，不修改 DeepSpeed 源码，也不改变模型参数、优化器或 checkpoint 的格式。

## 修复前现象

在 Qwen3.6-27B、8 卡 MUSA、ZeRO-3 训练中，forward、backward 和 optimizer step 均可正常完成，但训练结束阶段一直无进一步输出，无法正常退出。

典型表现包括：

- 训练进度已经达到 `1/1`；
- loss 和 step metrics 已正常打印；
- 进程持续占用 CPU，但没有生成 `final_model`；
- 等待数分钟后仍未退出，只能通过 SIGINT/SIGKILL 终止；
- 定期 checkpoint 保存触发时可能出现同样问题。

该现象最初表现为“ZeRO-3 汇总完整 16-bit 模型时卡住”，容易被误判为模型过大或显存不足。

## 根因分析

项目原来的保存逻辑如下：

```python
if self.accelerator.is_main_process:
    state_dict = self.accelerator.get_state_dict(self.model)
```

但在 ZeRO-3 模式下，`accelerator.get_state_dict()` 会调用 DeepSpeed 的
`_zero3_consolidated_16bit_state_dict()`。该函数通过 `GatheredParameters` 对参数逐层执行跨 rank 的 `all_gather`，要求所有 rank 必须同时进入该调用。

原实现只有 rank 0 调用 `get_state_dict()`，其余 rank 直接进入后续 barrier，导致：

1. rank 0 在等待其他 rank 参与参数 gather；
2. 其他 rank 在等待 rank 0 到达 barrier；
3. collective 调用顺序不一致，形成永久等待。

因此，问题根因是项目代码中的 rank 分支位置错误，而不是 DeepSpeed 的 ZeRO-3 gather 实现错误。

## 修改方案

在定期 checkpoint 和训练结束保存两处，统一改为：

```python
# 所有 rank 都必须参与 ZeRO-3 参数 gather
state_dict = self.accelerator.get_state_dict(self.model)

# 只有 rank 0 负责写文件
if self.accelerator.is_main_process:
    torch.save(state_dict, output_path)
```

具体调整：

- `VLATrainer._save_checkpoint()`：将 `get_state_dict()` 移到 `is_main_process` 判断之前；
- `VLATrainer._finalize_training()`：将 `get_state_dict()` 移到 `is_main_process` 判断之前；
- 文件写入、summary/config 写入仍只由 rank 0 执行；
- 保留现有 `wait_for_everyone()` 同步逻辑；
- 不修改 DeepSpeed 源码。

## 验证结果

验证环境：

- 8 × MTT S5000 MUSA；
- Qwen3.6-27B；
- DeepSpeed ZeRO-3；
- CPU parameter/optimizer offload 关闭；
- batch size 为 1；
- 训练 1 step。

修复后结果：

- forward、backward、optimizer step 正常完成；
- loss 正常打印；
- 所有 rank 成功参与 ZeRO-3 参数汇总；
- 完整 BF16 模型成功保存，文件大小约 55.2 GB；
- 日志打印 `Training complete. Final model saved at ...`；
- 日志打印 `... and that's all, folks!`；
- 所有训练进程正常退出；
- 未出现 OOM、collective hang 或异常 traceback。

同时在 Qwen3.6-35B-A3B 的 CPU offload 配置下进行了相同保存路径验证，完整模型约 70.3 GB，训练结束后也能正常退出。

## 影响范围

本修复只影响 ZeRO-3 模型状态汇总和保存阶段：

- 不改变训练 forward/backward 的数值逻辑；
- 不改变模型结构或参数命名；
- 不改变优化器和 checkpoint 格式；
- 非 ZeRO-3 模式下不会引入额外的分布式通信；
- 只有 rank 0 写入最终模型文件，避免多进程同时写盘。

需要注意，ZeRO-3 汇总完整模型本身仍然是高耗时、高内存的操作。对于 27B/35B 模型，建议合理设置 `save_interval`，或在长时间训练中使用 DeepSpeed 分片 checkpoint，以避免频繁生成几十 GB 的完整模型文件。

## 关联文件

- `starVLA/training/train_starvla.py`
- `VLATrainer._save_checkpoint()`
- `VLATrainer._finalize_training()`

