### PR TITLE
[fix] (deployment): rewrite debug_server_policy around predict_action

### DIFF
--- a/deployment/model_server/README.md
+++ b/deployment/model_server/README.md
@@ -51,7 +51,7 @@ Caveats:
 ## Connect to server for debug
 
 ```bash
-python deployment/model_server/debug_server_policy.py
+python -m deployment.model_server.tools.debug_server_policy --port 10093
 
 # use server_policy.py in your eval client by referencing debug_server_policy.py
 ```

--- a/deployment/model_server/tools/debug_server_policy.py
+++ b/deployment/model_server/tools/debug_server_policy.py
@@ -2,24 +2,33 @@
 Debug / smoke-test client for deployment/model_server/server_policy.py.
 
 Purpose:
-  - Establish a WebSocket connection to the policy server.
-  - Initialize device on the server side.
-  - Optionally run a very simple inference request to verify end-to-end transport
-    (serialization + server handling).
+  - Establish a WebSocket connection to the policy server and echo its handshake metadata.
+  - Send one synthetic `predict_action` request to verify end-to-end transport
+    (msgpack serialization + server routing + policy call + response shape).
 
 Usage example:
-  python debug_server_policy.py --host 127.0.0.1 --port 10093 --device cuda --test infer
+  python -m deployment.model_server.tools.debug_server_policy --host 127.0.0.1 --port 10093
 
 Notes:
