### PR TITLE
fix(evaluation): make SimplerEnv runs reproducible

### DIFF
--- a/deployment/model_server/seed_utils.py
+++ b/deployment/model_server/seed_utils.py
@@ -1,0 +1,22 @@
+"""Randomness helpers shared by policy servers and evaluation clients."""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed_everywhere(seed: int) -> None:
+    """Seed the Python, NumPy, and PyTorch random number generators."""
+    if not 0 <= seed <= np.iinfo(np.uint32).max:
+        raise ValueError(f"seed must be between 0 and {np.iinfo(np.uint32).max}")
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False

--- a/deployment/model_server/server_policy.py
+++ b/deployment/model_server/server_policy.py
@@ -8,6 +8,7 @@ import os
 import socket
 
 from deployment.model_server.policy_wrapper import PolicyServerWrapper
+from deployment.model_server.seed_utils import set_seed_everywhere
 from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
 
 
@@ -18,6 +19,12 @@ def main(args) -> None:
     eval clients (LIBERO / SimplerEnv / etc.) just need to forward `examples`
     and consume already-unnormalized actions from the response.
     """
+    seed = getattr(args, "seed", None)
+    if not isinstance(seed, int):
+        seed = None
+    if seed is not None:
+        set_seed_everywhere(seed)
+
     config_overrides = getattr(args, "config_override", [])
     if config_overrides:
         override_keys = [item.split("=", 1)[0] for item in config_overrides]
@@ -57,14 +64,16 @@ def main(args) -> None:
     )
 
     # start websocket server; wrapper.metadata is sent at handshake.
+    metadata = dict(wrapper.metadata)
+    metadata["seed"] = seed
     server = WebsocketPolicyServer(
         policy=wrapper,
         host="0.0.0.0",
         port=args.port,
         idle_timeout=args.idle_timeout,
-        metadata=wrapper.metadata,
+        metadata=metadata,
     )
-    logging.info("server running ... metadata=%s", wrapper.metadata)
+    logging.info("server running ... metadata=%s", metadata)
     server.serve_forever()
 
 
@@ -73,6 +82,7 @@ def build_argparser():
     parser.add_argument("--ckpt_path", type=str, default="Qwen/Qwen2.5-VL-3B-Instruct")
     parser.add_argument("--port", type=int, default=10093)
     parser.add_argument("--use_bf16", action="store_true")
+    parser.add_argument("--seed", type=int, default=None, help="Seed Python, NumPy, and PyTorch before loading the policy")
     parser.add_argument("--idle_timeout", type=int, default=1800, help="Idle timeout in seconds, -1 means never close")
     parser.add_argument(
         "--config_override",

--- a/examples/simBenchmarks/SimplerEnv/README.md
+++ b/examples/simBenchmarks/SimplerEnv/README.md
@@ -80,6 +80,17 @@ bash examples/simBenchmarks/SimplerEnv/start_simpler_env.sh ${MODEL_PATH}
 ```
 This script will automatically launch the WidowX Robot evaluation tasks, reproducing the benchmark results reported above.
 
+For reproducible runs, pass a seed to the evaluator and optionally write a
+machine-readable summary for each run:
+
+```bash
+seed=7 bash examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.sh ${MODEL_PATH}
+```
+
+The direct entrypoint accepts `--seed` and `--results-file` as well. The JSON
+summary records the seed, checkpoint, environment, robot, episode counts, and
+per-episode success values so that results can be compared across runs.
+
 ⚠️ **Note:** Please ensure that you specify the correct `SimplerEnv_PATH`in 
 `start_simpler_env.sh`  
 
@@ -154,5 +165,4 @@ bash ./examples/simBenchmarks/SimplerEnv/train_files/run_oxe_train.sh
 ```
 
 ⚠️ **Note:** Ensure that the script explicitly uses the validated config path in `run_lerobot_datasets.sh`. If not already passed, add the `--config_yaml` argument.
-
 

--- a/examples/simBenchmarks/SimplerEnv/README.md
+++ b/examples/simBenchmarks/SimplerEnv/README.md
@@ -61,7 +61,7 @@ Available SimplerEnv WidowX checkpoints (see [docs/model_zoo.md](../../docs/mode
 In the first terminal, activate the `starVLA` conda environment and run:  
 
 ```bash
-bash examples/simBenchmarks/SimplerEnv/eval_files/run_policy_server.sh
+seed=7 bash examples/simBenchmarks/SimplerEnv/eval_files/run_policy_server.sh
 ```
 
 ⚠️ **Note:** Please ensure that you specify the correct checkpoint path in  
@@ -87,9 +87,12 @@ machine-readable summary for each run:
 seed=7 bash examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.sh ${MODEL_PATH}
 ```
 
-The direct entrypoint accepts `--seed` and `--results-file` as well. The JSON
-summary records the seed, checkpoint, environment, robot, episode counts, and
-per-episode success values so that results can be compared across runs.
+Use the same `seed` value for the policy server and evaluator. The direct
+entrypoint accepts `--seed` and `--results-file` as well. The JSON summary
+records the seed, the checkpoint reported by the policy server, environment,
+task, robot, episode counts, and per-episode success values so that results can
+be compared across runs. Evaluation stops if the server does not report a seed
+or if its seed differs from the evaluator seed.
 
 ⚠️ **Note:** Please ensure that you specify the correct `SimplerEnv_PATH`in 
 `start_simpler_env.sh`  
@@ -165,4 +168,3 @@ bash ./examples/simBenchmarks/SimplerEnv/train_files/run_oxe_train.sh
 ```
 
 ⚠️ **Note:** Ensure that the script explicitly uses the validated config path in `run_lerobot_datasets.sh`. If not already passed, add the `--config_yaml` argument.
-

--- a/examples/simBenchmarks/SimplerEnv/eval_files/custom_argparse.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/custom_argparse.py
@@ -112,8 +112,15 @@ def get_args():
         "is allowed.",
     )
     parser.add_argument("--logging-dir", type=str, default="./results")
+    parser.add_argument(
+        "--results-file",
+        type=str,
+        default=None,
+        help="Optional JSON file for reproducible evaluation metadata and results",
+    )
     parser.add_argument("--tf-memory-limit", type=int, default=3072, help="Tensorflow memory limit")
     parser.add_argument("--octo-init-rng", type=int, default=0, help="Octo init rng seed")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for reproducible evaluation")
     parser.add_argument("--async-freq", type=int, default=1)
     parser.add_argument("--host", type=str, default="127.0.0.1", help="Octo init rng seed")
     parser.add_argument("--port", type=int, default=10093)

--- a/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
@@ -1,0 +1,62 @@
+"""Small, dependency-light helpers for reproducible SimplerEnv evaluations."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import torch
+
+
+def set_seed_everywhere(seed: int) -> None:
+    """Seed the RNGs used by the evaluation process.
+
+    SimplerEnv owns the environment construction, so the caller seeds the
+    process before invoking its evaluator. This keeps the integration limited
+    to StarVLA while covering the RNGs used by model and environment helpers.
+    """
+    if not 0 <= seed <= np.iinfo(np.uint32).max:
+        raise ValueError(f"seed must be between 0 and {np.iinfo(np.uint32).max}")
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def build_evaluation_summary(args: Any, success_arr: Iterable[bool]) -> dict[str, Any]:
+    """Build a JSON-serializable summary for one evaluator invocation."""
+    successes = [bool(value) for value in success_arr]
+    num_successes = sum(successes)
+    num_episodes = len(successes)
+
+    return {
+        "seed": args.seed,
+        "policy_model": args.policy_model,
+        "policy_setup": args.policy_setup,
+        "checkpoint": args.ckpt_path,
+        "environment": args.env_name,
+        "task": args.env_name,
+        "scene": args.scene_name,
+        "robot": args.robot,
+        "object_variation_mode": args.obj_variation_mode,
+        "object_episode_range": list(args.obj_episode_range),
+        "max_episode_steps": args.max_episode_steps,
+        "num_episodes": num_episodes,
+        "num_successes": num_successes,
+        "success_rate": num_successes / num_episodes if num_episodes else 0.0,
+        "successes": successes,
+    }
+
+
+def write_evaluation_summary(path: str | Path, summary: dict[str, Any]) -> None:
+    """Write an evaluation summary, creating its parent directory if needed."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
@@ -3,35 +3,26 @@
 from __future__ import annotations
 
 import json
-import random
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
-import numpy as np
-import torch
-
-
-def set_seed_everywhere(seed: int) -> None:
-    """Seed the RNGs used by the evaluation process.
-
-    SimplerEnv owns the environment construction, so the caller seeds the
-    process before invoking its evaluator. This keeps the integration limited
-    to StarVLA while covering the RNGs used by model and environment helpers.
-    """
-    if not 0 <= seed <= np.iinfo(np.uint32).max:
-        raise ValueError(f"seed must be between 0 and {np.iinfo(np.uint32).max}")
-
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+from deployment.model_server.seed_utils import set_seed_everywhere
 
 
-def build_evaluation_summary(args: Any, success_arr: Iterable[bool]) -> dict[str, Any]:
+def build_evaluation_summary(
+    args: Any,
+    success_arr: Iterable[bool],
+    server_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build a JSON-serializable summary for one evaluator invocation."""
+    if not server_metadata or not server_metadata.get("ckpt_path"):
+        raise ValueError("policy server metadata must include the served ckpt_path")
+    server_seed = server_metadata.get("seed")
+    if server_seed is None:
+        raise ValueError("policy server metadata must include the served seed")
+    if server_seed != args.seed:
+        raise ValueError(f"evaluation seed {args.seed} does not match policy server seed {server_seed}")
+
     successes = [bool(value) for value in success_arr]
     num_successes = sum(successes)
     num_episodes = len(successes)