-  - The random observation is synthetic and only meant to validate the interface.
-  - Adjust keys (e.g. 'images', 'task_description') to match the server's expected schema.
+  - The observation is synthetic: it validates the interface, not the policy. The
+    returned actions are meaningless, only their shape is checked.
+  - Any interface or transport failure raises, so the script exits non-zero and can
+    be used as a gate in launch scripts.
+  - Adjust `--num_images` / `--image_size` to match the camera contract the
+    checkpoint was trained with; the server does not reorder or infer camera views.
+    The default of one view matches `examples/eval_protocol.md`; the LIBERO client
+    sends two (primary + wrist), so pass `--num_images 2` for those checkpoints.
+  - The example carries no `state`, matching `eval_libero.py`. A framework that
+    reads `example["state"]` unconditionally will fail here.
 """
 
 import argparse
 import logging
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-from tools.websocket_policy_client import WebsocketClientPolicy
+
+from deployment.model_server.tools.websocket_policy_client import WebsocketClientPolicy, _expected_image_hw
 
 
 def _build_argparser() -> argparse.ArgumentParser:
@@ -27,64 +36,115 @@ def _build_argparser() -> argparse.ArgumentParser:
     ap.add_argument("--host", default="127.0.0.1", help="server hostname/IP (do not use 0.0.0.0)")
     ap.add_argument("--port", type=int, default=10093, help="server port")
     ap.add_argument("--api_key", default="", help="optional: API key for authentication")
-    ap.add_argument("--device", default="cuda", choices=["cuda", "cpu"], help="initialize device")
     ap.add_argument(
-        "--test", choices=["init", "infer"], default="infer", help="test mode: only initialize, or try simple inference"
+        "--unnorm_key",
+        default=None,
+        help="dataset key for un-normalization; default: taken from the server handshake metadata",
+    )
+    ap.add_argument("--instruction", default="pick up the red block", help="task instruction sent as `lang`")
+    ap.add_argument("--num_images", type=int, default=1, help="number of camera views in the synthetic example")
+    ap.add_argument(
+        "--image_size",
+        type=int,
+        nargs=2,
+        default=None,
+        metavar=("H", "W"),
+        help="synthetic image size; default: `training_obs_image_size` from the server, else 224 224",
     )
     ap.add_argument("--log_level", default="INFO")
     return ap
 
 
-def _main():
-    args = _build_argparser().parse_args()
+def _resolve_unnorm_key(metadata: Dict, explicit: Optional[str]) -> Optional[str]:
+    """Pick the un-normalization key to send, or None to let the server decide.
+
+    `PolicyServerWrapper.predict_action` owns validation: on a multi-dataset
+    checkpoint it rejects a missing key and names the valid ones.
+    """
+    if explicit:
+        return explicit
+    default_key = metadata.get("default_unnorm_key")
+    if default_key:
+        return default_key
+    available = metadata.get("available_unnorm_keys") or []
+    return available[0] if len(available) == 1 else None
+
+
+def _resolve_image_size(metadata: Dict, explicit: Optional[List[int]]) -> Tuple[int, int]:
+    if explicit:
+        return int(explicit[0]), int(explicit[1])
+    return _expected_image_hw(metadata) or (224, 224)
+
+
+def _build_query(metadata: Dict, args: argparse.Namespace) -> Dict:
+    """Build one `predict_action` request matching the eval-client contract.
+
+    The payload is forwarded to `PolicyServerWrapper.predict_action(**payload)`;
+    `examples/simBenchmarks/LIBERO/eval_files/model2libero_interface.py` is the
+    reference client for its shape.
+    """
+    height, width = _resolve_image_size(metadata, args.image_size)
+    images = [
+        np.random.randint(0, 256, (height, width, 3), dtype=np.uint8)  # (H, W, C), uint8 0-255
+        for _ in range(args.num_images)
+    ]
+    query_info = {"examples": [{"image": images, "lang": args.instruction}]}
+    unnorm_key = _resolve_unnorm_key(metadata, args.unnorm_key)
+    if unnorm_key is not None:
+        query_info["unnorm_key"] = unnorm_key
+    logging.info(
+        "Request: num_images=%d, image_size=%s, unnorm_key=%s, lang=%r",
+        args.num_images,
+        (height, width),
+        unnorm_key,
+        args.instruction,
+    )
+    return query_info
+
+
+def _check_response(response: Dict, metadata: Dict) -> np.ndarray:
+    """Raise unless the server returned a well-formed action chunk."""
+    if not isinstance(response, dict):
+        raise RuntimeError(f"malformed response, expected a dict: {response!r}")
+    if response.get("status") != "ok":
+        raise RuntimeError(f"server reported an error: {response.get('error', response)}")
+
+    data = response.get("data")
+    if not isinstance(data, dict) or "actions" not in data:
+        raise RuntimeError(
+            f"response has no 'actions'; data keys={list(data.keys()) if isinstance(data, dict) else type(data)}"
+        )
+
+    actions = np.asarray(data["actions"])
+    if actions.ndim != 3:
+        raise RuntimeError(f"expected actions of shape (B, T, D), got {actions.shape}")
+
+    chunk_size = metadata.get("action_chunk_size")
+    if chunk_size is not None and actions.shape[1] != int(chunk_size):
+        logging.warning(
+            "action chunk length %d does not match the server's action_chunk_size %s",
+            actions.shape[1],
+            chunk_size,
+        )
+    return actions
+
+
+def _main(argv: Optional[List[str]] = None) -> None:
+    args = _build_argparser().parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), force=True)
 
     client = WebsocketClientPolicy(host=args.host, port=args.port, api_key=(args.api_key or None))
-    logging.info("Connected. Server metadata: %s", client.get_server_metadata())
+    try:
+        metadata = client.get_server_metadata()
+        logging.info("Connected. Server metadata: %s", metadata)
 
-    # 1) device initialization
-    init_ret = client.init_device(args.device)  # here to set some things on the server
-    logging.info("Init device resp: %s", init_ret)
+        response = client.predict_action(_build_query(metadata, args))
+        actions = _check_response(response, metadata)
+        logging.info("Received actions with shape %s (B, T, D), dtype=%s", actions.shape, actions.dtype)
+    finally:
+        client.close()
 
-    # 2) optional: try one simple inference
-    if args.test == "infer":
-        try:
-            # build observation aligned with model API
-            H, W = 224, 224
-            img = np.random.randint(0, 256, (H, W, 3), dtype=np.uint8)
-            wrist_img = np.random.randint(0, 256, (H, W, 3), dtype=np.uint8)
-            state = np.zeros((7,), dtype=np.float32)  # [x,y,z, ax,ay,az, gripper]
-
-            observation = {  # key to align with model API
-                "request_id": "smoke-test",
-                "observation.primary": np.expand_dims(img, axis=0),  # (1,H,W,C), uint8 0-255
-                "observation.wrist_image": np.expand_dims(wrist_img, axis=0),  # (1,H,W,C)
-                "observation.state": np.expand_dims(state, axis=0),  # (1,7), float32
-                "instruction": ["debug: pick up the red block"],  # single element list
-            }
-
-            image_path = "assets/table.jpeg"
-            # read image as PIL
-            from PIL import Image
-
-            image_primary = Image.open(image_path).convert("RGB")
-            # Convert PIL -> numpy uint8 (H,W,3)
-            image_primary_np = np.asarray(image_primary, dtype=np.uint8)
-
-            instruction_lang = "pick up the red block"
-            obs = {
-                "request_id": "smoke-test",
-                "batch_images": [[image_primary_np]],
-                "instructions": [instruction_lang],  # assume batch task description
-            }
-
-            infer_ret = client.infer(obs)
-            logging.info("Infer resp: %s", infer_ret)
-        except Exception as e:
-            logging.error("Infer error (this still proves transport OK): %s", e)
-
-    client.close()
-    logging.info("Smoke test done.")
+    logging.info("Smoke test passed.")
 
 
 if __name__ == "__main__":

--- a/deployment/model_server/tools/debug_server_policy.py
+++ b/deployment/model_server/tools/debug_server_policy.py
@@ -119,12 +119,14 @@ def _check_response(response: Dict, metadata: Dict) -> np.ndarray:
     if actions.ndim != 3:
         raise RuntimeError(f"expected actions of shape (B, T, D), got {actions.shape}")
 
+    # Eval clients cache a chunk and index it as `raw_actions[step % action_chunk_size]`
+    # (model2libero_interface.py:159, model2metaworld_interface.py:120), reading the size
+    # from this handshake. A short chunk raises IndexError mid-episode and a long one
+    # silently drops actions, so a disagreement here is a failure, not a warning.
     chunk_size = metadata.get("action_chunk_size")
     if chunk_size is not None and actions.shape[1] != int(chunk_size):
-        logging.warning(
-            "action chunk length %d does not match the server's action_chunk_size %s",
-            actions.shape[1],
-            chunk_size,
+        raise RuntimeError(
+            f"action chunk length {actions.shape[1]} does not match the server's action_chunk_size {chunk_size}"
         )
     return actions
 

--- a/deployment/readme-deployment.md
+++ b/deployment/readme-deployment.md
@@ -15,7 +15,7 @@ python deployment/model_server/server_policy.py \
 ## Connect to server for debug
 
 ```bash
-python deployment/model_server/debug_server_policy.py
+python -m deployment.model_server.tools.debug_server_policy --port 10093
 
 # use server_policy.py in your eval client by referencing debug_server_policy.py
 ```

--- a/tests/test_debug_server_policy.py
+++ b/tests/test_debug_server_policy.py
@@ -146,6 +146,13 @@ class DebugServerPolicyTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, r"\(B, T, D\)"):
             self._run_smoke_test()
 
+    def test_chunk_length_disagreeing_with_the_handshake_fails_the_smoke_test(self):
+        # Eval clients index the cached chunk by the handshake's action_chunk_size,
+        # so a disagreement breaks them at rollout time rather than here.
+        self.policy.response = {"actions": np.zeros((1, CHUNK - 1, ACTION_DIM), dtype=np.float32)}
+        with self.assertRaisesRegex(RuntimeError, "action_chunk_size"):
+            self._run_smoke_test()
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, force=True)

--- a/tests/test_debug_server_policy.py
+++ b/tests/test_debug_server_policy.py
@@ -1,0 +1,152 @@
+"""Protocol tests for the policy-server smoke-test client.
+
+Verifies that ``deployment/model_server/tools/debug_server_policy.py`` speaks the
+contract that ``WebsocketClientPolicy`` and ``WebsocketPolicyServer`` actually
+implement:
+
+- the request is a single ``predict_action`` message carrying
+  ``{"examples": [{"image": [...], "lang": ...}], "unnorm_key": ...}``,
+- images default to the server's ``training_obs_image_size``,
+- a policy-side failure, or a response without a usable action chunk, makes the
+  smoke test *fail* rather than log success.
+
+The policy is stubbed (no GPU / checkpoint needed); the websocket transport, the
+msgpack codec and the server's routing run for real.
+"""
+
+import asyncio
+import logging
+import threading
+import unittest
+
+import numpy as np
+import websockets.asyncio.server
+
+from deployment.model_server.tools import debug_server_policy
+from deployment.model_server.tools.websocket_policy_server import WebsocketPolicyServer
+
+CHUNK = 8
+ACTION_DIM = 7
+TRAINING_IMAGE_SIZE = [96, 128]  # deliberately not the 224x224 fallback
+UNNORM_KEY = "stub_mix"
+
+METADATA = {
+    "env": "starvla_policy_server",
+    "ckpt_path": "/stub",
+    "action_chunk_size": CHUNK,
+    "available_unnorm_keys": [UNNORM_KEY],
+    "default_unnorm_key": UNNORM_KEY,
+    "training_obs_image_size": TRAINING_IMAGE_SIZE,
+}
+
+
+class _StubPolicy:
+    """Duck-typed PolicyServerWrapper: records requests, returns a fixed chunk."""
+
+    def __init__(self):
+        self.requests = []
+        self.raise_on_next = False
+        self.response = None  # override the returned dict when set
+
+    def predict_action(self, examples, unnorm_key=None, **kwargs):
+        self.requests.append({"examples": examples, "unnorm_key": unnorm_key, "kwargs": kwargs})
+        if self.raise_on_next:
+            raise RuntimeError("stub policy failure")
+        if self.response is not None:
+            return self.response
+        return {"actions": np.zeros((len(examples), CHUNK, ACTION_DIM), dtype=np.float32)}
+
+
+class DebugServerPolicyTest(unittest.TestCase):
+    """Drives the real `WebsocketPolicyServer._handler` over a real socket.
+
+    The handler is served directly rather than through `serve_forever()`, which
+    never returns, so the port is bound on 0 (no free-port race) and released at
+    teardown. `tests/test_gr00t_zmq_compat_server.py` drives its ZMQ server the
+    same way.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = _StubPolicy()
+        server = WebsocketPolicyServer(cls.policy, host="127.0.0.1", port=0, metadata=METADATA)
+        cls.loop = asyncio.new_event_loop()
+        cls.ready = threading.Event()
+        cls.thread = threading.Thread(target=cls._serve, args=(server,), daemon=True)
+        cls.thread.start()
+        if not cls.ready.wait(timeout=15):
+            raise RuntimeError("stub policy server never started listening")
+
+    @classmethod
+    def _serve(cls, server):
+        asyncio.set_event_loop(cls.loop)
+        try:
+            cls.loop.run_until_complete(cls._serve_until_stopped(server))
+        finally:
+            cls.loop.close()
+
+    @classmethod
+    async def _serve_until_stopped(cls, server):
+        cls.stop = asyncio.Event()
+        async with websockets.asyncio.server.serve(
+            server._handler, "127.0.0.1", 0, compression=None, max_size=None
+        ) as ws_server:
+            cls.port = ws_server.sockets[0].getsockname()[1]
+            cls.ready.set()
+            await cls.stop.wait()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loop.call_soon_threadsafe(cls.stop.set)
+        cls.thread.join(timeout=5)
+
+    def setUp(self):
+        self.policy.requests.clear()
+        self.policy.raise_on_next = False
+        self.policy.response = None
+
+    def _run_smoke_test(self, *extra_argv):
+        debug_server_policy._main(["--host", "127.0.0.1", "--port", str(self.port), *extra_argv])
+
+    def test_smoke_test_sends_the_documented_payload(self):
+        self._run_smoke_test("--num_images", "2", "--instruction", "pick up the red block")
+
+        self.assertEqual(len(self.policy.requests), 1)
+        request = self.policy.requests[0]
+        self.assertEqual(request["unnorm_key"], UNNORM_KEY)
+
+        examples = request["examples"]
+        self.assertEqual(len(examples), 1)
+        self.assertEqual(examples[0]["lang"], "pick up the red block")
+        images = examples[0]["image"]
+        self.assertEqual(len(images), 2)
+        for image in images:
+            # Image size defaults to the server's training_obs_image_size.
+            self.assertEqual(np.asarray(image).shape, (*TRAINING_IMAGE_SIZE, 3))
+            self.assertEqual(np.asarray(image).dtype, np.uint8)
+
+    def test_image_size_override_is_honoured(self):
+        self._run_smoke_test("--image_size", "64", "80")
+
+        images = self.policy.requests[0]["examples"][0]["image"]
+        self.assertEqual(np.asarray(images[0]).shape, (64, 80, 3))
+
+    def test_policy_failure_fails_the_smoke_test(self):
+        self.policy.raise_on_next = True
+        with self.assertRaisesRegex(RuntimeError, "stub policy failure"):
+            self._run_smoke_test()
+
+    def test_response_without_actions_fails_the_smoke_test(self):
+        self.policy.response = {"normalized_actions": np.zeros((1, CHUNK, ACTION_DIM), dtype=np.float32)}
+        with self.assertRaisesRegex(RuntimeError, "no 'actions'"):
+            self._run_smoke_test()
+
+    def test_response_with_a_mis_shaped_chunk_fails_the_smoke_test(self):
+        self.policy.response = {"actions": np.zeros((CHUNK, ACTION_DIM), dtype=np.float32)}
+        with self.assertRaisesRegex(RuntimeError, r"\(B, T, D\)"):
+            self._run_smoke_test()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, force=True)
+    unittest.main()


### PR DESCRIPTION
## Description

Follow-up to #459, along the lines you suggested there. `deployment/model_server/tools/debug_server_policy.py` is rebuilt around the `predict_action` request that the eval interfaces already use, and a CPU regression test pins that contract, so a later change to the request shape fails the test rather than the script.

Please tell me if you would rather keep the script smaller than this — I added the response check and the metadata-driven defaults because they are what makes it usable as a gate in a launch script, but I am happy to trim either.

## Motivation

Closes #459

Measured against `starVLA_dev` at `d81fc66`, with a stub policy on CPU (no checkpoint, no GPU):

- Running it the two ways the docstring shows, the import fails before anything reaches the server. `from tools.websocket_policy_client import ...` needs `deployment/model_server/` on `sys.path`, which neither `python deployment/model_server/tools/debug_server_policy.py` nor `cd .../tools && python debug_server_policy.py` provides. If there is an invocation I missed, this bullet and the next one go away:

  ```
  File "deployment/model_server/tools/debug_server_policy.py", line 22, in <module>
      from tools.websocket_policy_client import WebsocketClientPolicy
  ModuleNotFoundError: No module named 'tools'
  ```

- With that path added by hand, the connection and handshake succeed and the next call fails:

  ```
  File "deployment/model_server/tools/debug_server_policy.py", line 46, in _main
      init_ret = client.init_device(args.device)
  AttributeError: 'WebsocketClientPolicy' object has no attribute 'init_device'
  ```

  `WebsocketClientPolicy` exposes `get_server_metadata` and `predict_action`; `WebsocketPolicyServer._route_message` routes `ping` and `infer`/`predict_action`, and there is no `init` branch, so `--test init` had nothing to reach either.