@@ -40,7 +31,8 @@ def build_evaluation_summary(args: Any, success_arr: Iterable[bool]) -> dict[str
         "seed": args.seed,
         "policy_model": args.policy_model,
         "policy_setup": args.policy_setup,
-        "checkpoint": args.ckpt_path,
+        "checkpoint": server_metadata["ckpt_path"],
+        "requested_checkpoint": args.ckpt_path,
         "environment": args.env_name,
         "task": args.env_name,
         "scene": args.scene_name,

--- a/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/evaluation_utils.py
@@ -9,12 +9,8 @@ from typing import Any, Iterable, Mapping
 from deployment.model_server.seed_utils import set_seed_everywhere
 
 
-def build_evaluation_summary(
-    args: Any,
-    success_arr: Iterable[bool],
-    server_metadata: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Build a JSON-serializable summary for one evaluator invocation."""
+def validate_server_metadata(args: Any, server_metadata: Mapping[str, Any] | None) -> None:
+    """Validate the policy server identity before running an evaluation."""
     if not server_metadata or not server_metadata.get("ckpt_path"):
         raise ValueError("policy server metadata must include the served ckpt_path")
     server_seed = server_metadata.get("seed")
@@ -22,6 +18,15 @@ def build_evaluation_summary(
         raise ValueError("policy server metadata must include the served seed")
     if server_seed != args.seed:
         raise ValueError(f"evaluation seed {args.seed} does not match policy server seed {server_seed}")
+
+
+def build_evaluation_summary(
+    args: Any,
+    success_arr: Iterable[bool],
+    server_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-serializable summary for one evaluator invocation."""
+    validate_server_metadata(args, server_metadata)
 
     successes = [bool(value) for value in success_arr]
     num_successes = sum(successes)

--- a/examples/simBenchmarks/SimplerEnv/eval_files/model2simpler_interface.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/model2simpler_interface.py
@@ -83,6 +83,7 @@ class ModelClient:
         self.num_image_history = 0
 
         server_meta = self.client.get_server_metadata()
+        self.server_metadata = dict(server_meta)
         print(f"*** policy_setup: {policy_setup}, unnorm_key: {unnorm_key}, server_meta: {server_meta} ***")
 
     def _add_image_to_history(self, image: np.ndarray) -> None:

--- a/examples/simBenchmarks/SimplerEnv/eval_files/run_policy_server.sh
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/run_policy_server.sh
@@ -5,6 +5,7 @@ STARVLA_DIR="${STARVLA_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 star_vla_python="${star_vla_python:-python}"
 port="${port:-6678}"
 gpu_id="${gpu_id:-0}"
+seed="${seed:-0}"
 your_ckpt="${your_ckpt:-./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt}"
 USE_BF16="${USE_BF16:-1}"
 
@@ -22,6 +23,7 @@ CMD=(
   "${star_vla_python}" deployment/model_server/server_policy.py
   --ckpt_path "${your_ckpt}"
   --port "${port}"
+  --seed "${seed}"
 )
 
 if [[ "${USE_BF16}" == "1" ]]; then

--- a/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     # policy model creation; update this if you are using a new policy model
     # run real-to-sim evaluation
     success_arr = maniskill2_evaluator(model, args)
-    summary = build_evaluation_summary(args, success_arr)
+    summary = build_evaluation_summary(args, success_arr, model.server_metadata)
     print(args)
     print(" " * 10, "Average success", summary["success_rate"])
     print(json.dumps(summary, indent=2, sort_keys=True))

--- a/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
@@ -6,6 +6,7 @@ from examples.simBenchmarks.SimplerEnv.eval_files.custom_argparse import get_arg
 from examples.simBenchmarks.SimplerEnv.eval_files.evaluation_utils import (
     build_evaluation_summary,
     set_seed_everywhere,
+    validate_server_metadata,
     write_evaluation_summary,
 )
 
@@ -43,6 +44,7 @@ if __name__ == "__main__":
         action_scale=args.action_scale,
         cfg_scale=1.5,  # cfg from 1.5 to 7 also performs well
     )
+    validate_server_metadata(args, model.server_metadata)
 
     # policy model creation; update this if you are using a new policy model
     # run real-to-sim evaluation

--- a/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py
@@ -1,11 +1,13 @@
+import json
 import os
-
-import numpy as np
-from simpler_env.evaluation.maniskill2_evaluator import maniskill2_evaluator
 
 # from IPython import embed; embed()
 from examples.simBenchmarks.SimplerEnv.eval_files.custom_argparse import get_args
-from examples.simBenchmarks.SimplerEnv.eval_files.model2simpler_interface import ModelClient
+from examples.simBenchmarks.SimplerEnv.eval_files.evaluation_utils import (
+    build_evaluation_summary,
+    set_seed_everywhere,
+    write_evaluation_summary,
+)
 
 
 def start_debugpy_once():
@@ -21,6 +23,12 @@ def start_debugpy_once():
 
 if __name__ == "__main__":
     args = get_args()
+    set_seed_everywhere(args.seed)
+
+    # Import simulation and model dependencies after seeding the process.
+    from simpler_env.evaluation.maniskill2_evaluator import maniskill2_evaluator
+
+    from examples.simBenchmarks.SimplerEnv.eval_files.model2simpler_interface import ModelClient
 
     os.environ["DISPLAY"] = ""
     # prevent a single jax process from taking up all the GPU memory
@@ -39,5 +47,9 @@ if __name__ == "__main__":
     # policy model creation; update this if you are using a new policy model
     # run real-to-sim evaluation
     success_arr = maniskill2_evaluator(model, args)
+    summary = build_evaluation_summary(args, success_arr)
     print(args)
-    print(" " * 10, "Average success", np.mean(success_arr))
+    print(" " * 10, "Average success", summary["success_rate"])
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if args.results_file is not None:
+        write_evaluation_summary(args.results_file, summary)

--- a/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.sh
+++ b/examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.sh
@@ -9,6 +9,7 @@ SimplerEnv_PATH="${SimplerEnv_PATH:-}"
 SIMPLER_ENV_LIB_DIR="${SIMPLER_ENV_LIB_DIR:-}"
 port="${port:-6678}"
 gpu_id="${gpu_id:-0}"
+seed="${seed:-0}"
 your_ckpt="${your_ckpt:-./results/Checkpoints/0418_oxe_bridge_rt_1_QwenGR00T/checkpoints/steps_10000_pytorch_model.pt}"
 
 MODEL_PATH=${1:-"${your_ckpt}"}
@@ -65,6 +66,8 @@ for i in "${!ENV_NAMES[@]}"; do
     ${sim_python} examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py \
       --ckpt-path ${ckpt_path} \
       --port ${port} \
+      --seed ${seed} \
+      --results-file "${output_eval_dir}/${ckpt_name}_${env}_run${run_idx}.json" \
       --robot ${robot} \
       --policy-setup widowx_bridge \
       --control-freq 5 \
@@ -106,6 +109,8 @@ for i in "${!ENV_NAMES_V2[@]}"; do
     ${sim_python} examples/simBenchmarks/SimplerEnv/eval_files/start_simpler_env.py\
       --ckpt-path ${ckpt_path} \
       --port ${port} \
+      --seed ${seed} \
+      --results-file "${output_eval_dir}/${ckpt_name}_${env}_run${run_idx}.json" \
       --robot ${robot} \
       --policy-setup widowx_bridge \
       --control-freq 5 \

--- a/tests/test_simpler_env_evaluation_utils.py
+++ b/tests/test_simpler_env_evaluation_utils.py
@@ -46,13 +46,30 @@ def test_build_and_write_evaluation_summary(tmp_path):
         max_episode_steps=120,
     )
 