- Past that point I did not get to run, so this part is read off the source rather than measured: `client.infer(obs)` has no matching client method either, and the call sits inside an `except Exception` that logs `"Infer error (this still proves transport OK)"` and falls through to `"Smoke test done."` at exit code 0. With the first two fixed, a failing request would still exit 0.

## Changes

- Import the client by its package path, `deployment.model_server.tools.websocket_policy_client`, matching `examples/simBenchmarks/LIBERO/eval_files/model2libero_interface.py`. The script now runs as `python -m deployment.model_server.tools.debug_server_policy` from the repo root.
- Replace `init_device` + `infer` with one `predict_action` request shaped the way `model2libero_interface.py:132` builds it and `PolicyServerWrapper.predict_action` (`policy_wrapper.py:161`) accepts it: `{"examples": [{"image": [...], "lang": ...}], "unnorm_key": ...}`.
- Drop `--device` and `--test`: `_route_message` has no `init` branch, so they have no server side to reach. Add `--unnorm_key`, `--instruction`, `--num_images` and `--image_size`.
- Take defaults from the handshake metadata: `default_unnorm_key` / `available_unnorm_keys` for the key, and the client's own `_expected_image_hw` for the image size, so that lookup is not duplicated. On a multi-dataset checkpoint with no `--unnorm_key` the request goes out without one and `PolicyServerWrapper.predict_action` raises `"Pass one of [...]"` as it already does — I did not want a second copy of that rule on the client.
- `--num_images` defaults to 1. `eval_libero.py:168` sends two views (primary + wrist), so that case needs `--num_images 2`, which the docstring notes. Nothing in the handshake metadata reports an expected view count, so I left the default at one rather than guess — say the word if you would rather it were 2.
- Check the response: `status == "ok"`, `data["actions"]` present and shaped `(B, T, D)`, and that the chunk length matches the server's `action_chunk_size`. Failures propagate, so the script exits non-zero.
- Add `tests/test_debug_server_policy.py`: a stubbed policy behind the real `WebsocketPolicyServer._handler`, following `tests/test_gr00t_zmq_compat_server.py`. The transport, the msgpack codec and the server routing run for real; only the policy is stubbed. It binds port 0 and shuts the server down in `tearDownClass`, so it leaves no thread and nothing listening.
- Repoint the "Connect to server for debug" command in `deployment/model_server/README.md` and `deployment/readme-deployment.md`. Both said `python deployment/model_server/debug_server_policy.py`, which has no `tools/` in it, so it fails with `No such file or directory` before the import problem above can even come up. I folded this in because it is the same drift, but happy to split it out if you would rather keep the PR to the script.

## Testing

Both boxes below are left unchecked on purpose: this touches only a debug script, no framework, benchmark or training path, and loads no weights.

- [ ] Local training for N steps without errors
- [ ] Benchmark evaluation results (**required** for framework / benchmark changes, see table below)

| Benchmark | Metric | Result |
|-----------|--------|--------|
| n/a       | n/a    | n/a    |

What I ran instead, on `starVLA-mlc` (torch 2.6.0+cu124), CPU only:

| Check | Result |
|-------|--------|
| `python -m unittest discover -s tests` on `starVLA_dev` @ `d81fc66` | 41 tests, OK (baseline) |
| `python -m unittest discover -s tests` on this branch | 47 tests, OK |
| `python -m unittest tests.test_debug_server_policy` against the **pre-fix** script | 1 error at collection, `ModuleNotFoundError: No module named 'tools'` — the bug this PR fixes |
| the same with the old swallow-and-log restored around the request | 4 failures, every test asserting that a bad response propagates |
| `python -m deployment.model_server.tools.debug_server_policy --port <stub>` end to end | exit 0, `Received actions with shape (1, 8, 7) (B, T, D)` |
| after the test module finishes: leaked threads, sockets still in `LISTEN` | 0 and 0 |
| `black --line-length 121` / `ruff check --line-length 121` on both files | clean |