-    summary = build_evaluation_summary(args, [True, False, True])
+    summary = build_evaluation_summary(
+        args,
+        [True, False, True],
+        {"ckpt_path": "/server/checkpoint.pt", "seed": 7},
+    )
     assert summary["num_episodes"] == 3
     assert summary["num_successes"] == 2
     assert summary["success_rate"] == 2 / 3
     assert summary["task"] == "PickCube-v1"
+    assert summary["checkpoint"] == "/server/checkpoint.pt"
+    assert summary["requested_checkpoint"] == "checkpoint.pt"
 
     output = tmp_path / "nested" / "summary.json"
     write_evaluation_summary(output, summary)
     assert output.exists()
     assert '"seed": 7' in output.read_text()
+
+
+def test_build_evaluation_summary_rejects_server_seed_mismatch():
+    args = SimpleNamespace(seed=7, ckpt_path="checkpoint.pt")
+
+    try:
+        build_evaluation_summary(args, [], {"ckpt_path": "server.pt", "seed": 8})
+    except ValueError as exc:
+        assert "does not match" in str(exc)
+    else:
+        raise AssertionError("expected a server/evaluator seed mismatch to be rejected")

--- a/tests/test_simpler_env_evaluation_utils.py
+++ b/tests/test_simpler_env_evaluation_utils.py
@@ -1,0 +1,58 @@
+import random
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from examples.simBenchmarks.SimplerEnv.eval_files.evaluation_utils import (
+    build_evaluation_summary,
+    set_seed_everywhere,
+    write_evaluation_summary,
+)
+
+
+def test_set_seed_everywhere_repeats_python_numpy_and_torch_streams():
+    set_seed_everywhere(123)
+    first = (random.random(), np.random.rand(3), torch.rand(3))
+
+    set_seed_everywhere(123)
+    second = (random.random(), np.random.rand(3), torch.rand(3))
+
+    assert first[0] == second[0]
+    np.testing.assert_array_equal(first[1], second[1])
+    torch.testing.assert_close(first[2], second[2])
+
+
+def test_set_seed_everywhere_rejects_seeds_numpy_cannot_represent():
+    try:
+        set_seed_everywhere(np.iinfo(np.uint32).max + 1)
+    except ValueError as exc:
+        assert "seed must be between" in str(exc)
+    else:
+        raise AssertionError("expected an out-of-range seed to be rejected")
+
+
+def test_build_and_write_evaluation_summary(tmp_path):
+    args = SimpleNamespace(
+        seed=7,
+        policy_model="qwen",
+        policy_setup="widowx_bridge",
+        ckpt_path="checkpoint.pt",
+        env_name="PickCube-v1",
+        scene_name="bridge_table_1_v1",
+        robot="widowx",
+        obj_variation_mode="episode",
+        obj_episode_range=[0, 3],
+        max_episode_steps=120,
+    )
+
+    summary = build_evaluation_summary(args, [True, False, True])
+    assert summary["num_episodes"] == 3
+    assert summary["num_successes"] == 2
+    assert summary["success_rate"] == 2 / 3
+    assert summary["task"] == "PickCube-v1"
+
+    output = tmp_path / "nested" / "summary.json"
+    write_evaluation_summary(output, summary)
+    assert output.exists()
+    assert '"seed": 7' in output.read_text()


### PR DESCRIPTION
## Summary

- add an explicit seed to the SimplerEnv evaluation entrypoint and shell wrapper
- seed Python, NumPy, and PyTorch RNGs before simulator and model initialization
- optionally write JSON evaluation provenance with checkpoint, policy, environment/task, scene, episode counts, seed, and success values
- add CPU-testable regression coverage for deterministic helpers

## Scope

This change is limited to reproducibility and reporting in the SimplerEnv evaluation path, as discussed in #424. It does not modify or validate the released OFT checkpoint artifacts; the checkpoint mismatch remains a separate issue.

## Verification

- `py_compile` passed for the changed Python files
- `bash -n` passed for the evaluation wrapper
- CPU helper checks passed with Python, NumPy, and PyTorch
- Full pytest suite was not run because pytest is unavailable in the provided environment