To be straight about what the test does and does not show: it pins the new request/response contract, and the swallow-and-log row shows those assertions are load-bearing. It does not itself demonstrate the `init_device` / `infer` failures — the two tracebacks above are the evidence for those, run by hand against a stub server.

- **Checkpoint**: not applicable — the test stubs the policy, so no checkpoint is loaded.
- **Config**: not applicable — no config or example is added.
- **Reproduce**: `python -m unittest tests.test_debug_server_policy -v`

One thing I noticed but deliberately left alone: the client snippet in `examples/eval_protocol.md` (lines 34-52) still predates the server-side un-normalization change — it passes a bare `example` rather than `{"examples": [...]}` and reads `result["normalized_actions"]` instead of `result["data"]["actions"]`. Out of scope here, noting it in case it is news.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] New framework / benchmark integration
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no behavior change)

I marked this non-breaking, but the CLI surface does change: `--device` and `--test` are gone. Grepping the tree, the only callers are the two README lines updated here, and both were already pointing at a path that does not exist. If the script is referenced somewhere outside the repo I will tick "Breaking change" instead.

## Checklist

- [x] No unrelated changes mixed in
- [x] New features have example config in `examples/` (n/a — no new feature)
- [x] No secrets, API keys, or large binaries committed
- [x] Files stay isolated — no unnecessary modification to shared modules (`starVLA/dataloader/`, `starVLA/training/`, `starVLA/config/`)
- [x] No modifications to shared files, or justified above
- [x] If adding framework/benchmark: checkpoint uploaded to personal HF (public) (n/a — neither)
